### PR TITLE
Fixes for comments on PR #581

### DIFF
--- a/plugins/policy/processor/processor.go
+++ b/plugins/policy/processor/processor.go
@@ -551,9 +551,9 @@ func (pp *PolicyProcessor) getPoliciesAssignedToNamespace(ns *nsmodel.Namespace)
 							if labelsMap[label.Key] != label.Value {
 								break
 							}
+							policies[dataPolicyID] = dataPolicy
 						}
 					}
-					policies[dataPolicyID] = dataPolicy
 				}
 			}
 		}
@@ -571,9 +571,9 @@ func (pp *PolicyProcessor) getPoliciesAssignedToNamespace(ns *nsmodel.Namespace)
 							if labelsMap[label.Key] != label.Value {
 								break
 							}
+							policies[dataPolicyID] = dataPolicy
 						}
 					}
-					policies[dataPolicyID] = dataPolicy
 				}
 			}
 		}


### PR DESCRIPTION
- Moved policies[dataPolicyID] = dataPolicy inside the for loop. Loop breaks if one of the namespace labels doesn't match policy namespace label selectors.