### PR TITLE
Issue #354: Delete forcefully in push-all.sh cleanup

### DIFF
--- a/docker/push-all.sh
+++ b/docker/push-all.sh
@@ -152,5 +152,5 @@ fi
 
 if [ "${CLEANUP}" == "true" ]
 then
-    sudo docker images | fgrep "${TAG}" | awk '{print $3}' | uniq | xargs sudo docker rmi || true
+    sudo docker images | fgrep "${TAG}" | awk '{print $3}' | sort -u | xargs sudo docker rmi -f || true
 fi


### PR DESCRIPTION
Also, use "sort -u" instead of "uniq",
just to be sure non-contiguous duplicates are eliminated as well.

Signed-off-by: Vratko Polak <vrpolak@cisco.com>