### PR TITLE
User cli-listen file to enable vppctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ to contain the proper PCI address:
 ```
 unix {
     nodaemon
-    cli-listen 0.0.0.0:5002
-    cli-no-pager
+    cli-listen /run/vpp/cli.sock
 }
 dpdk {
     dev 0000:00:04.0


### PR DESCRIPTION
Instructing folks to set cli-listen to 0.0.0.0:5002 is a big security
hole.  Change to using cli-listen to a socket file, so that folks can
use vppctl instead (which is secure).

Signed-off-by: Ed Warnicke <eaw@cisco.com>