### PR TITLE
Create deep copy of BD config

### DIFF
--- a/plugins/contiv/node_events.go
+++ b/plugins/contiv/node_events.go
@@ -22,7 +22,9 @@ import (
 	"net"
 
 	"github.com/contiv/vpp/plugins/contiv/model/node"
+	"github.com/golang/protobuf/proto"
 	"github.com/ligato/cn-infra/datasync"
+	vpp_l2 "github.com/ligato/vpp-agent/plugins/defaultplugins/common/model/l2"
 	vpp_l3 "github.com/ligato/vpp-agent/plugins/defaultplugins/common/model/l3"
 )
 
@@ -145,7 +147,10 @@ func (s *remoteCNIserver) addRoutesToNode(nodeInfo *node.NodeInfo) error {
 
 		// add the VXLAN interface into the VXLAN bridge domain
 		s.addInterfaceToVxlanBD(s.vxlanBD, vxlanIf.Name)
-		txn.BD(s.vxlanBD)
+
+		// pass deep copy to local client since we are overwriting previously applied config
+		bd := proto.Clone(s.vxlanBD)
+		txn.BD(bd.(*vpp_l2.BridgeDomains_BridgeDomain))
 	}
 
 	// static routes

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -503,7 +503,9 @@ func (s *remoteCNIserver) configureVswitchVxlanBridgeDomain(config *vswitchConfi
 
 	// bridge domain for the VXLAN tunnel
 	config.vxlanBD = s.vxlanBridgeDomain(config.vxlanBVI.Name)
-	txn.BD(config.vxlanBD)
+	// create deep copy since the config will be overwritten when a node joins the cluster
+	newbd := proto.Clone(config.vxlanBD)
+	txn.BD(newbd.(*vpp_l2.BridgeDomains_BridgeDomain))
 	// remember the VXLAN config - needs to be reconfigured with each new VXLAN (each new node)
 	s.vxlanBD = config.vxlanBD
 


### PR DESCRIPTION
The PR fixes the issue of accessing pods deployed on a different node if the vxlans are used. Vxlan was not added to bridge domain.

The configuration of bridge domain where vxlan tunels are terminated is stored in the remote cni server. When a new node joins the cluster the config is updated and passed to local client. Unfortunately, (due to performance) local client does not create a copy of the configuration. Thus, before this fix we were effectively overwriting prev value of the change event generated by local client, i.e prevValue and new value were identical. Despite, the overwriting everything used to work as expected because BD was recreated upon each modification. Latest vpp-agent modifies BD only if neccessery (i.e. if there is a change which was the case because of overwrite).

Solution implemeted in the PR is to pass a deep copy to local client in order to avoid overwriting the prev value.


