### PR TITLE
Vagrantfile: make a few small changes & fixes

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -64,17 +64,16 @@ export https_proxy='#{https_proxy}'
 EOF
 
 source /etc/profile.d/envvar.sh
-echo "Updating Ubuntu..."
+echo "Updating apt lists..."
 apt-get update
 
-echo "Install os requirements"
+echo "Installing dependency packages..."
 apt-get install -y apt-transport-https \
-                   apt-transport-https \
                    ca-certificates \
                    curl \
                    software-properties-common
                    
-echo "Add Kubernetes & Docker repo..."
+echo "Adding Kubernetes & Docker repos..."
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
@@ -82,7 +81,7 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
 EOF
 
-echo "Updating Ubuntu..."
+echo "Updating apt lists..."
 apt-get update
 
 echo "Installing Docker-CE..."
@@ -96,9 +95,9 @@ systemctl start docker
 
 echo "Installing Kubernetes Components..."
 apt-get install -y kubelet kubectl kubeadm kubernetes-cni
-
-echo "Downloading Go..."
-curl --silent https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz > /tmp/go.tar.gz
+export GO_VERSION=1.9.3
+echo "Downloading Go $GO_VERSION..."
+curl --silent https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz > /tmp/go.tar.gz
 
 echo "Extracting Go..."
 tar -xvzf /tmp/go.tar.gz --directory /home/vagrant >/dev/null 2>&1
@@ -234,6 +233,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     config.vm.provider 'virtualbox' do |v|
         v.linked_clone = true if Vagrant::VERSION >= "1.8"
+        v.customize ['modifyvm', :id, '--paravirtprovider', 'kvm']
     end
 
     node_ips = num_nodes.times.collect { |n| base_ip + "#{n+10}" }
@@ -241,6 +241,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.ssh.insert_key = false
     node_names = num_nodes.times.collect { |n| "k8s-worker#{n+1}" }
+
+    if Vagrant.has_plugin?("vagrant-cachier")
+        config.cache.scope = :box
+        config.cache.enable :apt
+    end
     
     # Configure Master node
     config.vm.define "k8s-master" do |k8smaster|


### PR DESCRIPTION
This PR makes the following changes:
- changes some messages to say exactly what's being done
- adds support for vagrant-cachier
- enables kvm paravirt
- bumps Go to 1.9.3

The recently released Go 1.9.4 isn't used because it might break some packages which rely on CGO.