### PR TITLE
Do not python-parse output strings

### DIFF
--- a/tests/robot/libraries/SshCommons.robot
+++ b/tests/robot/libraries/SshCommons.robot
@@ -90,7 +90,9 @@ Append_Command_Log
     Builtin.Log_Many    ${command}    ${output}    ${stderr}    ${rc}
     ${connection} =    SSHLibrary.Get_Connection
     ${time} =    DateTime.Get_Current_Date
-    ${if_output} =    BuiltIn.Set_Variable_If    """${output}"""    ${output}${\n}    ${EMPTY}
-    ${if_stderr} =    BuiltIn.Set_Variable_If    """${stderr}"""    *** Stderr: ${stderr}${\n}    ${EMPTY}
+    ${output_length} =    BuiltIn.Get_Length    ${output}
+    ${if_output} =    BuiltIn.Set_Variable_If    ${output_length}    ${output}${\n}    ${EMPTY}
+    ${stderr_length} =    Builtin.Get_Length    ${stderr}
+    ${if_stderr} =    BuiltIn.Set_Variable_If    ${stderr_length}    *** Stderr: ${stderr}${\n}    ${EMPTY}
     ${if_rc} =    BuiltIn.Set_Variable_If    """${rc}"""    *** Return code: ${rc}${\n}    ${EMPTY}
     OperatingSystem.Append_To_File    ${RESULTS_FOLDER}/output_${connection.alias}.log    ${time}${\n}*** Command: ${command}${\n}${if_stderr}${if_rc}${if_output}


### PR DESCRIPTION
Long strings can contain quotes which may throw the parsing off.
Test string length instead.

Signed-off-by: Vratko Polak <vrpolak@cisco.com>