### PR TITLE
k8s/contiv-vpp.yaml: switch to vpp-cni & vpp-ksr

### DIFF
--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -270,7 +270,7 @@ spec:
         # This container installs the Contiv CNI binaries
         # and CNI network config file on each node.
         - name: contiv-cni
-          image: contivvpp/cni
+          image: contiv/vpp-cni
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /opt/cni/bin
@@ -348,7 +348,7 @@ spec:
 
       containers:
         - name: contiv-ksr
-          image: contivvpp/ksr
+          image: contiv/vpp-ksr
           imagePullPolicy: IfNotPresent
           env:
             - name: ETCDV3_CONFIG


### PR DESCRIPTION
This PR switches the deployment to the newly added Docker images.