### PR TITLE
Issue #264: Make teardown pod check configurable

### DIFF
--- a/tests/robot/libraries/KubernetesEnv.robot
+++ b/tests/robot/libraries/KubernetesEnv.robot
@@ -322,9 +322,9 @@ Log_Contiv_Ksr
     KubeCtl.Logs    ${ssh_session}    @{pod_list}[0]    namespace=kube-system
 
 Log_Contiv_Vswitch
-    [Arguments]    ${ssh_session}
+    [Arguments]    ${ssh_session}    ${exp_nr_vswitch}=${KUBE_CLUSTER_${CLUSTER_ID}_NODES}
     ${pod_list} =    Get_Pod_Name_List_By_Prefix    ${ssh_session}    contiv-vswitch-
-    BuiltIn.Length_Should_Be    ${pod_list}    ${KUBE_CLUSTER_${CLUSTER_ID}_NODES}
+    BuiltIn.Length_Should_Be    ${pod_list}    ${exp_nr_vswitch}
     : FOR    ${vswitch_pod}    IN    @{pod_list}
     \    KubeCtl.Logs    ${ssh_session}    ${vswitch_pod}    namespace=kube-system    container=contiv-cni
     \    KubeCtl.Logs    ${ssh_session}    ${vswitch_pod}    namespace=kube-system    container=contiv-vswitch
@@ -338,8 +338,8 @@ Log_Kube_Dns
     KubeCtl.Logs    ${ssh_session}    @{pod_list}[0]    namespace=kube-system    container=sidecar
 
 Log_Pods_For_Debug
-    [Arguments]    ${ssh_session}
+    [Arguments]    ${ssh_session}    ${exp_nr_vswitch}=${KUBE_CLUSTER_${CLUSTER_ID}_NODES}
     Log_Contiv_Etcd    ${ssh_session}
     Log_Contiv_Ksr    ${ssh_session}
-    Log_Contiv_Vswitch    ${ssh_session}
+    Log_Contiv_Vswitch    ${ssh_session}    ${exp_nr_vswitch}
     Log_Kube_Dns    ${ssh_session}

--- a/tests/robot/suites/one_node_two_pods.robot
+++ b/tests/robot/suites/one_node_two_pods.robot
@@ -78,7 +78,7 @@ OneNodeK8sSetup
     KubernetesEnv.Deploy_Client_And_Server_Pod_And_Verify_Running    ${testbed_connection}
 
 OneNodeK8sTeardown
-    KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}
+    KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}    exp_nr_vswitch=1
     KubernetesEnv.Remove_Client_And_Server_Pod_And_Verify_Removed    ${testbed_connection}
     Testsuite Teardown
 

--- a/tests/robot/suites/one_node_two_pods_with_nginx.robot
+++ b/tests/robot/suites/one_node_two_pods_with_nginx.robot
@@ -38,7 +38,7 @@ OneNodeK8sSetup
     KubernetesEnv.Deploy_Client_And_Nginx_Pod_And_Verify_Running    ${testbed_connection}
 
 OneNodeK8sTeardown
-    KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}
+    KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}    exp_nr_vswitch=1
     KubernetesEnv.Remove_Client_And_Nginx_Pod_And_Verify_Removed    ${testbed_connection}
     Testsuite Teardown
 

--- a/tests/robot/suites/one_node_two_pods_with_nginx_istio.robot
+++ b/tests/robot/suites/one_node_two_pods_with_nginx_istio.robot
@@ -39,6 +39,7 @@ OneNodeK8sSetup
     KubernetesEnv.Deploy_Client_And_Nginx_Pod_And_Verify_Running    ${testbed_connection}    client_file=${CLIENT_ISTIO_POD_FILE}    nginx_file=${NGINX_ISTIO_POD_FILE}
 
 OneNodeK8sTeardown
+    KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}    exp_nr_vswitch=1
     KubernetesEnv.Remove_Client_And_Nginx_Pod_And_Verify_Removed    ${testbed_connection}    client_file=${CLIENT_ISTIO_POD_FILE}    nginx_file=${NGINX_ISTIO_POD_FILE}
     KubernetesEnv.Remove_Istio_And_Verify_Removed    ${testbed_connection}
     Testsuite Teardown

--- a/tests/robot/suites/two_node_two_pods.robot
+++ b/tests/robot/suites/two_node_two_pods.robot
@@ -121,7 +121,7 @@ TwoNodesK8sSetup
 
 
 TwoNodesK8sTeardown
-    KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}
+    KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}    exp_nr_vswitch=2
     KubernetesEnv.Remove_Nginx_Pod_And_Verify_Removed    ${testbed_connection}    nginx_file=${NGINX_POD_FILE_NODE2}
     KubernetesEnv.Remove_Client_Pod_And_Verify_Removed    ${testbed_connection}    client_file=${CLIENT_POD_FILE_NODE1}
     KubernetesEnv.Remove_Server_Pod_And_Verify_Removed    ${testbed_connection}    server_file=${SERVER_POD_FILE_NODE2}


### PR DESCRIPTION
KubernetesEnv.Log_Pods_For_Debug was expecting each node
contains vswitch pod. This makes the expectation configurable
so that suites with less nodes work on setups with more nodes.

Signed-off-by: Vratko Polak <vrpolak@cisco.com>