### PR TITLE
Allow overriding vagrant vars without editing scripts

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -8,10 +8,12 @@ It is organized into two subfolders:
  - (config) - contains the files needed to share cluster information, used during the provisioning stage (master IP address, Certificates, hash-keys). Editing is not recommended!
  - (vagrant-scripts) - contains scripts for creating, destroying, rebooting and shuting down the VMs that host the K8s cluster.
 
-To define the cluster's size edit the value K8S_NODES found in vagrant-scripts/vagrant-up.sh script:
+If you wish to change the default number of nodes, set K8S_NODES before running vagrant-up.sh:
 ```
-export K8S_NODES=0, for a single-node setup
-export K8S_NODES=1, for a two-node setup
+# For a single node setup:
+export K8S_NODES=0
+# For a two node setup:
+export K8S_NODES=1
 ```
 
 To create and run the cluster run vagrant-up.sh script, located inside vagrant-scripts folder:

--- a/vagrant/vagrant-scripts/vagrant-cleanup.sh
+++ b/vagrant/vagrant-scripts/vagrant-cleanup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -euo pipefail
 
 if [ -f ../config/init.sh ] ; then
     rm ../config/init.sh

--- a/vagrant/vagrant-scripts/vagrant-reload.sh
+++ b/vagrant/vagrant-scripts/vagrant-reload.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -euo pipefail
+
 vagrant reload

--- a/vagrant/vagrant-scripts/vagrant-shutdown.sh
+++ b/vagrant/vagrant-scripts/vagrant-shutdown.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -euo pipefail
+
 vagrant halt

--- a/vagrant/vagrant-scripts/vagrant-up.sh
+++ b/vagrant/vagrant-scripts/vagrant-up.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-export K8S_NODE_OS=ubuntu
-export K8S_NODES=1
-export VAGRANT_DEFAULT_PROVIDER=virtualbox
+set -euo pipefail
+
+export K8S_NODE_OS=${K8S_NODE_OS:-ubuntu}
+export K8S_NODES=${K8S_NODES:-1}
+export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-virtualbox}
 
 vagrant up 


### PR DESCRIPTION
Changing runtime variable shouldn't require editing scripts that are
under revision control.

Additionally, bash scripts should have error exit and pipefail turned
on by default, so unexpected errors stop the script.