### PR TITLE
DHCP enhancements

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -54,12 +54,12 @@ To use the development image for testing with specific version of VPP, see
 
   * Node configuration (section `NodeConfig`; one entry for each node)
     - `NodeName`: name of a Kubernetes node;
-    - `UseDhcpOnMainInt`: acquire IP address for the main VPP interface using DHCP 
-        (beware: the change of IP address is not supported)
     - `MainVppInterface`: name of the interface to be used for node-to-node connectivity.
        IP address is allocated from `HostNodeSubnetCidr` defined in the IPAM section OR can be specified manually:
       - `InterfaceName`: name of the main interface;
       - `IP`: IP address to be attached to the main interface;
+      - `UseDHCP`: acquire IP address using DHCP
+              (beware: the change of IP address is not supported)
     - `OtherVPPInterfaces` (other configured interfaces only get IP address assigned in VPP)
       - `InterfaceName`: name of the interface;
       - `IP`: IP address to be attached to the interface;

--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -31,10 +31,10 @@ data:
       NodeInterconnectCIDR: "192.168.16.0/24"
       VxlanCIDR: "192.168.30.0/24"
 #      ServiceCIDR: "10.96.0.0/12"
+#      NodeInterconnectDHCP: True
 ### example of node configuration for VPP interfaces
 #    NodeConfig:
 #    - NodeName: "vm1"
-#      UseDhcpOnMainInt: False
 #      MainVppInterface:
 #        InterfaceName: "GigabitEthernet0/4/0"
 #        IP: 192.168.16.101/24
@@ -48,7 +48,7 @@ data:
 #      UseDhcpOnMainInt: False
 #      MainVppInterface:
 #        InterfaceName: "GigabitEthernet0/9/0"
-#        IP: 192.168.16.101/24
+#        UseDHCP: True
 #      Gateway: 192.168.1.1
 #      OtherVPPInterfaces:
 #      - InterfaceName: "GigabitEthernet0/7/0"

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -95,13 +95,13 @@ type OneNodeConfig struct {
 	MainVppInterface   InterfaceWithIP   // main VPP interface used for the inter-node connectivity
 	OtherVPPInterfaces []InterfaceWithIP // other interfaces on VPP, not necessarily used for inter-node connectivity
 	Gateway            string            // IP address of the default gateway
-	UseDhcpOnMainInt   bool              // request IP address for main VPP interface using DHCP
 }
 
 // InterfaceWithIP binds interface name with IP address for configuration purposes.
 type InterfaceWithIP struct {
 	InterfaceName string
 	IP            string
+	UseDHCP       bool
 }
 
 // Init initializes the Contiv plugin. Called automatically by plugin infra upon contiv-agent startup.

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -309,12 +309,13 @@ func (s *remoteCNIserver) configureVswitchNICs(config *vswitchConfig) error {
 	// find name of the main VPP NIC interface
 	nicName := ""
 	useDHCP := false
-	if s.nodeConfig != nil && strings.Trim(s.nodeConfig.MainVppInterface.InterfaceName, " ") != "" {
+	if s.nodeConfig != nil {
 		// use name as as specified in node config YAML
 		nicName = s.nodeConfig.MainVppInterface.InterfaceName
-		useDHCP = s.nodeConfig.UseDhcpOnMainInt
 		s.Logger.Debugf("Physical NIC name taken from nodeConfig: %v ", nicName)
-	} else {
+	}
+
+	if nicName == "" {
 		// name not specified in config, use heuristic - first non-virtual interface
 		for _, name := range s.swIfIndex.GetMapping().ListNames() {
 			if strings.HasPrefix(name, "local") || strings.HasPrefix(name, "loop") ||
@@ -331,6 +332,11 @@ func (s *remoteCNIserver) configureVswitchNICs(config *vswitchConfig) error {
 	nicIP := ""
 	if s.nodeConfig != nil && s.nodeConfig.MainVppInterface.IP != "" {
 		nicIP = s.nodeConfig.MainVppInterface.IP
+	} else if s.nodeConfig != nil && s.nodeConfig.MainVppInterface.UseDHCP {
+		useDHCP = true
+	} else if s.ipam.NodeInterconnectDHCPEnabled() {
+		// inherit DHCP from global setting
+		useDHCP = true
 	}
 
 	// configure the main VPP NIC interface
@@ -362,8 +368,10 @@ func (s *remoteCNIserver) configureMainVPPInterface(config *vswitchConfig, nicNa
 	// determine main node IP address
 	if useDHCP {
 		// ip address will be assigned by DHCP server, not known yet
+		s.Logger.Infof("Configuring %v to use dhcp", nicName)
 	} else if nicIP != "" {
 		s.setNodeIP(nicIP)
+		s.Logger.Infof("Configuring %v to use %v", nicName, nicIP)
 	} else {
 		nodeIP, err := s.ipam.NodeIPWithPrefix(s.ipam.NodeID())
 		if err != nil {
@@ -371,6 +379,7 @@ func (s *remoteCNIserver) configureMainVPPInterface(config *vswitchConfig, nicNa
 			return err
 		}
 		s.setNodeIP(nodeIP.String())
+		s.Logger.Infof("Configuring %v to use %v", nicName, nodeIP.String())
 	}
 
 	if nicName != "" {

--- a/plugins/contiv/remote_cni_server_test.go
+++ b/plugins/contiv/remote_cni_server_test.go
@@ -108,10 +108,10 @@ var (
 		},
 	}
 	nodeDHCPConfig = OneNodeConfig{
-		NodeName:         "test-node",
-		UseDhcpOnMainInt: true,
+		NodeName: "test-node",
 		MainVppInterface: InterfaceWithIP{
 			InterfaceName: "GigabitEthernet0/0/0/1",
+			UseDHCP:       true,
 		},
 		OtherVPPInterfaces: []InterfaceWithIP{
 			{


### PR DESCRIPTION
- added option that allows to enable dhcp for all nodes `NodeInterconnectDHCP` (where explicit IP is not specified), if it is set to true `NodeInterconnectCIDR` can be ommitted
- option `UseDhcpOnMainInt` was replaced by `UseDHCP` under MainVppInterface