### PR TITLE
Secure VPP debug access

### DIFF
--- a/docs/MANUAL_INSTALL.md
+++ b/docs/MANUAL_INSTALL.md
@@ -62,7 +62,7 @@ to contain the proper PCI address:
 ```
 unix {
     nodaemon
-    cli-listen 0.0.0.0:5002
+    cli-listen /run/vpp/cli.sock
     cli-no-pager
 }
 dpdk {
@@ -174,7 +174,7 @@ argument to kubeadm init.
 Verify that the VPP successfully grabbed the network interface specified in
 the VPP startup config (`GigabitEthernet0/4/0` in our case):
 ```
-$ telnet 0 5002
+$ sudo nc -U /run/vpp/cli.sock
 vpp# sh inter
               Name               Idx       State          Counter          Count
 GigabitEthernet0/4/0              1         up       rx packets                  1294
@@ -246,7 +246,7 @@ On each joined node, verify that the VPP successfully grabbed the network
 interface specified in the VPP startup config (`GigabitEthernet0/4/0` in
 our case):
 ```
-$ telnet 0 5002
+$ sudo nc -U /run/vpp/cli.sock
 vpp# sh inter
               Name               Idx       State          Counter          Count
 GigabitEthernet0/4/0              1         up
@@ -284,7 +284,7 @@ IP:		10.1.1.4
 You can check the pods' connectivity in one of the following ways:
 * Connect to the VPP debug CLI and ping any pod:
 ```
-  telnet 0 5002
+  sudo nc -U /run/vpp/cli.sock
   vpp# ping 10.1.1.3
 ```
 * Start busybox and ping any pod:

--- a/docs/MULTINODE.md
+++ b/docs/MULTINODE.md
@@ -47,7 +47,7 @@ to contain the proper PCI address:
 ```
 unix {
     nodaemon
-    cli-listen 0.0.0.0:5002
+    cli-listen /run/vpp/cli.sock
     cli-no-pager
 }
 dpdk {
@@ -96,7 +96,7 @@ $ kubectl get pods --all-namespaces
 On each node, verify that the VPP successfully grabbed the network interface specified 
 in the VPP startup config (`GigabitEthernet0/4/0` in our case):
 ```
-$ telnet 0 5002
+$ sudo nc -U /run/vpp/cli.sock
 vpp# sh inter
               Name               Idx       State          Counter          Count     
 GigabitEthernet0/4/0              1        down      

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -106,7 +106,7 @@ Device 'eth2' must be shutdown, do you want to proceed? [Y/n] y
 
 unix {
    nodaemon
-   cli-listen 0.0.0.0:5002
+   cli-listen /run/vpp/cli.sock
    cli-no-pager
 }
 dpdk {

--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -206,12 +206,19 @@ spec:
         - /bin/sh
         args:
         - -c
-        - "rm -rf /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api || true && \
-           rm -rf /vpp-lib64/* || true && \
-           cp -r $LD_PRELOAD_LIB_DIR/* /vpp-lib64/ && \
-           if [ ! -e /host/etc/vpp/contiv-vswitch.conf ]; then cp /etc/vpp/contiv-vswitch.conf /host/etc/vpp; fi && \
-           ip link del vpp1 || true"
-        imagePullPolicy: IfNotPresent
+        - |
+          set -euo pipefail
+          chmod 700 /run/vpp
+          rm -rf /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api /vpp-lib64/*
+          cp -r "$LD_PRELOAD_LIB_DIR"/* /vpp-lib64/
+          if [ ! -e /host/etc/vpp/contiv-vswitch.conf ]
+          then
+              cp /etc/vpp/contiv-vswitch.conf /host/etc/vpp/
+          fi
+          if ip link show vpp1 >/dev/null 2>&1
+          then
+               ip link del vpp1
+          fi
         resources: {}
         securityContext:
           privileged: true
@@ -222,6 +229,8 @@ spec:
             mountPath: /host/etc/vpp
           - name: shm
             mountPath: /dev/shm
+          - name: vpp-run
+            mountPath: /run/vpp
 
       containers:
         # Runs contiv-vswitch container on each Kubernetes node.
@@ -232,8 +241,6 @@ spec:
           securityContext:
             privileged: true
           ports:
-            # VPP debug CLI
-            - containerPort: 5002
             # readiness + liveness probe
             - containerPort: 9999
           readinessProbe:
@@ -264,6 +271,8 @@ spec:
               mountPath: /dev/shm
             - name: dev
               mountPath: /dev
+            - name: vpp-run
+              mountPath: /run/vpp
             - name: contiv-plugin-cfg
               mountPath: /etc/agent
             - name: govpp-plugin-cfg
@@ -307,6 +316,10 @@ spec:
         - name: shm
           hostPath:
             path: /dev/shm
+        # For CLI unix socket.
+        - name: vpp-run
+          hostPath:
+            path: /run/vpp
         # Used to configure contiv plugin.
         - name: contiv-plugin-cfg
           configMap:

--- a/k8s/examples/ldpreload/iperf/README.md
+++ b/k8s/examples/ldpreload/iperf/README.md
@@ -19,7 +19,7 @@ iperf-server-5574dcc986-g8fbv   1/1       Running   0          8s        10.1.1.
 
 Verify the binding on the VPP, on the host where the server POD has been deployed:
 ```
-$ telnet 0 5002
+$ sudo nc -U /run/vpp/cli.sock
 vpp# sh app server
 Connection                              App                 
 [#0][T] 10.1.1.3:5201->0.0.0.0:0        vcom-app-1          

--- a/k8s/examples/ldpreload/nginx/README.md
+++ b/k8s/examples/ldpreload/nginx/README.md
@@ -19,7 +19,7 @@ nginx-server-7686d857c-x922b   1/1       Running   0          5s        10.1.1.3
 
 Verify the binding on the VPP, on the host where the server POD has been deployed:
 ```
-$ telnet 0 5002
+$ sudo nc -U /run/vpp/cli.sock
 vpp# sh app server
 Connection                              App                 
 [#0][T] 10.1.1.3:80->0.0.0.0:0          vcom-app-1           

--- a/k8s/setup-node.sh
+++ b/k8s/setup-node.sh
@@ -82,7 +82,7 @@ selectNodeIntreconnectIf() {
    startup="
 unix {
    nodaemon
-   cli-listen 0.0.0.0:5002
+   cli-listen /run/vpp/cli.sock
    cli-no-pager
 }
 dpdk {

--- a/tests/robot/libraries/EnvConnections.robot
+++ b/tests/robot/libraries/EnvConnections.robot
@@ -28,7 +28,7 @@ Open_VPP_Connection
     BuiltIn.Log    ${node_index}
     ${vpp_connection}=    KubernetesEnv.Open_Connection_To_Node    vpp    ${node_index}
     BuiltIn.Set_Suite_Variable    ${vpp_connection}
-    SshCommons.Switch_And_Write_Command    ${vpp_connection}    telnet 0 5002
+    SshCommons.Switch_And_Write_Command    ${vpp_connection}    nc -U /run/vpp/cli.sock
 
 Find_Nginx_IP
     ${nginx_pod_details} =     KubeCtl.Describe_Pod    ${testbed_connection}    ${nginx_pod_name}

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -146,10 +146,7 @@ you have to untaint the master node:
 
 Check VPP and its interfaces:
 ```apple js
-vagrant@k8s-master:~$ telnet 0 5002
-Trying 0.0.0.0...
-Connected to 0.
-Escape character is '^]'.
+vagrant@k8s-master:~$ sudo nc -U /run/vpp/cli.sock
     _______    _        _   _____  ___ 
  __/ __/ _ \  (_)__    | | / / _ \/ _ \
  _/ _// // / / / _ \   | |/ / ___/ ___/

--- a/vagrant/Vagrantfile-prod
+++ b/vagrant/Vagrantfile-prod
@@ -128,7 +128,7 @@ touch /etc/vpp/contiv-vswitch.conf
   cat <<EOF >/etc/vpp/contiv-vswitch.conf
 unix {
    nodaemon
-   cli-listen 0.0.0.0:5002
+   cli-listen /run/vpp/cli.sock
    cli-no-pager
 }
 dpdk {


### PR DESCRIPTION
The current method of listening on a TCP socket allows non-root
users on the local host, and remote users to alter the network
configuration.  By switching this to a UNIX socket that only root
can access on the local host, we remove this vulnerability.

Note:  The documented netcat client does not support tab completion.
In the future, we should be able to make a simple CLI program that
will work with tab completion.

Drive by:  Cleaned up an inline bash script so it now reports error
status correctly, and made it more readable.