### PR TITLE
Issue #201: Improve recently merged suites

### DIFF
--- a/tests/robot/libraries/KubeCtl.robot
+++ b/tests/robot/libraries/KubeCtl.robot
@@ -77,11 +77,11 @@ Get_Nodes
 
 Logs
     [Arguments]    ${ssh_session}    ${pod_name}    ${container}=${EMPTY}    ${namespace}=${EMPTY}
-    [Documentation]    Execute "kubectl logs" with given params, and return the result while logging into separate file.
+    [Documentation]    Execute "kubectl logs" with given params, log output into a result file.
     BuiltIn.Log_Many    ${ssh_session}    ${pod_name}    ${container}    ${namespace}
     ${nsparam} =     BuiltIn.Set_Variable_If    """${namespace}""" != """${EMPTY}"""    --namespace ${namespace}    ${EMPTY}
     ${cntparam} =    BuiltIn.Set_Variable_If    """${container}""" != """${EMPTY}"""    ${container}    ${EMPTY}
-    BuiltIn.Run_Keyword_And_Return    SshCommons.Switch_Execute_And_Log_To_File    ${ssh_session}    kubectl logs ${nsparam} ${pod_name} ${cntparam}
+    SshCommons.Switch_Execute_And_Log_To_File    ${ssh_session}    kubectl logs ${nsparam} ${pod_name} ${cntparam}
 
 Describe_Pod
     [Arguments]    ${ssh_session}    ${pod_name}

--- a/tests/robot/libraries/KubernetesEnv.robot
+++ b/tests/robot/libraries/KubernetesEnv.robot
@@ -101,6 +101,8 @@ Docker_Pull_Contiv_Vpp
 
 Docker_Pull_Custom_Kube_Proxy
     [Arguments]    ${ssh_session}
+    [Documentation]    Execute proxy-install.sh script.
+    Builtin.Log_Many    ${ssh_session}
     SshCommons.Switch_And_Execute_Command    ${ssh_session}    bash <(curl -s https://raw.githubusercontent.com/contiv/vpp/master/k8s/proxy-install.sh)
 
 Apply_Contive_Vpp_Plugin
@@ -151,14 +153,16 @@ Deploy_Client_And_Server_Pod_And_Verify_Running
 
 Deploy_Client_Pod_And_Verify_Running
     [Arguments]    ${ssh_session}    ${client_file}=${CLIENT_POD_FILE}
-    [Documentation]     Deploy client ubuntu pod. Pod name in the yaml file is expectedt o be ubuntu-client
+    [Documentation]     Deploy client ubuntu pod. Pod name in the yaml file is expected to be ubuntu-client.
+    BuiltIn.Log_Many    ${ssh_session}    ${client_file}
     ${client_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${client_file}    ubuntu-client-
     BuiltIn.Set_Suite_Variable    ${client_pod_name}
 
 Deploy_Server_Pod_And_Verify_Running
-    [Arguments]    ${ssh_session}    ${server_file}=${SERVER_POD_FILE}
-    [Documentation]     Deploy server ubuntu pod. Pod name in the yaml file is expectedt o be ubuntu-server
-    ${server_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${server_file}    ubuntu-server-
+    [Arguments]    ${ssh_session}    ${server_file}=${SERVER_POD_FILE}    ${timeout}=60s
+    [Documentation]     Deploy server ubuntu pod. Pod name in the yaml file is expected to be ubuntu-server.
+    BuiltIn.Log_Many    ${ssh_session}    ${server_file}    ${timeout}
+    ${server_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${server_file}    ubuntu-server-    timeout=${timeout}
     BuiltIn.Set_Suite_Variable    ${server_pod_name}
 
 Remove_Client_And_Server_Pod_And_Verify_Removed
@@ -194,12 +198,15 @@ Deploy_Client_And_Nginx_Pod_And_Verify_Running
 Deploy_Nginx_Pod_And_Verify_Running
     [Arguments]    ${ssh_session}    ${nginx_file}=${NGINX_POD_FILE}
     [Documentation]     Deploy one nginx pod
+    BuiltIn.Log_Many    ${ssh_session}    ${nginx_file}
     ${nginx_pod_name} =    Deploy_Pod_And_Verify_Running    ${ssh_session}    ${nginx_file}    nginx-
     BuiltIn.Set_Suite_Variable    ${nginx_pod_name}
 
 Verify_Multireplica_Pods_Running
     [Arguments]    ${ssh_session}    ${pod_prefix}    ${nr_replicas}    ${namespace}
-    [Documentation]     We check istio- pods are running
+    [Documentation]     Check there is expected number of pods and they are running.
+    BuiltIn.Log_Many    ${ssh_session}    ${pod_prefix}    ${nr_replicas}    ${namespace}
+    BuiltIn.Comment    TODO: Join single- and multi- replica keywords.
     ${pods_list} =    Get_Pod_Name_List_By_Prefix    ${ssh_session}    ${pod_prefix}
     BuiltIn.Length_Should_Be   ${pods_list}     ${nr_replicas}
     : FOR    ${pod_name}    IN    @{pods_list}
@@ -208,7 +215,9 @@ Verify_Multireplica_Pods_Running
 
 Deploy_Multireplica_Pods_And_Verify_Running
     [Arguments]    ${ssh_session}    ${pod_file}    ${pod_prefix}    ${nr_replicas}    ${namespace}=default    ${setup_timeout}=60s
-    [Documentation]     Deploy pods from one provided yaml file with more replica specified
+    [Documentation]     Apply the provided yaml file with more replica specified, wait until pods are running, return pods details.
+    BuiltIn.Log_Many    ${ssh_session}    ${pod_file}    ${pod_prefix}    ${nr_replicas}    ${namespace}    ${setup_timeout}
+    BuiltIn.Comment    TODO: Join single- and multi- replica keywords.
     KubeCtl.Apply_F    ${ssh_session}    ${pod_file}
     ${pods_details} =    BuiltIn.Wait_Until_Keyword_Succeeds    ${setup_timeout}   4s    Verify_Multireplica_Pods_Running    ${ssh_session}    ${pod_prefix}    ${nr_replicas}    ${namespace}
     BuiltIn.Set_Suite_Variable    ${pods_details}
@@ -216,12 +225,15 @@ Deploy_Multireplica_Pods_And_Verify_Running
 Verify_Multireplica_Pods_Removed
     [Arguments]    ${ssh_session}    ${pod_prefix}
     [Documentation]     Check no pods are running with prefix: ${pod_prefix}
+    BuiltIn.Log_Many    ${ssh_session}    ${pod_prefix}
+    BuiltIn.Comment    TODO: Join single- and multi- replica keywords.
     ${pods_list} =    Get_Pod_Name_List_By_Prefix    ${ssh_session}    ${pod_prefix}
     BuiltIn.Length_Should_Be   ${pods_list}     0
 
 Remove_Multireplica_Pods_And_Verify_Removed
     [Arguments]    ${ssh_session}    ${pod_file}    ${pod_prefix}
-    [Documentation]     Remove pods and verify they're removed.
+    [Documentation]     Remove pods and verify they are removed.
+    BuiltIn.Log_Many    ${ssh_session}    ${pod_file}    ${pod_prefix}
     KubeCtl.Delete_F    ${ssh_session}    ${pod_file}
     BuiltIn.Wait_Until_Keyword_Succeeds    60s    5s    Verify_Multireplica_Pods_Removed    ${ssh_session}    ${pod_prefix}
 
@@ -236,6 +248,8 @@ Remove_Client_And_Nginx_Pod_And_Verify_Removed
 
 Remove_Nginx_Pod_And_Verify_Removed
     [Arguments]    ${ssh_session}    ${nginx_file}=${NGINX_POD_FILE}
+    [Documentation]    Remove pod and verify removal, nginx being the default file.
+    BuiltIn.Log_Many    ${ssh_session}    ${nginx_file}
     KubeCtl.Delete_F    ${ssh_session}    ${nginx_file}
     Wait_Until_Pod_Removed    ${ssh_session}    ${nginx_pod_name}
 
@@ -274,18 +288,20 @@ Remove_Istio_And_Verify_Removed
 
 Get_Deployed_Pod_Name
     [Arguments]    ${ssh_session}    ${pod_prefix}
+    [Documentation]    Get list of pod names matching the prefix, check tere is just one, return the name.
+    BuiltIn.Log_Many    ${ssh_session}    ${pod_prefix}
     ${pod_name_list} =   Get_Pod_Name_List_By_Prefix    ${ssh_session}    ${pod_prefix}
     BuiltIn.Length_Should_Be    ${pod_name_list}    1
     ${pod_name} =    BuiltIn.Evaluate     ${pod_name_list}[0]
     [Return]    ${pod_name}
 
 Deploy_Pod_And_Verify_Running
-    [Arguments]    ${ssh_session}    ${pod_file}    ${pod_prefix}
+    [Arguments]    ${ssh_session}    ${pod_file}    ${pod_prefix}    ${timeout}=60s
     [Documentation]    Deploy pod defined by \${pod_file}, wait until a pod matching \${pod_prefix} appears, check it was only 1 such pod, extract its name, wait until it is running, log and return the name.
     Builtin.Log_Many    ${ssh_session}    ${pod_file}    ${pod_prefix}
     KubeCtl.Apply_F    ${ssh_session}    ${pod_file}
     ${pod_name} =    BuiltIn.Wait_Until_Keyword_Succeeds    10s    2s    Get_Deployed_Pod_Name    ${ssh_session}    ${pod_prefix}
-    Wait_Until_Pod_Running    ${ssh_session}    ${pod_name}
+    Wait_Until_Pod_Running    ${ssh_session}    ${pod_name}    timeout=${timeout}
     BuiltIn.Log    ${pod_name}
     [Return]    ${pod_name}
 

--- a/tests/robot/libraries/SshCommons.robot
+++ b/tests/robot/libraries/SshCommons.robot
@@ -33,36 +33,35 @@ Execute_Command_With_Copied_File
     BuiltIn.Run_Keyword_And_Return    Execute_Command_And_Log    ${command_prefix} @{splitted_path}[-1]    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}
 
 Switch_Execute_And_Log_To_File
-    [Arguments]    ${ssh_session}    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}    ${log_stdout}=${False}
-    [Documentation]    Call Switch_And_Execute_Command (by default without logging stdout), put stdout into a file. Return stdout.
+    [Arguments]    ${ssh_session}    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}
+    [Documentation]    Call Switch_And_Execute_Command redirecting stdout to a remote file, download the file.
     ...    To distinguish separate invocations, suite name, test name, session alias
     ...    and full command are used to construct file name.
-    BuiltIn.Log_Many    ${ssh_session}    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}    ${log_stdout}
-    ${stdout} =    Switch_And_Execute_Command    ${ssh_session}    ${command}    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}    log_stdout=${log_stdout}
-    # TODO: Create a separate library for putting data into automatically named files?
-    ${underlined_command} =    String.Replace_String    ${command}    ${SPACE}    _
-    # We rely on the requested session being active now.
+    BuiltIn.Log_Many    ${ssh_session}    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}
+    SSHLibrary.Switch_Connection    ${ssh_session}
     ${connection} =    SSHLibrary.Get_Connection
     # In teardown, ${TEST_NAME} does not exist.
     ${testname} =    BuiltIn.Get_Variable_Value    ${TEST_NAME}    ${EMPTY}
-    ${filename} =    BuiltIn.Set_Variable    ${testname}__${SUITE_NAME}__${connection.alias}__${underlined_command}.log
+    ${filename_with_spaces} =    BuiltIn.Set_Variable    ${testname}__${SUITE_NAME}__${connection.alias}__${command}.log
+    ${filename} =    String.Replace_String    ${filename_with_spaces}    ${SPACE}    _
     BuiltIn.Log    ${filename}
-    OperatingSystem.Create_File    ${RESULTS_FOLDER}${/}${filename}    ${stdout}
-    [Return]    ${stdout}
+    Switch_And_Execute_Command    ${ssh_session}    ${command} > ${filename}    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}
+    SSHLibrary.Get_File    ${filename}    ${RESULTS_FOLDER}/${filename}
+    [Teardown]    Execute_Command_And_Log    rm ${filename}
 
 Switch_And_Execute_Command
-    [Arguments]    ${ssh_session}    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}    ${log_stdout}=${True}
+    [Arguments]    ${ssh_session}    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}
     [Documentation]    Switch to \${ssh_session}, and continue with Execute_Command_And_Log.
-    BuiltIn.Log_Many    ${ssh_session}    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}    ${log_stdout}
+    BuiltIn.Log_Many    ${ssh_session}    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}
     SSHLibrary.Switch_Connection    ${ssh_session}
-    BuiltIn.Run_Keyword_And_Return    Execute_Command_And_Log    ${command}    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}    log_stdout=${log_stdout}
+    BuiltIn.Run_Keyword_And_Return    Execute_Command_And_Log    ${command}    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}
 
 Execute_Command_And_Log
-    [Arguments]    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}    ${log_stdout}=${True}
+    [Arguments]    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}
     [Documentation]    Execute \${command} on current SSH session, log results, maybe fail on nonempty stderr, check \${expected_rc}, return stdout.
-    BuiltIn.Log_Many    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}    ${log_stdout}
+    BuiltIn.Log_Many    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}
     ${stdout}    ${stderr}    ${rc} =    SSHLibrary.Execute_Command    ${command}    return_stderr=True    return_rc=True
-    BuiltIn.Run_Keyword_If    ${log_stdout}    BuiltIn.Log    ${stdout}
+    BuiltIn.Log    ${stdout}
     BuiltIn.Log    ${stderr}
     BuiltIn.Log    ${rc}
     BuiltIn.Run_Keyword_Unless    ${ignore_stderr}    BuiltIn.Should_Be_Empty    ${stderr}

--- a/tests/robot/suites/one_node_two_pods_ldpreload_iperf.robot
+++ b/tests/robot/suites/one_node_two_pods_ldpreload_iperf.robot
@@ -3,35 +3,44 @@ Documentation    Test suite to test ldpreload functionality with iperf.
 Resource         ${CURDIR}/../libraries/all_libs.robot
 Suite Setup      OneNodeK8sSetup
 Suite Teardown   OneNodeK8sTeardown
+Test Timeout     5m
 
 *** Variables ***
 ${CLIENT_FILE}   ${CURDIR}/../resources/one-ldpreload-client-iperf.yaml
 ${SERVER_FILE}   ${CURDIR}/../resources/one-ldpreload-server-iperf.yaml
 
 *** Test Cases ***
-Pod_To_Pod_Iperf
+Host_To_Pod_Iperf
+    [Documentation]    Execute iperf3 comand from host towards server pod, checking return code is zero.
     [Setup]    Setup_Hosts_Connections
-    ${stdout} =    KubeCtl.Execute_On_Pod    ${testbed_connection}    ${client_pod_name}    iperf3 -V4d -c ${server_ip}    ignore_stderr=${True}
-    Log    ${stdout}
+    SshCommons.Switch_And_Execute_Command    ${testbed_connection}    iperf3 -V4d -c ${server_ip}    ignore_stderr=${True}
+    [Teardown]    Teardown_Hosts_Connections
+
+Pod_To_Pod_Iperf
+    [Documentation]    Execute iperf3 comand from client pod towards server pod, checking return code is zero.
+    [Setup]    Setup_Hosts_Connections
+    KubeCtl.Execute_On_Pod    ${testbed_connection}    ${client_pod_name}    iperf3 -V4d -c ${server_ip}    ignore_stderr=${True}
+    [Teardown]    Teardown_Hosts_Connections
+
+Host_To_Pod_Iperf_Again
+    [Documentation]    Execute iperf3 comand from host towards server pod, checking return code is zero.
+    ...    This is to show whether the previous test case changes the result of this repeated test.
+    [Setup]    Setup_Hosts_Connections
+    SshCommons.Switch_And_Execute_Command    ${testbed_connection}    iperf3 -V4d -c ${server_ip}    ignore_stderr=${True}
     [Teardown]    Teardown_Hosts_Connections
 
 Pod_To_Pod_Iperf_Loop
+    [Documentation]    Execute multiple iperf3 comands from client pod towards server pod sequentially,
+    ...    checking return codes are zero.
     [Setup]    Setup_Hosts_Connections
-    [Timeout]    5 minutes
+    [Timeout]    10m
     Repeat Keyword    15    KubeCtl.Execute_On_Pod    ${testbed_connection}    ${client_pod_name}    iperf3 -V4d -c ${server_ip}    ignore_stderr=${True}
     [Teardown]    Teardown_Hosts_Connections
-
-Host_To_Pod_Iperf
-    [Setup]    Setup_Hosts_Connections
-    [Timeout]    5 minutes
-    ${stdout} =    SshCommons.Switch_And_Execute_Command    ${testbed_connection}    iperf3 -V4d -c ${server_ip}    ignore_stderr=${True}
-    Log    ${stdout}
-    [Teardown]    Teardown_Hosts_Connections
-
 
 *** Keywords ***
 OneNodeK8sSetup
     [Documentation]    Execute common setup, reinit 1node cluster, deploy client and server pods.
+    [Timeout]    10m
     setup-teardown.Testsuite_Setup
     KubernetesEnv.Reinit_One_Node_Kube_Cluster
     ${client_pod_name} =    KubernetesEnv.Deploy_Pod_And_Verify_Running    ${testbed_connection}    ${CLIENT_FILE}    test-client-
@@ -41,6 +50,7 @@ OneNodeK8sSetup
 
 OneNodeK8sTeardown
     [Documentation]    Log leftover output from pods, remove pods, execute common teardown.
+    [Timeout]    5m
     KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}    exp_nr_vswitch=1
     KubeCtl.Delete_F    ${testbed_connection}    ${CLIENT_FILE}
     KubeCtl.Delete_F    ${testbed_connection}    ${SERVER_FILE}
@@ -52,6 +62,7 @@ Setup_Hosts_Connections
     [Arguments]    ${user}=localadmin    ${password}=cisco123
     [Documentation]    Open and store two more SSH connections to master host, in them open
     ...    pod shells to client and server pod, parse their IP addresses and store them.
+    [Timeout]    5m
     Builtin.Log_Many    ${user}    ${password}
     ${conn} =     SSHLibrary.Get_Connection    ${testbed_connection}
     ${client_connection} =    SSHLibrary.Open_Connection    ${conn.host}    timeout=10
@@ -71,9 +82,12 @@ Setup_Hosts_Connections
 
 Teardown_Hosts_Connections
     [Documentation]    Exit pod shells, close corresponding SSH connections.
+    [Timeout]    5m
     KubernetesEnv.Leave_Container_Prompt_In_Pod    ${client_connection}
     KubernetesEnv.Leave_Container_Prompt_In_Pod    ${server_connection}
     SSHLibrary.Switch_Connection    ${client_connection}
     SSHLibrary.Close_Connection
     SSHLibrary.Switch_Connection    ${server_connection}
     SSHLibrary.Close_Connection
+    KubeCtl.Logs    ${testbed_connection}    ${server_pod_name}
+    KubeCtl.Logs    ${testbed_connection}    ${client_pod_name}

--- a/tests/robot/suites/two_node_ten_nginx.robot
+++ b/tests/robot/suites/two_node_ten_nginx.robot
@@ -13,7 +13,7 @@ Pod_To_Ten_Nginxs
     [Teardown]    Teardown_Hosts_Connections
 
 Host_To_Ten_Nginxs
-    [Documentation]    Curl from linux host pod to another on the same node
+    [Documentation]    Curl from linux host pod to another on the same node.
     Log    ${nginx_list}
     : FOR    ${nginx_node}     IN     @{nginx_list}
     \    ${nginx_node_details} =    KubeCtl.Describe_Pod    ${testbed_connection}    ${nginx_node}

--- a/tests/robot/suites/two_node_two_pods.robot
+++ b/tests/robot/suites/two_node_two_pods.robot
@@ -103,7 +103,7 @@ TwoNodesK8sSetup
     setup-teardown.Testsuite_Setup
     KubernetesEnv.Reinit_Multi_Node_Kube_Cluster
     KubernetesEnv.Deploy_Client_Pod_And_Verify_Running    ${testbed_connection}    client_file=${CLIENT_POD_FILE_NODE1}
-    KubernetesEnv.Deploy_Server_Pod_And_Verify_Running    ${testbed_connection}    server_file=${SERVER_POD_FILE_NODE2}
+    KubernetesEnv.Deploy_Server_Pod_And_Verify_Running    ${testbed_connection}    server_file=${SERVER_POD_FILE_NODE2}    timeout=12m
     KubernetesEnv.Deploy_Nginx_Pod_And_Verify_Running    ${testbed_connection}    nginx_file=${NGINX_POD_FILE_NODE2}
     ${client_pod_details} =     KubeCtl.Describe_Pod    ${testbed_connection}    ${client_pod_name}
     ${server_pod_details} =     KubeCtl.Describe_Pod    ${testbed_connection}    ${server_pod_name}
@@ -118,6 +118,8 @@ TwoNodesK8sSetup
 TwoNodesK8sTeardown
     [Documentation]    Log leftover output from pods, remove pods, execute common teardown.
     KubernetesEnv.Log_Pods_For_Debug    ${testbed_connection}    exp_nr_vswitch=2
+    ${server_name} =    KubernetesEnv.Get_Deployed_Pod_Name    ${testbed_connection}    ubuntu-server-
+    KubeCtl.Logs    ${testbed_connection}    ${server_name}
     KubernetesEnv.Remove_Nginx_Pod_And_Verify_Removed    ${testbed_connection}    nginx_file=${NGINX_POD_FILE_NODE2}
     KubernetesEnv.Remove_Client_Pod_And_Verify_Removed    ${testbed_connection}    client_file=${CLIENT_POD_FILE_NODE1}
     KubernetesEnv.Remove_Server_Pod_And_Verify_Removed    ${testbed_connection}    server_file=${SERVER_POD_FILE_NODE2}


### PR DESCRIPTION
Change log gathering keyword to not load the huge data into a variable.

Also, reorder test cases in one_node_two_pods_ldpreload_iperf.

Signed-off-by: Vratko Polak <vrpolak@cisco.com>