### PR TITLE
Issue #270: Store kubectl logs to files

### DIFF
--- a/tests/robot/libraries/KubeCtl.robot
+++ b/tests/robot/libraries/KubeCtl.robot
@@ -77,11 +77,11 @@ Get_Nodes
 
 Logs
     [Arguments]    ${ssh_session}    ${pod_name}    ${container}=${EMPTY}    ${namespace}=${EMPTY}
-    [Documentation]    Execute "kubectl logs" with given params and return the result.
+    [Documentation]    Execute "kubectl logs" with given params, and return the result while logging into separate file.
     BuiltIn.Log_Many    ${ssh_session}    ${pod_name}    ${container}    ${namespace}
     ${nsparam} =     BuiltIn.Set_Variable_If    """${namespace}""" != """${EMPTY}"""    --namespace ${namespace}    ${EMPTY}
     ${cntparam} =    BuiltIn.Set_Variable_If    """${container}""" != """${EMPTY}"""    ${container}    ${EMPTY}
-    BuiltIn.Run_Keyword_And_Return    SshCommons.Switch_And_Execute_Command    ${ssh_session}    kubectl logs ${nsparam} ${pod_name} ${cntparam}
+    BuiltIn.Run_Keyword_And_Return    SshCommons.Switch_Execute_And_Log_To_File    ${ssh_session}    kubectl logs ${nsparam} ${pod_name} ${cntparam}
 
 Describe_Pod
     [Arguments]    ${ssh_session}    ${pod_name}

--- a/tests/robot/libraries/SshCommons.robot
+++ b/tests/robot/libraries/SshCommons.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Documentation     This is a library for simple improvements over SSHLibrary for other robot libraries to use.
+Library           OperatingSystem
 Library           String
 Library           SSHLibrary
 
@@ -31,20 +32,37 @@ Execute_Command_With_Copied_File
     ${splitted_path} =    String.Split_String    ${file_path}    separator=${/}
     BuiltIn.Run_Keyword_And_Return    Execute_Command_And_Log    ${command_prefix} @{splitted_path}[-1]    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}
 
+Switch_Execute_And_Log_To_File
+    [Arguments]    ${ssh_session}    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}    ${log_stdout}=${False}
+    [Documentation]    Call Switch_And_Execute_Command (by default without logging stdout), put stdout into a file. Return stdout.
+    ...    To distinguish separate invocations, suite name, test name, session alias
+    ...    and full command are used to construct file name.
+    BuiltIn.Log_Many    ${ssh_session}    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}    ${log_stdout}
+    ${stdout} =    Switch_And_Execute_Command    ${ssh_session}    ${command}    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}    log_stdout=${log_stdout}
+    # TODO: Create a separate library for putting data into automatically named files?
+    ${underlined_command} =    String.Replace_String    ${command}    ${SPACE}    _
+    # We rely on the requested session being active now.
+    ${connection} =    SSHLibrary.Get_Connection
+    # In teardown, ${TEST_NAME} does not exist.
+    ${testname} =    BuiltIn.Get_Variable_Value    ${TEST_NAME}    ${EMPTY}
+    ${filename} =    BuiltIn.Set_Variable    ${testname}__${SUITE_NAME}__${connection.alias}__${underlined_command}.log
+    BuiltIn.Log    ${filename}
+    OperatingSystem.Create_File    ${RESULTS_FOLDER}${/}${filename}    ${stdout}
+    [Return]    ${stdout}
+
 Switch_And_Execute_Command
-    [Arguments]    ${ssh_session}    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}
+    [Arguments]    ${ssh_session}    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}    ${log_stdout}=${True}
     [Documentation]    Switch to \${ssh_session}, and continue with Execute_Command_And_Log.
-    BuiltIn.Log_Many    ${ssh_session}    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}=${False}
+    BuiltIn.Log_Many    ${ssh_session}    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}    ${log_stdout}
     SSHLibrary.Switch_Connection    ${ssh_session}
-    BuiltIn.Run_Keyword_And_Return    Execute_Command_And_Log    ${command}    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}
+    BuiltIn.Run_Keyword_And_Return    Execute_Command_And_Log    ${command}    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}    log_stdout=${log_stdout}
 
 Execute_Command_And_Log
-    [Arguments]    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}
+    [Arguments]    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}    ${log_stdout}=${True}
     [Documentation]    Execute \${command} on current SSH session, log results, maybe fail on nonempty stderr, check \${expected_rc}, return stdout.
-    BuiltIn.Log_Many    ${command}    ${expected_rc}    ${ignore_stderr}
-    BuiltIn.Comment    TODO: Add logging to file. See https://github.com/contiv/vpp/issues/200
+    BuiltIn.Log_Many    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}    ${log_stdout}
     ${stdout}    ${stderr}    ${rc} =    SSHLibrary.Execute_Command    ${command}    return_stderr=True    return_rc=True
-    BuiltIn.Log    ${stdout}
+    BuiltIn.Run_Keyword_If    ${log_stdout}    BuiltIn.Log    ${stdout}
     BuiltIn.Log    ${stderr}
     BuiltIn.Log    ${rc}
     BuiltIn.Run_Keyword_Unless    ${ignore_stderr}    BuiltIn.Should_Be_Empty    ${stderr}


### PR DESCRIPTION
Kubectl.Logs shall put the data into automatically named files
in resuls directory, instead of just BuiltIn.Log-ing them.

Signed-off-by: Vratko Polak <vrpolak@cisco.com>