### PR TITLE
Policy Cache & Policy Processor fixes for #566

### DIFF
--- a/plugins/policy/cache/cache_api.go
+++ b/plugins/policy/cache/cache_api.go
@@ -52,11 +52,11 @@ type PolicyCacheAPI interface {
 	LookupPod(pod podmodel.ID) (found bool, data *podmodel.Pod)
 
 	// LookupPodsByLabelSelector evaluates label selector (expression and/or match
-	// labels) and returns IDs of matching pods.
+	// labels) and returns IDs of matching pods in a namespace.
 	LookupPodsByLabelSelector(podLabelSelector *policymodel.Policy_LabelSelector) (pods []podmodel.ID)
 
 	// LookupPodsByNSLabelSelector evaluates label selector (expression and/or match
-	// labels and returns IDs of matching pods in a namespace.
+	// labels and returns IDs of matching pods.
 	LookupPodsByNSLabelSelector(policyNamespace string, podLabelSelector *policymodel.Policy_LabelSelector) (pods []podmodel.ID)
 
 	// LookupPodsByNamespace returns IDs of all pods inside a given namespace.

--- a/plugins/policy/cache/cache_impl.go
+++ b/plugins/policy/cache/cache_impl.go
@@ -104,34 +104,11 @@ func (pc *PolicyCache) LookupPodsByNSLabelSelector(policyNamespace string,
 	matchLabels := podLabelSelector.MatchLabel
 	matchExpressions := podLabelSelector.MatchExpression
 
-	if len(matchLabels) > 0 && len(matchExpressions) == 0 {
-		pods := pc.getPodsByNSLabelSelector(policyNamespace, matchLabels)
-		return utils.UnstringPodID(pods)
+	mlPods := pc.getPodsByNSLabelSelector(policyNamespace, matchLabels)
+	mePods := pc.getMatchExpressionPods(policyNamespace, matchExpressions)
 
-	} else if len(matchLabels) == 0 && len(matchExpressions) > 0 {
-		pods := pc.getMatchExpressionPods(policyNamespace, matchExpressions)
-		return utils.UnstringPodID(pods)
+	return utils.UnstringPodID(utils.Intersect(mlPods, mePods))
 
-	} else if len(matchLabels) > 0 && len(matchExpressions) > 0 {
-		mlPods := pc.getPodsByNSLabelSelector(policyNamespace, matchLabels)
-		if len(mlPods) == 0 {
-			return []podmodel.ID{}
-		}
-
-		mePods := pc.getMatchExpressionPods(policyNamespace, matchExpressions)
-		if len(mePods) == 0 {
-			return []podmodel.ID{}
-		}
-
-		pods := utils.Intersect(mlPods, mePods)
-		if len(pods) == 0 {
-			return []podmodel.ID{}
-		}
-
-		return utils.UnstringPodID(pods)
-	}
-
-	return []podmodel.ID{}
 }
 
 // LookupPodsByLabelSelector evaluates label selector (expression and/or match

--- a/plugins/policy/cache/cache_impl.go
+++ b/plugins/policy/cache/cache_impl.go
@@ -105,39 +105,33 @@ func (pc *PolicyCache) LookupPodsByNSLabelSelector(policyNamespace string,
 	matchExpressions := podLabelSelector.MatchExpression
 
 	if len(matchLabels) > 0 && len(matchExpressions) == 0 {
-		found, pods := pc.getPodsByNSLabelSelector(policyNamespace, matchLabels)
-		if !found {
-			return []podmodel.ID{}
-		}
+		pods := pc.getPodsByNSLabelSelector(policyNamespace, matchLabels)
 		return utils.UnstringPodID(pods)
 
 	} else if len(matchLabels) == 0 && len(matchExpressions) > 0 {
-		found, pods := pc.getMatchExpressionPods(policyNamespace, matchExpressions)
-		if !found {
-			return []podmodel.ID{}
-		}
+		pods := pc.getMatchExpressionPods(policyNamespace, matchExpressions)
 		return utils.UnstringPodID(pods)
 
 	} else if len(matchLabels) > 0 && len(matchExpressions) > 0 {
-		foundMlPods, mlPods := pc.getPodsByNSLabelSelector(policyNamespace, matchLabels)
-		if !foundMlPods {
+		mlPods := pc.getPodsByNSLabelSelector(policyNamespace, matchLabels)
+		if len(mlPods) == 0 {
 			return []podmodel.ID{}
 		}
 
-		foundMePods, mePods := pc.getMatchExpressionPods(policyNamespace, matchExpressions)
-		if !foundMePods {
+		mePods := pc.getMatchExpressionPods(policyNamespace, matchExpressions)
+		if len(mePods) == 0 {
 			return []podmodel.ID{}
 		}
 
 		pods := utils.Intersect(mlPods, mePods)
-		if pods == nil {
-			return nil
+		if len(pods) == 0 {
+			return []podmodel.ID{}
 		}
 
 		return utils.UnstringPodID(pods)
 	}
 
-	return nil
+	return []podmodel.ID{}
 }
 
 // LookupPodsByLabelSelector evaluates label selector (expression and/or match
@@ -154,13 +148,11 @@ func (pc *PolicyCache) LookupPodsByLabelSelector(
 			Infof("Empty namespace selector returning pods: %+v", pods)
 		return utils.UnstringPodID(pods)
 	}
-	pc.Log.WithField("LookupPodsByNSLabelSelector", namespaceLabelSelector).
-		Debugf("Namespace Label Selector is: %+v", namespaceLabelSelector)
 	// List of match labels and match expressions.
 	matchLabels := namespaceLabelSelector.MatchLabel
 
-	found, namespaceSelectorPods := pc.getPodsByLabelSelector(matchLabels)
-	if !found {
+	namespaceSelectorPods := pc.getPodsByLabelSelector(matchLabels)
+	if len(namespaceSelectorPods) == 0 {
 		return []podmodel.ID{}
 	}
 	return utils.UnstringPodID(namespaceSelectorPods)

--- a/plugins/policy/cache/match_expression.go
+++ b/plugins/policy/cache/match_expression.go
@@ -29,26 +29,26 @@ const (
 )
 
 // getMatchExpressionPods returns all the pods that match a collection of expressions (expressions are ANDed)
-func (pc *PolicyCache) getMatchExpressionPods(namespace string, expressions []*policymodel.Policy_LabelSelector_LabelExpression) (bool, []string) {
+func (pc *PolicyCache) getMatchExpressionPods(namespace string, expressions []*policymodel.Policy_LabelSelector_LabelExpression) []string {
 	var inPodSet, notInPodSet, existsPodSet, notExistPodSet []string
 	for _, expression := range expressions {
 		switch expression.Operator {
 		case in:
 			labels := utils.ConstructLabels(expression.Key, expression.Value)
-			isMatch, podSet := pc.getPodsByNSLabelSelector(namespace, labels)
-			if !isMatch {
-				return false, nil
+			podSet := pc.getPodsByNSLabelSelector(namespace, labels)
+			if len(podSet) == 0 {
+				return []string{}
 			}
 
 			inPodSet = append(inPodSet, podSet...)
 
 		case notIn:
 			labels := utils.ConstructLabels(expression.Key, expression.Value)
-			isMatch, podSet := pc.getPodsByNSLabelSelector(namespace, labels)
-			if !isMatch {
+			podSet := pc.getPodsByNSLabelSelector(namespace, labels)
+			if len(podSet) == 0 {
 				podNamespaceAll := pc.configuredPods.LookupPodsByNamespace(namespace)
-				if podNamespaceAll == nil {
-					return false, nil
+				if len(podNamespaceAll) == 0 {
+					return []string{}
 				}
 				notInPodSet = append(notInPodSet, podNamespaceAll...)
 				break
@@ -57,24 +57,24 @@ func (pc *PolicyCache) getMatchExpressionPods(namespace string, expressions []*p
 			podNamespaceAll := pc.configuredPods.LookupPodsByNamespace(namespace)
 			pods := utils.Difference(podNamespaceAll, podSet)
 			notInPodSet = append(notInPodSet, pods...)
-			if notInPodSet == nil {
-				return false, nil
+			if len(notInPodSet) == 0 {
+				return []string{}
 			}
 
 		case exists:
 			podSet := pc.configuredPods.LookupPodsByNSKey(namespace + "/" + expression.Key)
-			if podSet == nil {
-				return false, nil
+			if len(podSet) == 0 {
+				return []string{}
 			}
 
 			existsPodSet = append(existsPodSet, podSet...)
 
 		case doesNotExist:
 			podSet := pc.configuredPods.LookupPodsByNSKey(namespace + "/" + expression.Key)
-			if podSet == nil {
+			if len(podSet) == 0 {
 				podNamespaceAll := pc.configuredPods.LookupPodsByNamespace(namespace)
-				if podNamespaceAll == nil {
-					return false, nil
+				if len(podNamespaceAll) == 0 {
+					return []string{}
 				}
 
 				notExistPodSet = append(notExistPodSet, podNamespaceAll...)
@@ -84,8 +84,8 @@ func (pc *PolicyCache) getMatchExpressionPods(namespace string, expressions []*p
 			podNamespaceAll := pc.configuredPods.LookupPodsByNamespace(namespace)
 			pods := utils.Difference(podNamespaceAll, podSet)
 			notExistPodSet = append(notExistPodSet, pods...)
-			if notExistPodSet == nil {
-				return false, nil
+			if len(notExistPodSet) == 0 {
+				return []string{}
 			}
 
 		}
@@ -97,17 +97,14 @@ func (pc *PolicyCache) getMatchExpressionPods(namespace string, expressions []*p
 	notExistPodSet = utils.RemoveDuplicates(inPodSet)
 
 	inMatcher := utils.Intersect(inPodSet, notInPodSet)
-	if inMatcher == nil {
-		return false, nil
+	if len(inMatcher) == 0 {
+		return []string{}
 	}
 	existsMatcher := utils.Intersect(existsPodSet, notExistPodSet)
-	if existsMatcher == nil {
-		return false, nil
+	if len(existsMatcher) == 0 {
+		return []string{}
 	}
 
 	pods := utils.Intersect(inMatcher, existsMatcher)
-	if pods == nil {
-		return false, nil
-	}
-	return true, pods
+	return pods
 }

--- a/plugins/policy/cache/match_expression.go
+++ b/plugins/policy/cache/match_expression.go
@@ -31,6 +31,11 @@ const (
 // getMatchExpressionPods returns all the pods that match a collection of expressions (expressions are ANDed)
 func (pc *PolicyCache) getMatchExpressionPods(namespace string, expressions []*policymodel.Policy_LabelSelector_LabelExpression) []string {
 	var inPodSet, notInPodSet, existsPodSet, notExistPodSet []string
+	// Check if we have empty expressions
+	if len(expressions) == 0 {
+		return []string{}
+	}
+
 	for _, expression := range expressions {
 		switch expression.Operator {
 		case in:
@@ -90,21 +95,7 @@ func (pc *PolicyCache) getMatchExpressionPods(namespace string, expressions []*p
 
 		}
 	}
-	// Remove duplicates from slices
-	inPodSet = utils.RemoveDuplicates(inPodSet)
-	notInPodSet = utils.RemoveDuplicates(inPodSet)
-	existsPodSet = utils.RemoveDuplicates(inPodSet)
-	notExistPodSet = utils.RemoveDuplicates(inPodSet)
 
-	inMatcher := utils.Intersect(inPodSet, notInPodSet)
-	if len(inMatcher) == 0 {
-		return []string{}
-	}
-	existsMatcher := utils.Intersect(existsPodSet, notExistPodSet)
-	if len(existsMatcher) == 0 {
-		return []string{}
-	}
+	return utils.Intersect(inPodSet, notInPodSet, existsPodSet, notExistPodSet)
 
-	pods := utils.Intersect(inMatcher, existsMatcher)
-	return pods
 }

--- a/plugins/policy/cache/match_label.go
+++ b/plugins/policy/cache/match_label.go
@@ -23,6 +23,10 @@ import (
 
 // getPodsByNSLabelSelector returns the pods that match a collection of Label Selectors in the same namespace
 func (pc *PolicyCache) getPodsByNSLabelSelector(namespace string, labels []*policymodel.Policy_Label) []string {
+	// Check if we have empty labels
+	if len(labels) == 0 {
+		return []string{}
+	}
 	prevNSLabelSelector := namespace + "/" + labels[0].Key + "/" + labels[0].Value
 	prevPodSet := pc.configuredPods.LookupPodsByNSLabelSelector(prevNSLabelSelector)
 	current := prevPodSet
@@ -33,7 +37,7 @@ func (pc *PolicyCache) getPodsByNSLabelSelector(namespace string, labels []*poli
 		newPodSet := pc.configuredPods.LookupPodsByNSLabelSelector(newNSLabelSelector)
 		current := utils.Intersect(prevPodSet, newPodSet)
 		if len(current) == 0 {
-			return []string{}
+			break
 		}
 	}
 
@@ -42,6 +46,10 @@ func (pc *PolicyCache) getPodsByNSLabelSelector(namespace string, labels []*poli
 
 // getPodsByLabelSelector returns the pods that match a collection of Label Selectors
 func (pc *PolicyCache) getPodsByLabelSelector(labels []*policymodel.Policy_Label) []string {
+	// Check if we have empty labels
+	if len(labels) == 0 {
+		return []string{}
+	}
 	pods := []string{}
 	prevNSLabelSelector := labels[0].Key + "/" + labels[0].Value
 	prevNamespaceSet := pc.configuredNamespaces.LookupNamespacesByLabelSelector(prevNSLabelSelector)
@@ -53,7 +61,7 @@ func (pc *PolicyCache) getPodsByLabelSelector(labels []*policymodel.Policy_Label
 		newNamespaceSet := pc.configuredNamespaces.LookupNamespacesByLabelSelector(newNSLabelSelector)
 		current = utils.Intersect(prevNamespaceSet, newNamespaceSet)
 		if len(current) == 0 {
-			return []string{}
+			break
 		}
 	}
 	for _, namespace := range current {

--- a/plugins/policy/processor/processor.go
+++ b/plugins/policy/processor/processor.go
@@ -198,7 +198,7 @@ func (pp *PolicyProcessor) DelPod(pod *podmodel.Pod) error {
 					}
 
 					isMatchNamespaceSelector := pp.isNamespaceMatchLabel(pod, matchLabels)
-					if !isMatchPodSelector && isMatchNamespaceSelector {
+					if !isMatchPodSelector && !isMatchNamespaceSelector {
 						continue
 					}
 
@@ -231,7 +231,7 @@ func (pp *PolicyProcessor) DelPod(pod *podmodel.Pod) error {
 					}
 
 					isMatchNamespaceSelector := pp.isNamespaceMatchLabel(pod, matchLabels)
-					if !isMatchPodSelector && isMatchNamespaceSelector {
+					if !isMatchPodSelector && !isMatchNamespaceSelector {
 						continue
 					}
 
@@ -352,7 +352,7 @@ func (pp *PolicyProcessor) UpdatePod(oldPod, newPod *podmodel.Pod) error {
 					}
 
 					isMatchNamespaceSelector := pp.isNamespaceMatchLabel(oldPod, matchLabels)
-					if !isMatchPodSelector && isMatchNamespaceSelector {
+					if !isMatchPodSelector && !isMatchNamespaceSelector {
 						continue
 					}
 
@@ -385,7 +385,7 @@ func (pp *PolicyProcessor) UpdatePod(oldPod, newPod *podmodel.Pod) error {
 					}
 
 					isMatchNamespaceSelector := pp.isNamespaceMatchLabel(oldPod, matchLabels)
-					if !isMatchPodSelector && isMatchNamespaceSelector {
+					if !isMatchPodSelector && !isMatchNamespaceSelector {
 						continue
 					}
 
@@ -424,7 +424,7 @@ func (pp *PolicyProcessor) UpdatePod(oldPod, newPod *podmodel.Pod) error {
 					}
 
 					isMatchNamespaceSelector := pp.isNamespaceMatchLabel(newPod, matchLabels)
-					if !isMatchPodSelector && isMatchNamespaceSelector {
+					if !isMatchPodSelector && !isMatchNamespaceSelector {
 						continue
 					}
 
@@ -457,7 +457,7 @@ func (pp *PolicyProcessor) UpdatePod(oldPod, newPod *podmodel.Pod) error {
 					}
 
 					isMatchNamespaceSelector := pp.isNamespaceMatchLabel(newPod, matchLabels)
-					if !isMatchPodSelector && isMatchNamespaceSelector {
+					if !isMatchPodSelector && !isMatchNamespaceSelector {
 						continue
 					}
 

--- a/plugins/policy/processor/rules_match_expression.go
+++ b/plugins/policy/processor/rules_match_expression.go
@@ -29,7 +29,7 @@ const (
 	doesNotExist = policymodel.Policy_LabelSelector_LabelExpression_DOES_NOT_EXIST
 )
 
-// isMatchExpression returns all the pods that match a collection of expressions (expressions are ANDed)
+// isMatchExpression returns true/false if pod labels match a collection of pod selector expressions (expressions are ANDed).
 func (pp *PolicyProcessor) isMatchExpression(pod *podmodel.Pod,
 	expressions []*policymodel.Policy_LabelSelector_LabelExpression, policyNamespace string) bool {
 

--- a/plugins/policy/processor/rules_match_label.go
+++ b/plugins/policy/processor/rules_match_label.go
@@ -21,6 +21,7 @@ import (
 	policymodel "github.com/contiv/vpp/plugins/ksr/model/policy"
 )
 
+// isMatchLabel returns true/false if pod labels match a collection of pod selector labels (labels are ANDed).
 func (pp *PolicyProcessor) isMatchLabel(pod *podmodel.Pod, matchLabels []*policymodel.Policy_Label, policyNamespace string) bool {
 	namespace := pod.Namespace
 	podLabels := pod.Label
@@ -44,6 +45,7 @@ func (pp *PolicyProcessor) isMatchLabel(pod *podmodel.Pod, matchLabels []*policy
 
 }
 
+// isNamespaceMatchLabel returns true/false if pod namespace matches a collection of namespace selector labels (labels are ANDed).
 func (pp *PolicyProcessor) isNamespaceMatchLabel(pod *podmodel.Pod, matchLabels []*policymodel.Policy_Label) bool {
 
 	podNamespace := pod.Namespace
@@ -54,13 +56,14 @@ func (pp *PolicyProcessor) isNamespaceMatchLabel(pod *podmodel.Pod, matchLabels 
 		// Get all namespaces that match namespace label selector
 		namespaces := pp.Cache.LookupNamespacesByLabelSelector(label)
 		if len(namespaces) == 0 {
-			return isMatch
+			return false
 		}
 		namespaceExists := false
 		// Check if matched namespaces include pod's namespace
 		for _, namespace := range namespaces {
 			if namespace == podNamespace {
 				namespaceExists = true
+				break
 			}
 		}
 		// Namespaces are AND'ed, if one is not a match then exit

--- a/plugins/policy/utils/utils.go
+++ b/plugins/policy/utils/utils.go
@@ -41,8 +41,7 @@ func RemoveDuplicates(el []string) []string {
 	return result
 }
 
-// Intersect returns the common elements of or more slices
-// Intersect needs at least two lists
+// Intersect returns the common elements of two or more slices
 func Intersect(a []string, b []string, s ...[]string) []string {
 	if len(a) == 0 || len(b) == 0 {
 		return []string{}

--- a/plugins/policy/utils/utils.go
+++ b/plugins/policy/utils/utils.go
@@ -41,21 +41,26 @@ func RemoveDuplicates(el []string) []string {
 	return result
 }
 
-// Intersect returns the common elements of two slices
-func Intersect(a []string, b []string) []string {
+// Intersect returns the common elements of or more slices
+// Intersect needs at least two lists
+func Intersect(a []string, b []string, s ...[]string) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return []string{}
+	}
 	set := make([]string, 0)
 	hash := make(map[string]bool)
-
 	for _, el := range a {
 		hash[el] = true
 	}
-
 	for _, el := range b {
 		if _, found := hash[el]; found {
 			set = append(set, el)
 		}
 	}
-	return set
+	if len(s) == 0 {
+		return set
+	}
+	return Intersect(set, s[0], s[1:]...)
 }
 
 // Difference returns the difference of two slices


### PR DESCRIPTION
This PR addresses comment suggestions of #566.

 - Refactor code for match_expression and match_label go files to return only []string
    instead of (bool, []string)

 - Simplified getPodsByNSLabelSelector & getPodsByLabelSelector in match_label.go to be
   easily readable

 - Added missing comments for function description and more robust comments in code

 - Fixed two bugs in processor.go (missing "!" and worng function call)