### PR TITLE
Add nginx tests for two nodes testing

### DIFF
--- a/tests/robot/libraries/KubernetesEnv.robot
+++ b/tests/robot/libraries/KubernetesEnv.robot
@@ -10,6 +10,9 @@ ${NV_PLUGIN_URL}    https://raw.githubusercontent.com/contiv/vpp/master/k8s/cont
 ${CLIENT_POD_FILE}    ${CURDIR}/../resources/ubuntu-client.yaml
 ${SERVER_POD_FILE}    ${CURDIR}/../resources/ubuntu-server.yaml
 ${NGINX_POD_FILE}    ${CURDIR}/../resources/nginx.yaml
+${CLIENT_POD_FILE_NODE1}    ${CURDIR}/../resources/ubuntu-client-node1.yaml
+${SERVER_POD_FILE_NODE2}    ${CURDIR}/../resources/ubuntu-server-node2.yaml
+${NGINX_POD_FILE_NODE2}    ${CURDIR}/../resources/nginx-node2.yaml
 ${CLIENT_ISTIO_POD_FILE}    ${CURDIR}/../resources/one-ubuntu-istio.yaml
 ${NGINX_ISTIO_POD_FILE}    ${CURDIR}/../resources/nginx-istio.yaml
 ${ISTIO_FILE}    ${CURDIR}/../resources/istio029.yaml
@@ -64,6 +67,7 @@ Reinit_Multinode_Kube_Cluster
     # label the nodes
     :FOR    ${index}    IN RANGE    1    ${KUBE_CLUSTER_${CLUSTER_ID}_NODES}+1
     \    KubeCtl.Label_Nodes    ${VM_SSH_ALIAS_PREFIX}1    ${KUBE_CLUSTER_${CLUSTER_ID}_VM_${index}_HOST_NAME}   location    ${KUBE_CLUSTER_${CLUSTER_ID}_VM_${index}_LABEL}
+    BuiltIn.Set_Suite_Variable    ${testbed_connection}    ${VM_SSH_ALIAS_PREFIX}1
 
 Docker_Pull_Contiv_Vpp
     [Arguments]    ${ssh_session}
@@ -113,18 +117,40 @@ Get_Pod_Name_List_By_Prefix
     BuiltIn.Return_From_Keyword    ${output}
 
 Deploy_Client_And_Server_Pod_And_Verify_Running
-    [Arguments]    ${ssh_session}
+    [Arguments]    ${ssh_session}    ${client_file}=${CLIENT_POD_FILE}    ${server_file}=${SERVER_POD_FILE}
     [Documentation]     Deploy two ubuntu pods and 
-    ${client_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${CLIENT_POD_FILE}    ubuntu-client-
-    ${server_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${SERVER_POD_FILE}    ubuntu-server-
+    ${client_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${client_file}    ubuntu-client-
+    ${server_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${server_file}    ubuntu-server-
     BuiltIn.Set_Suite_Variable    ${client_pod_name}
     BuiltIn.Set_Suite_Variable    ${server_pod_name}
 
+Deploy_Client_Pod_And_Verify_Running
+    [Arguments]    ${ssh_session}    ${client_file}=${CLIENT_POD_FILE}
+    [Documentation]     Deploy client ubuntu pod. Pod name in the yaml file is expectedt o be ubuntu-client
+    ${client_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${client_file}    ubuntu-client-
+    BuiltIn.Set_Suite_Variable    ${client_pod_name}
+
+Deploy_Server_Pod_And_Verify_Running
+    [Arguments]    ${ssh_session}    ${server_file}=${SERVER_POD_FILE}
+    [Documentation]     Deploy server ubuntu pod. Pod name in the yaml file is expectedt o be ubuntu-server
+    ${server_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${server_file}    ubuntu-server-
+    BuiltIn.Set_Suite_Variable    ${server_pod_name}
+
 Remove_Client_And_Server_Pod_And_Verify_Removed
-    [Arguments]    ${ssh_session}
-    KubeCtl.Delete_F    ${ssh_session}    ${CLIENT_POD_FILE}
-    KubeCtl.Delete_F    ${ssh_session}    ${SERVER_POD_FILE}
+    [Arguments]    ${ssh_session}    ${client_file}=${CLIENT_POD_FILE}    ${server_file}=${SERVER_POD_FILE}
+    KubeCtl.Delete_F    ${ssh_session}    ${client_file}
+    KubeCtl.Delete_F    ${ssh_session}    ${server_file}
     Wait_Until_Pod_Removed    ${ssh_session}    ${client_pod_name}
+    Wait_Until_Pod_Removed    ${ssh_session}    ${server_pod_name}
+
+Remove_Client_Pod_And_Verify_Removed
+    [Arguments]    ${ssh_session}    ${client_file}=${CLIENT_POD_FILE}
+    KubeCtl.Delete_F    ${ssh_session}    ${client_file}
+    Wait_Until_Pod_Removed    ${ssh_session}    ${client_pod_name}
+
+Remove_Server_Pod_And_Verify_Removed
+    [Arguments]    ${ssh_session}    ${server_file}=${SERVER_POD_FILE}
+    KubeCtl.Delete_F    ${ssh_session}    ${server_file}
     Wait_Until_Pod_Removed    ${ssh_session}    ${server_pod_name}
 
 Deploy_Client_And_Nginx_Pod_And_Verify_Running
@@ -135,11 +161,22 @@ Deploy_Client_And_Nginx_Pod_And_Verify_Running
     BuiltIn.Set_Suite_Variable    ${client_pod_name}
     BuiltIn.Set_Suite_Variable    ${nginx_pod_name}
 
+Deploy_Nginx_Pod_And_Verify_Running
+    [Arguments]    ${ssh_session}    ${nginx_file}=${NGINX_POD_FILE}
+    [Documentation]     Deploy one nginx pod
+    ${nginx_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${nginx_file}    nginx-
+    BuiltIn.Set_Suite_Variable    ${nginx_pod_name}
+
 Remove_Client_And_Nginx_Pod_And_Verify_Removed
     [Arguments]    ${ssh_session}    ${client_file}=${CLIENT_POD_FILE}    ${nginx_file}=${NGINX_POD_FILE}
     KubeCtl.Delete_F    ${ssh_session}    ${client_file}
     KubeCtl.Delete_F    ${ssh_session}    ${nginx_file}
     Wait_Until_Pod_Removed    ${ssh_session}    ${client_pod_name}
+    Wait_Until_Pod_Removed    ${ssh_session}    ${nginx_pod_name}
+
+Remove_Nginx_Pod_And_Verify_Removed
+    [Arguments]    ${ssh_session}    ${nginx_file}=${NGINX_POD_FILE}
+    KubeCtl.Delete_F    ${ssh_session}    ${nginx_file}
     Wait_Until_Pod_Removed    ${ssh_session}    ${nginx_pod_name}
 
 Verify_Istio_Running
@@ -287,9 +324,10 @@ Log_Contiv_Ksr
 Log_Contiv_Vswitch
     [Arguments]    ${ssh_session}
     ${pod_list} =    Get_Pod_Name_List_By_Prefix    ${ssh_session}    contiv-vswitch-
-    BuiltIn.Length_Should_Be    ${pod_list}    1
-    KubeCtl.Logs    ${ssh_session}    @{pod_list}[0]    namespace=kube-system    container=contiv-cni
-    KubeCtl.Logs    ${ssh_session}    @{pod_list}[0]    namespace=kube-system    container=contiv-vswitch
+    BuiltIn.Length_Should_Be    ${pod_list}    ${KUBE_CLUSTER_${CLUSTER_ID}_NODES}
+    : FOR    ${vswitch_pod}    IN    @{pod_list}
+    \    KubeCtl.Logs    ${ssh_session}    ${vswitch_pod}    namespace=kube-system    container=contiv-cni
+    \    KubeCtl.Logs    ${ssh_session}    ${vswitch_pod}    namespace=kube-system    container=contiv-vswitch
 
 Log_Kube_Dns
     [Arguments]    ${ssh_session}

--- a/tests/robot/resources/nginx-node2.yaml
+++ b/tests/robot/resources/nginx-node2.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+  - name: http
+    port: 80
+  selector:
+    app: nginx
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        ports:
+        - containerPort: 80
+      nodeSelector:
+        location: server_node

--- a/tests/robot/suites/two_node_two_pods.robot
+++ b/tests/robot/suites/two_node_two_pods.robot
@@ -12,36 +12,40 @@ ${ENV}                common
 
 *** Test Cases ***
 Pod_To_Pod_Ping
+    [Documentation]    Pod to pod ping, pods are on different nodes.
     [Setup]    Setup_Hosts_Connections
     ${stdout} =    KubernetesEnv.Run_Finite_Command_In_Pod    ping -c 5 ${server_ip}    ssh_session=${client_connection}
     BuiltIn.Should_Contain   ${stdout}    5 received, 0% packet loss
-    ${stdout} =    KubernetesEnv.Run_Finite_Command_In_Pod    ping -c 5 ${client_ip}    ssh_session=${server_connection}
-    BuiltIn.Should_Contain   ${stdout}    5 received, 0% packet loss
+#    ${stdout} =    KubernetesEnv.Run_Finite_Command_In_Pod    ping -c 5 ${client_ip}    ssh_session=${server_connection}
+#    BuiltIn.Should_Contain   ${stdout}    5 received, 0% packet loss
     [Teardown]    Teardown_Hosts_Connections
 
-Pod_To_Pod_Udp
-    [Setup]    Setup_Hosts_Connections
-    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -ul -p 7000    ssh_session=${server_connection}
-    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -u ${server_ip} 7000    ssh_session=${client_connection}
-    ${text} =    BuiltIn.Set_Variable    Text to be received
-    SSHLibrary.Write    ${text}
-    ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${client_connection}
-    ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
-    BuiltIn.Should_Contain   ${server_stdout}    ${text}
-    [Teardown]    Teardown_Hosts_Connections
+#Pod_To_Pod_Udp
+#    [Documentation]    Pod to pod udp, pods are on different nodes.
+#    [Setup]    Setup_Hosts_Connections
+#    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -ul -p 7000    ssh_session=${server_connection}
+#    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -u ${server_ip} 7000    ssh_session=${client_connection}
+#    ${text} =    BuiltIn.Set_Variable    Text to be received
+#    SSHLibrary.Write    ${text}
+#    ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${client_connection}
+#    ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
+#    BuiltIn.Should_Contain   ${server_stdout}    ${text}
+#    [Teardown]    Teardown_Hosts_Connections
 
-Pod_To_Pod_Tcp
-    [Setup]    Setup_Hosts_Connections
-    ${text} =    BuiltIn.Set_Variable    Text to be received
-    KubernetesEnv.Run_Finite_Command_In_Pod    cd; echo "${text}" > some.file    ssh_session=${client_connection}
-    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -l -p 4444    ssh_session=${server_connection}
-    KubernetesEnv.Init_Infinite_Command_in_Pod    cd; nc ${server_ip} 4444 < some.file    ssh_session=${client_connection}
-    ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
-    BuiltIn.Should_Contain   ${server_stdout}    ${text}
-    ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${client_connection}
-    [Teardown]    Teardown_Hosts_Connections
+#Pod_To_Pod_Tcp
+#    [Documentation]    Pod to pod tcp, pods are on different nodes.
+#    [Setup]    Setup_Hosts_Connections
+#    ${text} =    BuiltIn.Set_Variable    Text to be received
+#    KubernetesEnv.Run_Finite_Command_In_Pod    cd; echo "${text}" > some.file    ssh_session=${client_connection}
+#    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -l -p 4444    ssh_session=${server_connection}
+#    KubernetesEnv.Init_Infinite_Command_in_Pod    cd; nc ${server_ip} 4444 < some.file    ssh_session=${client_connection}
+#    ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
+#    BuiltIn.Should_Contain   ${server_stdout}    ${text}
+#    ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${client_connection}
+#    [Teardown]    Teardown_Hosts_Connections
 
 Host_To_Pod_Ping
+    [Documentation]    Host to pod ping, client_ip is local, server_ip is remote
     [Setup]    Setup_Hosts_Connections
     ${stdout} =    KubernetesEnv.Execute_Command_And_Log_All    ${testbed_connection}    ping -c 5 ${server_ip}
     BuiltIn.Should_Contain   ${stdout}    5 received, 0% packet loss
@@ -49,36 +53,78 @@ Host_To_Pod_Ping
     BuiltIn.Should_Contain   ${stdout}    5 received, 0% packet loss
     [Teardown]    Teardown_Hosts_Connections
 
-Host_To_Pod_Udp
+#Host_To_Pod_Udp_Remote
+#    [Documentation]    Host to pod udp, dst pod runs on a different nodes.
+#    [Setup]    Setup_Hosts_Connections
+#    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -ul -p 7000    ssh_session=${server_connection}
+#    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -u ${server_ip} 7000    ssh_session=${testbed_connection}
+#    ${text} =    BuiltIn.Set_Variable    Text to be received
+#    SSHLibrary.Write    ${text}
+#    ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${testbed_connection}    prompt=$
+#    ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
+#    BuiltIn.Should_Contain   ${server_stdout}    ${text}
+#    [Teardown]    Teardown_Hosts_Connections
+
+#Host_To_Pod_Tcp_Remote
+#    [Documentation]    Host to pod tcp, dst pod runs on a different nodes.
+#    [Setup]    Setup_Hosts_Connections
+#    ${text} =    BuiltIn.Set_Variable    Text to be received
+#    KubernetesEnv.Run_Finite_Command_In_Pod    cd; echo "${text}" > some.file    ssh_session=${testbed_connection}
+#    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -l -p 4444    ssh_session=${server_connection}
+#    KubernetesEnv.Init_Infinite_Command_in_Pod    cd; nc ${server_ip} 4444 < some.file    ssh_session=${testbed_connection}
+#    ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
+#    BuiltIn.Should_Contain   ${server_stdout}    ${text}
+#    ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${testbed_connection}    prompt=$
+#    [Teardown]    Teardown_Hosts_Connections
+
+#Pod_To_Nginx_Local
+#    [Documentation]    Curl from one pod to another on the same node. Server_pod is just a ubuntu pod running on the same
+#    ...    same node as nxinf pod.
+#    [Setup]    Setup_Hosts_Connections
+#    ${stdout} =    KubernetesEnv.Run_Finite_Command_In_Pod    curl http://${nginx_ip}    ssh_session=${server_connection}
+#    BuiltIn.Should_Contain   ${stdout}    If you see this page, the nginx web server is successfully installed
+#    [Teardown]    Teardown_Hosts_Connections
+
+Pod_To_Nginx_Remote
+    [Documentation]    Curl from one pod to another. Pods are on different nodes.
     [Setup]    Setup_Hosts_Connections
-    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -ul -p 7000    ssh_session=${server_connection}
-    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -u ${server_ip} 7000    ssh_session=${testbed_connection}
-    ${text} =    BuiltIn.Set_Variable    Text to be received
-    SSHLibrary.Write    ${text}
-    ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${testbed_connection}    prompt=$
-    ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
-    BuiltIn.Should_Contain   ${server_stdout}    ${text}
+    ${stdout} =    KubernetesEnv.Run_Finite_Command_In_Pod    curl http://${nginx_ip}    ssh_session=${client_connection}
+    BuiltIn.Should_Contain   ${stdout}    If you see this page, the nginx web server is successfully installed
     [Teardown]    Teardown_Hosts_Connections
 
-Host_To_Pod_Tcp
-    [Setup]    Setup_Hosts_Connections
-    ${text} =    BuiltIn.Set_Variable    Text to be received
-    KubernetesEnv.Run_Finite_Command_In_Pod    cd; echo "${text}" > some.file    ssh_session=${testbed_connection}
-    KubernetesEnv.Init_Infinite_Command_in_Pod    nc -l -p 4444    ssh_session=${server_connection}
-    KubernetesEnv.Init_Infinite_Command_in_Pod    cd; nc ${server_ip} 4444 < some.file    ssh_session=${testbed_connection}
-    ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
-    BuiltIn.Should_Contain   ${server_stdout}    ${text}
-    ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${testbed_connection}    prompt=$
-    [Teardown]    Teardown_Hosts_Connections
+Host_To_Nginx_Local
+    [Documentation]    Curl from linux host pod to another on the same node
+    ${stdout} =    KubernetesEnv.Execute_Command_And_Log_All    ${VM_SSH_ALIAS_PREFIX}2    curl http://${nginx_ip} --noproxy ${nginx_ip}   ignore_stderr=${True}
+    BuiltIn.Should_Contain   ${stdout}    If you see this page, the nginx web server is successfully installed
+
+Host_To_Nginx_Remote
+    [Documentation]    Curl from linux host to pod on another node
+    ${stdout} =    KubernetesEnv.Execute_Command_And_Log_All    ${VM_SSH_ALIAS_PREFIX}1    curl http://${nginx_ip} --noproxy ${nginx_ip}    ignore_stderr=${True}
+    BuiltIn.Should_Contain   ${stdout}    If you see this page, the nginx web server is successfully installed
 
 *** Keywords ***
 TwoNodesK8sSetup
     Testsuite Setup
     KubernetesEnv.Reinit_Multi_Node_Kube_Cluster
-    #KubernetesEnv.Deploy_Client_And_Server_Pod_And_Verify_Running    ${testbed_connection}
+    KubernetesEnv.Deploy_Client_Pod_And_Verify_Running    ${testbed_connection}    client_file=${CLIENT_POD_FILE_NODE1}
+    KubernetesEnv.Deploy_Server_Pod_And_Verify_Running    ${testbed_connection}    server_file=${SERVER_POD_FILE_NODE2}
+    KubernetesEnv.Deploy_Nginx_Pod_And_Verify_Running    ${testbed_connection}    nginx_file=${NGINX_POD_FILE_NODE2}
+    ${client_pod_details} =     KubeCtl.Describe_Pod    ${testbed_connection}    ${client_pod_name}
+    ${server_pod_details} =     KubeCtl.Describe_Pod    ${testbed_connection}    ${server_pod_name}
+    ${nginx_pod_details} =     KubeCtl.Describe_Pod    ${testbed_connection}    ${nginx_pod_name}
+    ${server_ip} =     BuiltIn.Evaluate    &{server_pod_details}[${server_pod_name}]["IP"]
+    ${client_ip} =     BuiltIn.Evaluate    &{client_pod_details}[${client_pod_name}]["IP"]
+    ${nginx_ip} =     BuiltIn.Evaluate    &{nginx_pod_details}[${nginx_pod_name}]["IP"]
+    BuiltIn.Set_Suite_Variable    ${server_ip}
+    BuiltIn.Set_Suite_Variable    ${client_ip}
+    BuiltIn.Set_Suite_Variable    ${nginx_ip}
+
 
 TwoNodesK8sTeardown
-    #KubernetesEnv.Remove_Client_And_Server_Pod_And_Verify_Removed    ${testbed_connection}
+    KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}
+    KubernetesEnv.Remove_Nginx_Pod_And_Verify_Removed    ${testbed_connection}    nginx_file=${NGINX_POD_FILE_NODE2}
+    KubernetesEnv.Remove_Client_Pod_And_Verify_Removed    ${testbed_connection}    client_file=${CLIENT_POD_FILE_NODE1}
+    KubernetesEnv.Remove_Server_Pod_And_Verify_Removed    ${testbed_connection}    server_file=${SERVER_POD_FILE_NODE2}
     Testsuite Teardown
 
 Setup_Hosts_Connections
@@ -91,17 +137,11 @@ Setup_Hosts_Connections
     SSHLibrary.Login    ${user}    ${password}
     BuiltIn.Set_Suite_Variable    ${server_connection}
     KubernetesEnv.Get_Into_Container_Prompt_In_Pod    ${client_connection}    ${client_pod_name}    prompt=#
-    KubernetesEnv.Get_Into_Container_Prompt_In_Pod    ${server_connection}    ${server_pod_name}    prompt=#
-    ${client_pod_details} =     KubeCtl.Describe_Pod    ${testbed_connection}    ${client_pod_name}
-    ${server_pod_details} =     KubeCtl.Describe_Pod    ${testbed_connection}    ${server_pod_name}
-    ${server_ip} =     BuiltIn.Evaluate    &{server_pod_details}[${server_pod_name}]["IP"]
-    ${client_ip} =     BuiltIn.Evaluate    &{client_pod_details}[${client_pod_name}]["IP"]
-    BuiltIn.Set_Suite_Variable    ${server_ip}
-    BuiltIn.Set_Suite_Variable    ${client_ip}
+#    KubernetesEnv.Get_Into_Container_Prompt_In_Pod    ${server_connection}    ${server_pod_name}    prompt=#
 
 Teardown_Hosts_Connections
     KubernetesEnv.Leave_Container_Prompt_In_Pod    ${client_connection}
-    KubernetesEnv.Leave_Container_Prompt_In_Pod    ${server_connection}
+#    KubernetesEnv.Leave_Container_Prompt_In_Pod    ${server_connection}
     SSHLibrary.Switch_Connection    ${client_connection}
     SSHLibrary.Close_Connection
     SSHLibrary.Switch_Connection    ${server_connection}

--- a/tests/robot/variables/common_variables.robot
+++ b/tests/robot/variables/common_variables.robot
@@ -39,6 +39,23 @@ ${KUBE_CLUSTER_4_VM_1_USER}        localadmin
 ${KUBE_CLUSTER_4_VM_1_PSWD}        cisco123
 ${KUBE_CLUSTER_4_DOCKER_COMMAND}   docker
 
+${KUBE_CLUSTER_5_NODES}            2
+${KUBE_CLUSTER_5_VM_1_PUBLIC_IP}   192.168.251.105
+${KUBE_CLUSTER_5_VM_1_LOCAL_IP}    192.168.251.105
+${KUBE_CLUSTER_5_VM_1_HOST_NAME}   vm5
+${KUBE_CLUSTER_5_VM_1_USER}        localadmin
+${KUBE_CLUSTER_5_VM_1_PSWD}        cisco123
+${KUBE_CLUSTER_5_VM_1_ROLE}        master
+${KUBE_CLUSTER_5_VM_1_LABEL}       client_node
+${KUBE_CLUSTER_5_VM_2_PUBLIC_IP}   192.168.251.106
+${KUBE_CLUSTER_5_VM_2_LOCAL_IP}    192.168.251.106
+${KUBE_CLUSTER_5_VM_2_HOST_NAME}   vm6
+${KUBE_CLUSTER_5_VM_2_USER}        localadmin
+${KUBE_CLUSTER_5_VM_2_PSWD}        cisco123
+${KUBE_CLUSTER_5_VM_2_ROLE}        slave
+${KUBE_CLUSTER_5_VM_2_LABEL}       server_node
+${KUBE_CLUSTER_5_DOCKER_COMMAND}   docker
+
 # Other variables
 ${RESULTS_FOLDER}                  results
 ${TEST_DATA_FOLDER}                test_data


### PR DESCRIPTION
TODO:
- uncomment tests which are commented out

The reason is:
kubectl exec -it ubuntu-server-6d9ccdbf44-6xcwx -- /bin/bash
error: unable to upgrade connection: 404 page not found

server pod runs on node2, kubectl exec is done on node1 (k8s master)

- Cleanup KubernetesEnv.robot
Some keywords were split in 2 , such as Remove_Client_And_Server_Pod..
into Remove_CLient and Remvoe_Server.., but one node automated tests use
the old keywords. So cleanup to be done after one node tests update.

Signed-off-by: Peter Gubka <pgubka@cisco.com>