### PR TITLE
Issue 317: Use docker exec instead kubectl in test

### DIFF
--- a/tests/robot/libraries/KubeCtl.robot
+++ b/tests/robot/libraries/KubeCtl.robot
@@ -104,11 +104,26 @@ Label_Nodes
     Builtin.Log_Many    ${ssh_session}    ${node_name}   ${label_key}    ${label_value}
     BuiltIn.Run_Keyword_And_Return    SshCommons.Switch_And_Execute_Command    ${ssh_session}    kubectl label nodes ${node_name} ${label_key}=${label_value}
 
+Get_Container_Id
+    [Arguments]    ${ssh_session}    ${pod_name}    ${container}=${EMPTY}
+    [Documentation]    Return \${container} or describe pod, parse for first container ID, log and return that.
+    ...    As kubectl is usually only present only on master node, switch to \${ssh_session} is done after.
+    BuiltIn.Log_Many    ${ssh_session}    ${pod_name}    ${container}
+    Builtin.Return_From_Keyword_If    """${container}"""    ${container}
+    ${output} =    SshCommons.Switch_And_Execute_Command    ${VM_SSH_ALIAS_PREFIX}1    kubectl describe pod ${pod_name}
+    SSHLibrary.Switch_Connection    ${ssh_session}
+    ${id} =    kube_parser.parse_for_first_container_id    ${output}
+    Builtin.Log    ${id}
+    [Return]    ${id}
+
 Execute_On_Pod
-    [Arguments]    ${ssh_session}    ${pod_name}    ${cmd}    ${container}=${EMPTY}    ${tty}=${False}    ${stdin}=${False}    ${ignore_stderr}=${False}    ${ignore_rc}=${False}
-    [Documentation]    Execute "kubectl exec" with given parameters, return the result.
-    Builtin.Log_Many    ${ssh_session}    ${pod_name}    ${cmd}    ${container}    ${tty}    ${stdin}    ${ignore_stderr}    ${ignore_rc}
-    ${c_param} =    BuiltIn.Set_Variable_If    """${container}""" != """${EMPTY}"""    -c ${container}    ${EMPTY}
-    ${t_param} =    BuiltIn.Set_Variable_If    ${tty}                                  -t                 ${EMPTY}
-    ${i_param} =    BuiltIn.Set_Variable_If    ${stdin}                                -i                 ${EMPTY}
-    BuiltIn.Run_Keyword_And_Return    SshCommons.Switch_And_Execute_Command    ${ssh_session}    kubectl exec ${pod_name} ${c_param} ${t_param} ${i_param} -- ${cmd}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}
+    [Arguments]    ${ssh_session}    ${pod_name}    ${cmd}    ${container}=${EMPTY}    ${tty}=${False}    ${stdin}=${False}    ${privileged}=${True}    ${ignore_stderr}=${False}    ${ignore_rc}=${False}
+    [Documentation]    Execute "docker exec" with given parameters, return the result.
+    ...    Container ID is autodetected if empty. This only works if \${ssh_session} points to the correct host.
+    Builtin.Log_Many    ${ssh_session}    ${pod_name}    ${cmd}    ${container}    ${tty}    ${stdin}    ${privileged}    ${ignore_stderr}    ${ignore_rc}
+    ${container_id} =    Get_Container_Id    ${ssh_session}    ${pod_name}    ${container}
+    ${t_param} =    BuiltIn.Set_Variable_If    ${tty}    -t    ${EMPTY}
+    ${i_param} =    BuiltIn.Set_Variable_If    ${stdin}    -i    ${EMPTY}
+    ${p_param} =    BuiltIn.Set_Variable_If    ${privileged}    ---privileged=true    --privileged=false
+    ${docker} =    BuiltIn.Set_Variable    ${KUBE_CLUSTER_${CLUSTER_ID}_DOCKER_COMMAND}
+    BuiltIn.Run_Keyword_And_Return    SshCommons.Switch_And_Execute_Command    ${ssh_session}    ${docker} exec ${i_param} ${t_param} ${p_param} ${container_id} ${cmd}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}

--- a/tests/robot/libraries/KubernetesEnv.robot
+++ b/tests/robot/libraries/KubernetesEnv.robot
@@ -387,9 +387,11 @@ Get_Into_Container_Prompt_In_Pod
     [Documentation]    Configure if prompt, execute interactive bash in ${pod_name}, read until prompt, log and return output.
     BuiltIn.Log_Many    ${ssh_session}    ${pod_name}    ${prompt}
     # TODO: PodBash.robot?
-    SSHLibrary.Switch_Connection    ${ssh_session}
+    ${docker} =    BuiltIn.Set_Variable    ${KUBE_CLUSTER_${CLUSTER_ID}_DOCKER_COMMAND}
+    ${container_id} =    KubeCtl.Get_Container_Id    ${ssh_session}    ${pod_name}
+    # That already switched the ssh session.
     BuiltIn.Run_Keyword_If    """${prompt}""" != """${EMPTY}"""    SSHLibrary.Set_Client_Configuration    prompt=${prompt}
-    SSHLibrary.Write    kubectl exec -it ${pod_name} -- /bin/bash
+    SSHLibrary.Write    ${docker} exec -i -t --privileged=true ${container_id} /bin/bash
     ${output} =     SSHLibrary.Read_Until_Prompt
     Log     ${output}
     [Return]    ${output}

--- a/tests/robot/libraries/kube_parser.py
+++ b/tests/robot/libraries/kube_parser.py
@@ -1,5 +1,8 @@
 """
 Library to parse output (stdout) of kubectl adn kubeadm command
+
+TODO: Do not use this, call the following (example):
+  kubectl get pod -l "app=test-server" -o jsonpath='{.items[0].status.podIP}'
 """
 
 def _general_parser(stdout):
@@ -55,6 +58,15 @@ def parse_kubectl_describe_pod(stdout):
                 result[item] = line.split(":")[-1].strip()
     name = result.pop("Name")
     return {name: result}
+
+_CID = "Container ID:"
+
+def parse_for_first_container_id(stdout):
+    lines = stdout.splitlines()
+    for line in lines:
+        stripline = line.strip()
+        if stripline.startswith(_CID):
+            return stripline[len(_CID):].strip().rpartition("//")[2]
 
 def get_join_from_kubeadm_init(stdout):
     """Parse kubeadm init output

--- a/tests/robot/suites/two_node_two_pods.robot
+++ b/tests/robot/suites/two_node_two_pods.robot
@@ -21,6 +21,7 @@ Pod_To_Pod_Udp
     KubernetesEnv.Init_Infinite_Command_in_Pod    nc -u ${server_ip} 7000    ssh_session=${client_connection}
     ${text} =    BuiltIn.Set_Variable    Text to be received
     SSHLibrary.Write    ${text}
+    BuiltIn.Sleep    1
     ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${client_connection}
     ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
     BuiltIn.Should_Contain   ${server_stdout}    ${text}
@@ -33,6 +34,7 @@ Pod_To_Pod_Tcp
     KubernetesEnv.Run_Finite_Command_In_Pod    cd; echo "${text}" > some.file    ssh_session=${client_connection}
     KubernetesEnv.Init_Infinite_Command_in_Pod    nc -l -p 4444    ssh_session=${server_connection}
     KubernetesEnv.Init_Infinite_Command_in_Pod    cd; nc ${server_ip} 4444 < some.file    ssh_session=${client_connection}
+    BuiltIn.Sleep    1
     ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
     BuiltIn.Should_Contain   ${server_stdout}    ${text}
     ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${client_connection}
@@ -54,6 +56,7 @@ Host_To_Pod_Udp_Remote
     KubernetesEnv.Init_Infinite_Command_in_Pod    nc -u ${server_ip} 7000    ssh_session=${testbed_connection}
     ${text} =    BuiltIn.Set_Variable    Text to be received
     SSHLibrary.Write    ${text}
+    BuiltIn.Sleep    1
     ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${testbed_connection}    prompt=$
     ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
     BuiltIn.Should_Contain   ${server_stdout}    ${text}
@@ -66,6 +69,7 @@ Host_To_Pod_Tcp_Remote
     KubernetesEnv.Run_Finite_Command_In_Pod    cd; echo "${text}" > some.file    ssh_session=${testbed_connection}
     KubernetesEnv.Init_Infinite_Command_in_Pod    nc -l -p 4444    ssh_session=${server_connection}
     KubernetesEnv.Init_Infinite_Command_in_Pod    cd; nc ${server_ip} 4444 < some.file    ssh_session=${testbed_connection}
+    BuiltIn.Sleep    1
     ${server_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${server_connection}
     BuiltIn.Should_Contain   ${server_stdout}    ${text}
     ${client_stdout} =    KubernetesEnv.Stop_Infinite_Command_In_Pod    ssh_session=${testbed_connection}    prompt=$
@@ -131,14 +135,15 @@ Setup_Hosts_Connections
     ...    pod shell to client pod.
     Builtin.Log_Many    ${user}    ${password}
     ${conn} =     SSHLibrary.Get_Connection    ${testbed_connection}
-    ${client_connection} =    SSHLibrary.Open_Connection    ${conn.host}    timeout=10
+    ${client_connection} =    SSHLibrary.Open_Connection    ${conn.host}    timeout=60
     SSHLibrary.Login    ${user}    ${password}
     BuiltIn.Set_Suite_Variable    ${client_connection}
-    ${server_connection} =    SSHLibrary.Open_Connection    ${conn.host}    timeout=10
+    ${conn} =     SSHLibrary.Get_Connection    ${VM_SSH_ALIAS_PREFIX}2
+    ${server_connection} =    SSHLibrary.Open_Connection    ${conn.host}    timeout=60
     SSHLibrary.Login    ${user}    ${password}
     BuiltIn.Set_Suite_Variable    ${server_connection}
-    KubernetesEnv.Get_Into_Container_Prompt_In_Pod    ${client_connection}    ${client_pod_name}    prompt=\#
-    KubernetesEnv.Get_Into_Container_Prompt_In_Pod    ${server_connection}    ${server_pod_name}    prompt=\#
+    KubernetesEnv.Get_Into_Container_Prompt_In_Pod    ${client_connection}    ${client_pod_name}    prompt=#
+    KubernetesEnv.Get_Into_Container_Prompt_In_Pod    ${server_connection}    ${server_pod_name}    prompt=#
 
 Teardown_Hosts_Connections
     [Documentation]    Exit client pod shell, close both new SSH connections.


### PR DESCRIPTION
Do some changes to two_node_two_pods.robot
to make sure docker exec itself is not causing the failures.

Signed-off-by: Vratko Polak <vrpolak@cisco.com>