### PR TITLE
Robot: Compress logs before downloading them

### DIFF
--- a/tests/robot/libraries/KubeCtl.robot
+++ b/tests/robot/libraries/KubeCtl.robot
@@ -76,12 +76,12 @@ Get_Nodes
     [Return]    ${output}
 
 Logs
-    [Arguments]    ${ssh_session}    ${pod_name}    ${container}=${EMPTY}    ${namespace}=${EMPTY}
+    [Arguments]    ${ssh_session}    ${pod_name}    ${container}=${EMPTY}    ${namespace}=${EMPTY}    ${compress}=${True}
     [Documentation]    Execute "kubectl logs" with given params, log output into a result file.
-    BuiltIn.Log_Many    ${ssh_session}    ${pod_name}    ${container}    ${namespace}
+    BuiltIn.Log_Many    ${ssh_session}    ${pod_name}    ${container}    ${namespace}    ${compress}
     ${nsparam} =     BuiltIn.Set_Variable_If    """${namespace}""" != """${EMPTY}"""    --namespace ${namespace}    ${EMPTY}
     ${cntparam} =    BuiltIn.Set_Variable_If    """${container}""" != """${EMPTY}"""    ${container}    ${EMPTY}
-    SshCommons.Switch_Execute_And_Log_To_File    ${ssh_session}    kubectl logs ${nsparam} ${pod_name} ${cntparam}
+    SshCommons.Switch_Execute_And_Log_To_File    ${ssh_session}    kubectl logs ${nsparam} ${pod_name} ${cntparam}    compress=${compress}
 
 Describe_Pod
     [Arguments]    ${ssh_session}    ${pod_name}

--- a/tests/robot/libraries/SshCommons.robot
+++ b/tests/robot/libraries/SshCommons.robot
@@ -33,11 +33,11 @@ Execute_Command_With_Copied_File
     BuiltIn.Run_Keyword_And_Return    Execute_Command_And_Log    ${command_prefix} @{splitted_path}[-1]    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}
 
 Switch_Execute_And_Log_To_File
-    [Arguments]    ${ssh_session}    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}
+    [Arguments]    ${ssh_session}    ${command}    ${expected_rc}=0    ${ignore_stderr}=${False}    ${ignore_rc}=${False}    ${compress}=${False}
     [Documentation]    Call Switch_And_Execute_Command redirecting stdout to a remote file, download the file.
     ...    To distinguish separate invocations, suite name, test name, session alias
     ...    and full command are used to construct file name.
-    BuiltIn.Log_Many    ${ssh_session}    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}
+    BuiltIn.Log_Many    ${ssh_session}    ${command}    ${expected_rc}    ${ignore_stderr}    ${ignore_rc}    ${compress}
     SSHLibrary.Switch_Connection    ${ssh_session}
     ${connection} =    SSHLibrary.Get_Connection
     # In teardown, ${TEST_NAME} does not exist.
@@ -45,7 +45,9 @@ Switch_Execute_And_Log_To_File
     ${filename_with_spaces} =    BuiltIn.Set_Variable    ${testname}__${SUITE_NAME}__${connection.alias}__${command}.log
     ${filename} =    String.Replace_String    ${filename_with_spaces}    ${SPACE}    _
     BuiltIn.Log    ${filename}
-    Switch_And_Execute_Command    ${ssh_session}    ${command} > ${filename}    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}
+    Execute_Command_And_Log    ${command} > ${filename}    expected_rc=${expected_rc}    ignore_stderr=${ignore_stderr}    ignore_rc=${ignore_rc}
+    BuiltIn.Run_Keyword_If    ${compress}    Execute_Command_And_Log    xz -9e ${filename}
+    ${filename} =    Builtin.Set_Variable_If    ${compress}    ${filename}.xz    ${filename}
     SSHLibrary.Get_File    ${filename}    ${RESULTS_FOLDER}/${filename}
     [Teardown]    Execute_Command_And_Log    rm ${filename}
 


### PR DESCRIPTION
KubeCtl.Logs and SshCommons.Switch_Execute_And_Log_To_File
now have compress argument, default true and false respectively.

Signed-off-by: Vratko Polak <vrpolak@cisco.com>