### PR TITLE
Added VMWare Fusion support for vagrant. Cleaned up Vagrantfiles

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -53,13 +53,13 @@ leave empty) or the *development environment* (use the -d flag) . Instructions
 on how to build the development contiv/vpp-vswitch image can be found in the
 next paragraph.
 
-_For the testing environment run:_
+For the testing environment run:
 ```
 cd vagrant-scripts/
 ./vagrant-up
 ```
 
-_For the development environment run:_
+For the development environment run:
 ```
 cd vagrant-scripts/
 ./vagrant-up -d

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -12,7 +12,7 @@ It is organized into two subfolders:
  - (vagrant-scripts) - contains scripts for creating, destroying, rebooting
     and shuting down the VMs that host the K8s cluster.
 
-If you wish to change the default number of nodes, set K8S_NODES before running
+If you wish to change the default number of nodes, edit and set K8S_NODES before running
 vagrant-up:
 ```
 # For a single node setup:
@@ -23,6 +23,17 @@ export K8S_NODES=1
 
 By default, if you do not specify the number of nodes in the environment 
 variable, two nodes (one master, one worker) are created.
+
+If you wish to change the default vagrant provider, you can edit and set the VAGRANT_DEFAULT_PROVIDER value 
+in vagrant-up script to `vmware_fusion`. You can always switch back to the default `virtualbox`.
+(note: for vmware_fusion you need to install the vmware_fusion plugin `vagrant plugin install vagrant-vmware-fusion` 
+and have a valid license)
+
+```
+# For virtualbox provider:
+export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-virtualbox}
+# For vmware_fusion provider:
+export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-vmware_fusion}
 
 To create and run the cluster run vagrant-up script, located inside
 vagrant-scripts folder. You can choose to deploy between the testing (use the 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -30,26 +30,28 @@ provider, edit the vagrant-up script and set the VAGRANT_DEFAULT_PROVIDER value
 to `vmware_fusion`. You can always switch back to the default `virtualbox`.
 
 Note: to use vmware_fusion, you need to have a valid license and install the 
-vmware_fusion plugin for 
-vagrant:
+vmware_fusion plugin for vagrant:
 ```
 vagrant plugin install vagrant-vmware-fusion
 ```
 
-# To use the virtualbox provider:
+- To use the virtualbox provider, set the `VAGRANT_DEFAULT_PROVIDER` variable
+as follows:
 ```
 export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-virtualbox}
 ```
-# To use the vmware_fusion provider:
+- To use the vmware_fusion provider, set the `VAGRANT_DEFAULT_PROVIDER` 
+variable as follows:
 ```
 export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-vmware_fusion}
 ```
 
-To create and run the cluster run vagrant-up script, located inside
-vagrant-scripts folder. You can choose to deploy between the testing (use the 
--t flag or leave empty) and the development environment (use the -d flag) when 
-running the vagrant-up script. Instructions on how to build the development
-contiv/vpp-vswitch image can be found in the next paragraph.
+To create and run a K8s cluster with contiv-vpp CNI plugin, run the 
+`vagrant-up` script, located in the vagrant-scripts folder. The `vagrant-up`
+script can deploy either the *testing environment* (using the -t flag or 
+leave empty) or the *development environment* (use the -d flag) . Instructions
+on how to build the development contiv/vpp-vswitch image can be found in the
+next paragraph.
 
 _For the testing environment run:_
 ```

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -12,8 +12,8 @@ It is organized into two subfolders:
  - (vagrant-scripts) - contains scripts for creating, destroying, rebooting
     and shuting down the VMs that host the K8s cluster.
 
-If you wish to change the default number of nodes, edit and set K8S_NODES before running
-vagrant-up:
+If you wish to change the default number of nodes, edit and set K8S_NODES 
+before running vagrant-up:
 ```
 # For a single node setup:
 export K8S_NODES=0
@@ -24,16 +24,26 @@ export K8S_NODES=1
 By default, if you do not specify the number of nodes in the environment 
 variable, two nodes (one master, one worker) are created.
 
-If you wish to change the default vagrant provider, you can edit and set the VAGRANT_DEFAULT_PROVIDER value 
-in vagrant-up script to `vmware_fusion`. You can always switch back to the default `virtualbox`.
-(note: for vmware_fusion you need to install the vmware_fusion plugin `vagrant plugin install vagrant-vmware-fusion` 
-and have a valid license)
+Two vagrant providers are supported: VirtualBox and VmWare Fusion. The default 
+provider is VirtualBox. If you wish to use VmWare Fusion as the default vagrant
+provider, edit the vagrant-up script and set the VAGRANT_DEFAULT_PROVIDER value
+to `vmware_fusion`. You can always switch back to the default `virtualbox`.
 
+Note: to use vmware_fusion, you need to have a valid license and install the 
+vmware_fusion plugin for 
+vagrant:
 ```
-# For virtualbox provider:
+vagrant plugin install vagrant-vmware-fusion
+```
+
+# To use the virtualbox provider:
+```
 export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-virtualbox}
-# For vmware_fusion provider:
+```
+# To use the vmware_fusion provider:
+```
 export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-vmware_fusion}
+```
 
 To create and run the cluster run vagrant-up script, located inside
 vagrant-scripts folder. You can choose to deploy between the testing (use the 

--- a/vagrant/Vagrantfiles/virtualbox-dev
+++ b/vagrant/Vagrantfiles/virtualbox-dev
@@ -1,0 +1,309 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'fileutils'
+
+BEGIN {
+  STATEFILE = ".vagrant-state"
+
+  # if there's a state file, set all the envvars in the current environment
+  if File.exist?(STATEFILE)
+    File.read(STATEFILE).lines.map { |x| x.split("=", 2) }.each { |x,y| ENV[x] = y.strip }
+  end
+}
+
+module VagrantPlugins
+    module EnvState
+        class Plugin < Vagrant.plugin('2')
+        name 'EnvState'
+
+        def self.up_hook(arg)
+            unless File.exist?(STATEFILE)
+            f = File.open(STATEFILE, "w") 
+            ENV.each do |x,y|
+                f.puts "%s=%s" % [x,y]
+            end
+            f.close
+            end
+        end
+
+        def self.destroy_hook(arg)
+            if File.exist?(STATEFILE)
+            File.unlink(STATEFILE)
+            end
+        end
+
+        action_hook(:EnvState, :machine_action_up) do |hook|
+            hook.prepend(method(:up_hook))
+        end
+
+        action_hook(:EnvState, :machine_action_destroy) do |hook|
+            hook.prepend(method(:destroy_hook))
+        end
+        end
+    end
+end
+
+# SET ENV
+http_proxy = ENV['HTTP_PROXY'] || ENV['http_proxy'] || ''
+https_proxy = ENV['HTTPS_PROXY'] || ENV['https_proxy'] || ''
+node_os = ENV['K8S_NODE_OS'] || 'ubuntu'
+base_ip = ENV['K8S_IP_PREFIX'] || '192.168.20.'
+num_nodes = ENV['K8S_NODES'].to_i == 0 ? 0 : ENV['K8S_NODES'].to_i
+
+provision_every_node = <<SCRIPT
+set -e
+set -x
+## setup the environment file. Export the env-vars passed as args to 'vagrant up'
+# This script will also: add keys, update and install pre-requisites
+
+echo Args passed: [[ $@ ]]
+cat <<EOF >/etc/profile.d/envvar.sh
+export http_proxy='#{http_proxy}'
+export https_proxy='#{https_proxy}'
+EOF
+
+source /etc/profile.d/envvar.sh
+echo "Updating apt lists..."
+apt-get update
+
+echo "Installing dependency packages..."
+apt-get install -y apt-transport-https \
+                   ca-certificates \
+                   curl \
+                   software-properties-common 
+
+echo "Adding Kubernetes & Docker repos..."
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+EOF
+
+echo "Updating apt lists..."
+apt-get update
+
+echo "Installing Docker-CE..."
+apt-get install -y docker-ce
+systemctl stop docker
+modprobe overlay
+
+echo '{"storage-driver": "overlay2"}' > /etc/docker/daemon.json
+rm -rf /var/lib/docker/*
+systemctl start docker
+
+echo "Installing Kubernetes Components..."
+apt-get install -y kubelet kubectl kubeadm kubernetes-cni
+export GO_VERSION=1.9.3
+echo "Downloading Go $GO_VERSION..."
+curl --silent https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz > /tmp/go.tar.gz
+
+echo "Extracting Go..."
+tar -xvzf /tmp/go.tar.gz --directory /home/vagrant >/dev/null 2>&1
+
+echo "Setting Go environment variables..."
+mkdir -p /home/vagrant/gopath/bin
+mkdir -p /home/vagrant/gopath/pkg
+chmod -R 777 /home/vagrant/gopath
+echo 'export GOROOT="/home/vagrant/go"' >> /home/vagrant/.bashrc
+echo 'export GOPATH="/home/vagrant/gopath"' >> /home/vagrant/.bashrc
+echo 'export PATH="$PATH:$GOROOT/bin:$GOPATH/bin"' >> /home/vagrant/.bashrc
+source /home/vagrant/.bashrc
+update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8
+echo 'All done!'
+
+#Load uio_pci_generic driver and setup the loading on each boot up
+installPCIUIO() {
+   modprobe uio_pci_generic
+      # check if the driver is not already added into the file
+      if ! grep -q "uio_pci_generic" /etc/modules; then
+         echo uio_pci_generic >> /etc/modules
+         echo "Module uio_pci_generic was added into /etc/modules"
+      fi
+}
+
+#Selects an interface that will be used for node interconnect
+createVPPconfig() {
+mkdir -p /etc/vpp
+touch /etc/vpp/contiv-vswitch.conf
+  cat <<EOF >/etc/vpp/contiv-vswitch.conf
+unix {
+   nodaemon
+   cli-listen 0.0.0.0:5002
+   cli-no-pager
+}
+dpdk {
+   dev 0000:00:08.0
+}
+EOF
+
+#shutdown interface
+ip link set enp0s8 down
+}
+
+kernelModule=$(lsmod | grep uio_pci_generic | wc -l)
+if [[ $kernelModule -gt 0 ]]; then
+    echo "PCI UIO driver is loaded"
+else
+    installPCIUIO
+fi
+createVPPconfig
+
+echo "#auto enp0s8" >> /etc/network/interfaces
+
+# Pull the latest images
+bash <(curl -s https://raw.githubusercontent.com/contiv/vpp/master/k8s/pull-images.sh)
+
+#Disable swap
+swapoff -a
+sed -e '/swap/ s/^#*/#/' -i /etc/fstab
+SCRIPT
+
+bootstrap_master = <<SCRIPT
+set -e
+set -x
+
+echo Args passed: [[ $@ ]]
+
+# --------------------------------------------------------
+# ---> Build Contiv/VPP-vswitch Development Image <---
+# --------------------------------------------------------
+
+echo "vagrant" >> /home/vagrant/gopath/src/github.com/contiv/vpp/.dockerignore
+echo "Building development contivpp/vswitch image..."
+cd /home/vagrant/gopath/src/github.com/contiv/vpp/docker/ubuntu-based/dev; ./build.sh
+
+# --------------------------------------------------------
+# ---> Create token and export it with kube master IP <---
+# --------------------------------------------------------
+
+echo "Exporting Kube Master IP and Kubeadm Token..."
+echo "export KUBE_MASTER_IP=$2" >> /vagrant/config/init
+echo "export KUBEADM_TOKEN=$(kubeadm token generate)" >> /vagrant/config/init
+source /vagrant/config/init
+sed 's/127\.0\.0\.1.*k8s.*/'"$2"' '"$1"'/' -i /etc/hosts
+
+echo "export no_proxy='$1,$KUBE_MASTER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
+echo "export no_proxy='$1,$KUBE_MASTER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile
+source /etc/profile.d/envvar.sh
+source /home/vagrant/.profile
+
+# --------------------------------------------------------
+# --------------> Kubeadm & Networking <------------------
+# --------------------------------------------------------
+
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
+systemctl restart kubelet
+echo "$(kubeadm init --token-ttl 0 --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
+
+echo "Create folder to store kubernetes and network configuration"
+mkdir -p /home/vagrant/.kube
+sudo cp -i /etc/kubernetes/admin.conf /home/vagrant/.kube/config
+sudo chown vagrant:vagrant -R /home/vagrant/.kube
+
+echo "Installing Contiv-VPP networking as user"
+sudo -u vagrant -H bash << EOF
+
+echo "Installing Pod Network..."
+kubectl apply -f https://raw.githubusercontent.com/contiv/vpp/master/k8s/contiv-vpp.yaml
+
+echo "Schedule Pods on master"
+kubectl taint nodes --all node-role.kubernetes.io/master-
+EOF
+SCRIPT
+
+bootstrap_worker = <<SCRIPT
+set -e
+set -x
+
+echo Args passed: [[ $@ ]]
+
+source /vagrant/config/init
+export KUBE_WORKER_IP=$2
+sed 's/127\.0\.0\.1.*k8s.*/'"$2"' '"$1"'/' -i /etc/hosts
+echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
+echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile
+source /etc/profile.d/envvar.sh
+source /home/vagrant/.profile
+
+# Kubeadm join expects kube_master_ip and kubeadm_token
+hash=$(awk 'END {print $NF}' /vagrant/config/cert)
+kubeadm join --token "${KUBEADM_TOKEN}"  "${KUBE_MASTER_IP}":6443 --discovery-token-ca-cert-hash "$hash"
+SCRIPT
+
+VAGRANTFILE_API_VERSION = "2"
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.box_check_update = false
+    if Vagrant.has_plugin?("vagrant-vbguest")
+        config.vbguest.auto_update = false
+    end 
+    if node_os == "ubuntu" then
+        config.vm.box = "puppetlabs/ubuntu-16.04-64-nocm"
+        config.vm.box_version = "1.0.0"
+    else
+        # Nothing for now, later add more OS
+    end
+    config.vm.provider 'virtualbox' do |v|
+        v.linked_clone = true if Vagrant::VERSION >= "1.8"
+        v.customize ['modifyvm', :id, '--paravirtprovider', 'kvm']
+    end
+
+    node_ips = num_nodes.times.collect { |n| base_ip + "#{n+10}" }
+    node_names = num_nodes.times.collect { |n| "k8s-worker#{n+1}" }
+
+    config.ssh.insert_key = false
+
+    if Vagrant.has_plugin?("vagrant-cachier")
+        config.cache.scope = :box
+        config.cache.enable :apt
+    end
+    
+    # Configure Master node
+    config.vm.define "k8s-master" do |k8smaster|
+        k8smaster.vm.host_name = "k8s-master"
+        k8smaster_ip = base_ip + "2"
+        k8smaster.vm.synced_folder "../", "/home/vagrant/gopath/src/github.com/contiv/vpp"
+        k8smaster.vm.network :private_network, type: "dhcp", auto_config: false
+        k8smaster.vm.network :private_network, ip: k8smaster_ip, virtualbox__intnet: "true"
+        k8smaster.vm.provider "virtualbox" do |v|
+            v.customize ["modifyvm", :id, "--ioapic", "on"]
+            v.memory = 4096
+            v.cpus = 4
+        end
+        k8smaster.vm.provision "shell" do |s|
+            s.inline = provision_every_node
+            s.args = [http_proxy, https_proxy]
+        end
+        k8smaster.vm.provision "shell" do |s|
+            s.inline = bootstrap_master
+            s.args = ["k8s-master", k8smaster_ip]
+        end
+    end
+
+    num_nodes.times do |n|
+        node_name = node_names[n]
+        node_addr = node_ips[n]
+
+        config.vm.define node_name do |node|
+            node.vm.hostname = node_name
+            # Interface for K8s Cluster
+            node.vm.network :private_network, type: "dhcp", auto_config: false
+            node.vm.network :private_network, ip: node_addr, virtualbox__intnet: "true"
+            node.vm.provider "virtualbox" do |v|
+            v.customize ["modifyvm", :id, "--ioapic", "on"]
+            v.memory = 2048
+            v.cpus = 2
+            end
+            node.vm.provision "shell" do |s|
+                s.inline = provision_every_node
+                s.args = [http_proxy, https_proxy]
+            end
+            node.vm.provision "shell" do |s|
+                s.inline = bootstrap_worker
+                s.args = [node_name, node_addr]
+            end
+        end
+    end
+end

--- a/vagrant/Vagrantfiles/virtualbox-dev
+++ b/vagrant/Vagrantfiles/virtualbox-dev
@@ -29,7 +29,7 @@ module VagrantPlugins
 
         def self.destroy_hook(arg)
             if File.exist?(STATEFILE)
-            File.unlink(STATEFILE)
+                File.unlink(STATEFILE)
             end
         end
 
@@ -130,7 +130,7 @@ touch /etc/vpp/contiv-vswitch.conf
   cat <<EOF >/etc/vpp/contiv-vswitch.conf
 unix {
    nodaemon
-   cli-listen 0.0.0.0:5002
+   cli-listen /run/vpp/cli.sock
    cli-no-pager
 }
 dpdk {

--- a/vagrant/Vagrantfiles/virtualbox-prod
+++ b/vagrant/Vagrantfiles/virtualbox-prod
@@ -48,7 +48,7 @@ end
 http_proxy = ENV['HTTP_PROXY'] || ENV['http_proxy'] || ''
 https_proxy = ENV['HTTPS_PROXY'] || ENV['https_proxy'] || ''
 node_os = ENV['K8S_NODE_OS'] || 'ubuntu'
-base_ip = ENV['K8S_IP_PREFIX'] || '192.169.1.'
+base_ip = ENV['K8S_IP_PREFIX'] || '192.168.20.'
 num_nodes = ENV['K8S_NODES'].to_i == 0 ? 0 : ENV['K8S_NODES'].to_i
 
 provision_every_node = <<SCRIPT
@@ -71,7 +71,7 @@ echo "Installing dependency packages..."
 apt-get install -y apt-transport-https \
                    ca-certificates \
                    curl \
-                   software-properties-common
+                   software-properties-common 
                    
 echo "Adding Kubernetes & Docker repos..."
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -84,6 +84,9 @@ EOF
 echo "Updating apt lists..."
 apt-get update
 
+echo "Installing Kubernetes Components..."
+apt-get install -y kubelet kubectl kubeadm kubernetes-cni
+
 echo "Installing Docker-CE..."
 apt-get install -y docker-ce
 systemctl stop docker
@@ -92,24 +95,6 @@ modprobe overlay
 echo '{"storage-driver": "overlay2"}' > /etc/docker/daemon.json
 rm -rf /var/lib/docker/*
 systemctl start docker
-
-echo "Installing Kubernetes Components..."
-apt-get install -y kubelet kubectl kubeadm kubernetes-cni
-export GO_VERSION=1.9.3
-echo "Downloading Go $GO_VERSION..."
-curl --silent https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz > /tmp/go.tar.gz
-
-echo "Extracting Go..."
-tar -xvzf /tmp/go.tar.gz --directory /home/vagrant >/dev/null 2>&1
-
-echo "Setting Go environment variables..."
-mkdir /home/vagrant/gopath
-chmod -R 777 /home/vagrant/gopath
-echo 'export GOROOT="/home/vagrant/go"' >> /home/vagrant/.bashrc
-echo 'export GOPATH="/home/vagrant/gopath"' >> /home/vagrant/.bashrc
-echo 'export PATH="$PATH:$GOROOT/bin:$GOPATH/bin"' >> /home/vagrant/.bashrc
-update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8
-echo 'All done!'
 
 #Load uio_pci_generic driver and setup the loading on each boot up
 installPCIUIO() {
@@ -153,34 +138,39 @@ echo "#auto enp0s8" >> /etc/network/interfaces
 # Pull the latest images
 bash <(curl -s https://raw.githubusercontent.com/contiv/vpp/master/k8s/pull-images.sh)
 
+#Disable swap
+swapoff -a
+sed -e '/swap/ s/^#*/#/' -i /etc/fstab
 SCRIPT
 
 bootstrap_master = <<SCRIPT
 set -e
 set -x
 
+echo Args passed: [[ $@ ]]
+
 # --------------------------------------------------------
 # ---> Create token and export it with kube master IP <---
 # --------------------------------------------------------
+
 echo "Exporting Kube Master IP and Kubeadm Token..."
-#echo "export KUBE_MASTER_IP=$(hostname -I | cut -f2 -d' ')" >> /vagrant/config/init
-echo "export KUBE_MASTER_IP=192.169.1.10\n" >> /vagrant/config/init
+echo "export KUBE_MASTER_IP=$2" >> /vagrant/config/init
 echo "export KUBEADM_TOKEN=$(kubeadm token generate)" >> /vagrant/config/init
 source /vagrant/config/init
-echo "export no_proxy='k8s-master,192.169.1.10,192.169.1.11,192.169.1.12,192.169.1.13,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
-echo "export no_proxy='k8s-master,192.169.1.10,192.169.1.11,192.169.1.12,192.169.1.13,localhost,127.0.0.1'" >> ~/.profile
+sed 's/127\.0\.0\.1.*k8s.*/'"$2"' '"$1"'/' -i /etc/hosts
+
+echo "export no_proxy='$1,$KUBE_MASTER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
+echo "export no_proxy='$1,$KUBE_MASTER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile
 source /etc/profile.d/envvar.sh
-source ~/.profile
+source /home/vagrant/.profile
 
 # --------------------------------------------------------
 # --------------> Kubeadm & Networking <------------------
 # --------------------------------------------------------
 
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--fail-swap-on=false --node-ip=192.169.1.10"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
-#Disable swap
-swapoff -a
 echo "$(kubeadm init --token-ttl 0 --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
 
 echo "Create folder to store kubernetes and network configuration"
@@ -200,21 +190,20 @@ EOF
 SCRIPT
 
 bootstrap_worker = <<SCRIPT
-echo "export no_proxy='k8s-worker1,192.169.1.10,192.169.1.11,192.169.1.12,192.169.1.13,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
-echo "export no_proxy='k8s-worker1,192.169.1.10,192.169.1.11,192.169.1.12,192.169.1.13,localhost,127.0.0.1'" >> ~/.profile
-source /etc/profile.d/envvar.sh
-source ~/.profile
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--fail-swap-on=false --node-ip=192.169.1.11"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-systemctl daemon-reload
-systemctl restart kubelet
-
-#Disable swap
-swapoff -a
-
-# Kubeadm join expects kube_master_ip and kubeadm_token
 set -e
 set -x
+
+echo Args passed: [[ $@ ]]
+
 source /vagrant/config/init
+export KUBE_WORKER_IP=$2
+sed 's/127\.0\.0\.1.*k8s.*/'"$2"' '"$1"'/' -i /etc/hosts
+echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
+echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile
+source /etc/profile.d/envvar.sh
+source /home/vagrant/.profile
+
+# Kubeadm join expects kube_master_ip and kubeadm_token
 hash=$(awk 'END {print $NF}' /vagrant/config/cert)
 kubeadm join --token "${KUBEADM_TOKEN}"  "${KUBE_MASTER_IP}":6443 --discovery-token-ca-cert-hash "$hash"
 SCRIPT
@@ -237,10 +226,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     node_ips = num_nodes.times.collect { |n| base_ip + "#{n+10}" }
-    cluster_ip_nodes = node_ips.join(",")
+    node_names = num_nodes.times.collect { |n| "k8s-worker#{n+1}" }
 
     config.ssh.insert_key = false
-    node_names = num_nodes.times.collect { |n| "k8s-worker#{n+1}" }
 
     if Vagrant.has_plugin?("vagrant-cachier")
         config.cache.scope = :box
@@ -250,22 +238,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Configure Master node
     config.vm.define "k8s-master" do |k8smaster|
         k8smaster.vm.host_name = "k8s-master"
+        k8smaster_ip = base_ip + "2"
         k8smaster.vm.network :private_network, type: "dhcp", auto_config: false
-        k8smaster.vm.network :private_network, ip: base_ip + "10", virtualbox__intnet: "true"
+        k8smaster.vm.network :private_network, ip: k8smaster_ip, virtualbox__intnet: "true"
         k8smaster.vm.provider "virtualbox" do |v|
             v.customize ["modifyvm", :id, "--ioapic", "on"]
             v.memory = 2048
             v.cpus = 2
         end
-        k8smaster_ip = base_ip + "51"
-        k8smaster.vm.provision :shell, inline: "sed 's/127\.0\.0\.1.*k8s.*/"+base_ip +"10 k8s-master/' -i /etc/hosts"
         k8smaster.vm.provision "shell" do |s|
             s.inline = provision_every_node
-            s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+            s.args = [http_proxy, https_proxy]
         end
         k8smaster.vm.provision "shell" do |s|
             s.inline = bootstrap_master
-            s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+            s.args = ["k8s-master", k8smaster_ip]
         end
     end
 
@@ -277,23 +264,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             node.vm.hostname = node_name
             # Interface for K8s Cluster
             node.vm.network :private_network, type: "dhcp", auto_config: false
-            #node.vm.network :private_network, ip: "node_addr", virtualbox__intnet: "true"
-            node.vm.network :private_network, ip: base_ip + "11", virtualbox__intnet: "true"
+            node.vm.network :private_network, ip: node_addr, virtualbox__intnet: "true"
             node.vm.provider "virtualbox" do |v|
             v.customize ["modifyvm", :id, "--ioapic", "on"]
             v.memory = 2048
             v.cpus = 2
             end
-            node_ip_last = n+10
-            #node.vm.provision :shell, inline: "sed 's/127\.0\.0\.1.*k8s.*/192\.169\.1\.#{node_ip_last} #{node_name}/' -i /etc/hosts"
-            node.vm.provision :shell, inline: "sed 's/127\.0\.0\.1.*k8s.*/"+base_ip+"11 k8s-worker1/' -i /etc/hosts"
             node.vm.provision "shell" do |s|
                 s.inline = provision_every_node
-                s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+                s.args = [http_proxy, https_proxy]
             end
             node.vm.provision "shell" do |s|
                 s.inline = bootstrap_worker
-                s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+                s.args = [node_name, node_addr]
             end
         end
     end

--- a/vagrant/Vagrantfiles/virtualbox-prod
+++ b/vagrant/Vagrantfiles/virtualbox-prod
@@ -29,7 +29,7 @@ module VagrantPlugins
 
         def self.destroy_hook(arg)
             if File.exist?(STATEFILE)
-            File.unlink(STATEFILE)
+                File.unlink(STATEFILE)
             end
         end
 
@@ -113,7 +113,7 @@ touch /etc/vpp/contiv-vswitch.conf
   cat <<EOF >/etc/vpp/contiv-vswitch.conf
 unix {
    nodaemon
-   cli-listen 0.0.0.0:5002
+   cli-listen /run/vpp/cli.sock
    cli-no-pager
 }
 dpdk {

--- a/vagrant/Vagrantfiles/vmware-dev
+++ b/vagrant/Vagrantfiles/vmware-dev
@@ -29,7 +29,7 @@ module VagrantPlugins
 
         def self.destroy_hook(arg)
             if File.exist?(STATEFILE)
-            File.unlink(STATEFILE)
+                File.unlink(STATEFILE)
             end
         end
 
@@ -48,7 +48,6 @@ end
 http_proxy = ENV['HTTP_PROXY'] || ENV['http_proxy'] || ''
 https_proxy = ENV['HTTPS_PROXY'] || ENV['https_proxy'] || ''
 node_os = ENV['K8S_NODE_OS'] || 'ubuntu'
-base_ip = ENV['K8S_IP_PREFIX'] || '192.169.1.'
 num_nodes = ENV['K8S_NODES'].to_i == 0 ? 0 : ENV['K8S_NODES'].to_i
 
 provision_every_node = <<SCRIPT
@@ -71,9 +70,8 @@ echo "Installing dependency packages..."
 apt-get install -y apt-transport-https \
                    ca-certificates \
                    curl \
-                   software-properties-common \
-                   git
-                   
+                   software-properties-common 
+
 echo "Adding Kubernetes & Docker repos..."
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
@@ -135,12 +133,12 @@ unix {
    cli-no-pager
 }
 dpdk {
-   dev 0000:00:08.0
+   dev 0000:03:00.0
 }
 EOF
 
 #shutdown interface
-ip link set enp0s8 down
+ip link set ens160 down
 }
 
 kernelModule=$(lsmod | grep uio_pci_generic | wc -l)
@@ -151,44 +149,52 @@ else
 fi
 createVPPconfig
 
-echo "#auto enp0s8" >> /etc/network/interfaces
+echo "#auto ens160" >> /etc/network/interfaces
 
 # Pull the latest images
 bash <(curl -s https://raw.githubusercontent.com/contiv/vpp/master/k8s/pull-images.sh)
 
+#Disable swap
+swapoff -a
+sed -e '/swap/ s/^#*/#/' -i /etc/fstab
 SCRIPT
 
 bootstrap_master = <<SCRIPT
 set -e
 set -x
 
+echo Args passed: [[ $@ ]]
+
+# --------------------------------------------------------
+# ---> Build Contiv/VPP-vswitch Development Image <---
+# --------------------------------------------------------
+
+echo "vagrant" >> /home/vagrant/gopath/src/github.com/contiv/vpp/.dockerignore
+echo "Building development contivpp/vswitch image..."
+cd /home/vagrant/gopath/src/github.com/contiv/vpp/docker/ubuntu-based/dev; ./build.sh
+
 # --------------------------------------------------------
 # ---> Create token and export it with kube master IP <---
 # --------------------------------------------------------
 
-echo "Building development contivpp/vswitch image..."
-cd /home/vagrant/gopath/src/github.com/contiv/vpp/docker/ubuntu-based/dev; ./build.sh
-
 echo "Exporting Kube Master IP and Kubeadm Token..."
-#echo "export KUBE_MASTER_IP=$(hostname -I | cut -f2 -d' ')" >> /vagrant/config/init
-echo "export KUBE_MASTER_IP=192.169.1.10\n" >> /vagrant/config/init
+echo "export KUBE_MASTER_IP=$(hostname -I | cut -f1 -d' ')" >> /vagrant/config/init
 echo "export KUBEADM_TOKEN=$(kubeadm token generate)" >> /vagrant/config/init
 source /vagrant/config/init
-echo "export no_proxy='k8s-master,192.169.1.10,192.169.1.11,192.169.1.12,192.169.1.13,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
-echo "export no_proxy='k8s-master,192.169.1.10,192.169.1.11,192.169.1.12,192.169.1.13,localhost,127.0.0.1'" >> ~/.profile
+sed 's/127\.0\.0\.1.*k8s.*/'"$KUBE_MASTER_IP"' '"$1"'/' -i /etc/hosts
+
+echo "export no_proxy='k8s-master,$KUBE_MASTER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
+echo "export no_proxy='k8s-master,$KUBE_MASTER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile
 source /etc/profile.d/envvar.sh
-source ~/.profile
+source /home/vagrant/.profile
 
 # --------------------------------------------------------
 # --------------> Kubeadm & Networking <------------------
 # --------------------------------------------------------
 
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--fail-swap-on=false --node-ip=192.169.1.10"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
-
-#Disable swap
-swapoff -a
 echo "$(kubeadm init --token-ttl 0 --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
 
 echo "Create folder to store kubernetes and network configuration"
@@ -208,21 +214,20 @@ EOF
 SCRIPT
 
 bootstrap_worker = <<SCRIPT
-echo "export no_proxy='k8s-worker1,192.169.1.10,192.169.1.11,192.169.1.12,192.169.1.13,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
-echo "export no_proxy='k8s-worker1,192.169.1.10,192.169.1.11,192.169.1.12,192.169.1.13,localhost,127.0.0.1'" >> ~/.profile
-source /etc/profile.d/envvar.sh
-source ~/.profile
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--fail-swap-on=false --node-ip=192.169.1.11"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-systemctl daemon-reload
-systemctl restart kubelet
-
-#Disable swap
-swapoff -a
-
-# Kubeadm join expects kube_master_ip and kubeadm_token
 set -e
 set -x
+
+echo Args passed: [[ $@ ]]
+
 source /vagrant/config/init
+export KUBE_WORKER_IP=$(hostname -I | cut -f1 -d' ')
+sed 's/127\.0\.0\.1.*k8s.*/'"$KUBE_WORKER_IP"' '"$1"'/' -i /etc/hosts
+echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
+echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile
+source /etc/profile.d/envvar.sh
+source /home/vagrant/.profile
+
+# Kubeadm join expects kube_master_ip and kubeadm_token
 hash=$(awk 'END {print $NF}' /vagrant/config/cert)
 kubeadm join --token "${KUBEADM_TOKEN}"  "${KUBE_MASTER_IP}":6443 --discovery-token-ca-cert-hash "$hash"
 SCRIPT
@@ -239,13 +244,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     else
         # Nothing for now, later add more OS
     end
-    config.vm.provider 'virtualbox' do |v|
+    config.vm.provider 'vmware_fusion' do |v|
         v.linked_clone = true if Vagrant::VERSION >= "1.8"
-        v.customize ['modifyvm', :id, '--paravirtprovider', 'kvm']
     end
-
-    node_ips = num_nodes.times.collect { |n| base_ip + "#{n+10}" }
-    cluster_ip_nodes = node_ips.join(",")
 
     config.ssh.insert_key = false
     node_names = num_nodes.times.collect { |n| "k8s-worker#{n+1}" }
@@ -259,50 +260,41 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define "k8s-master" do |k8smaster|
         k8smaster.vm.host_name = "k8s-master"
         k8smaster.vm.network :private_network, type: "dhcp", auto_config: false
-        k8smaster.vm.network :private_network, ip: base_ip + "10", virtualbox__intnet: "true"
-        k8smaster.vm.provider "virtualbox" do |v|
-            v.customize ["modifyvm", :id, "--ioapic", "on"]
-            v.memory = 4096
-            v.cpus = 4
+        k8smaster.vm.provider "vmware_fusion" do |v|
+          v.vmx["memsize"] = "4096"
+          v.vmx["numvcpus"] = "4"
+          v.vmx["ethernet1.virtualdev"] = "vmxnet3"
         end
         k8smaster.vm.synced_folder "../", "/home/vagrant/gopath/src/github.com/contiv/vpp"
-        k8smaster_ip = base_ip + "51"
-        k8smaster.vm.provision :shell, inline: "sed 's/127\.0\.0\.1.*k8s.*/"+base_ip +"10 k8s-master/' -i /etc/hosts"
         k8smaster.vm.provision "shell" do |s|
             s.inline = provision_every_node
-            s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+            s.args = [http_proxy, https_proxy]
         end
         k8smaster.vm.provision "shell" do |s|
             s.inline = bootstrap_master
-            s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+            s.args = ["k8s-master"]
         end
     end
 
     num_nodes.times do |n|
         node_name = node_names[n]
-        node_addr = node_ips[n]
 
         config.vm.define node_name do |node|
             node.vm.hostname = node_name
             # Interface for K8s Cluster
             node.vm.network :private_network, type: "dhcp", auto_config: false
-            #node.vm.network :private_network, ip: "node_addr", virtualbox__intnet: "true"
-            node.vm.network :private_network, ip: base_ip + "11", virtualbox__intnet: "true"
-            node.vm.provider "virtualbox" do |v|
-            v.customize ["modifyvm", :id, "--ioapic", "on"]
-            v.memory = 2048
-            v.cpus = 2
+            node.vm.provider "vmware_fusion" do |v|
+              v.vmx["memsize"] = "2048"
+              v.vmx["numvcpus"] = "2"
+              v.vmx["ethernet1.virtualdev"] = "vmxnet3"
             end
-            node_ip_last = n+10
-            #node.vm.provision :shell, inline: "sed 's/127\.0\.0\.1.*k8s.*/192\.169\.1\.#{node_ip_last} #{node_name}/' -i /etc/hosts"
-            node.vm.provision :shell, inline: "sed 's/127\.0\.0\.1.*k8s.*/"+base_ip+"11 k8s-worker1/' -i /etc/hosts"
             node.vm.provision "shell" do |s|
                 s.inline = provision_every_node
-                s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+                s.args = [http_proxy, https_proxy]
             end
             node.vm.provision "shell" do |s|
                 s.inline = bootstrap_worker
-                s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+                s.args = [node_name]
             end
         end
     end

--- a/vagrant/Vagrantfiles/vmware-dev
+++ b/vagrant/Vagrantfiles/vmware-dev
@@ -129,7 +129,7 @@ touch /etc/vpp/contiv-vswitch.conf
   cat <<EOF >/etc/vpp/contiv-vswitch.conf
 unix {
    nodaemon
-   cli-listen 0.0.0.0:5002
+   cli-listen /run/vpp/cli.sock
    cli-no-pager
 }
 dpdk {

--- a/vagrant/Vagrantfiles/vmware-prod
+++ b/vagrant/Vagrantfiles/vmware-prod
@@ -29,7 +29,7 @@ module VagrantPlugins
 
         def self.destroy_hook(arg)
             if File.exist?(STATEFILE)
-            File.unlink(STATEFILE)
+                File.unlink(STATEFILE)
             end
         end
 
@@ -112,7 +112,7 @@ touch /etc/vpp/contiv-vswitch.conf
   cat <<EOF >/etc/vpp/contiv-vswitch.conf
 unix {
    nodaemon
-   cli-listen 0.0.0.0:5002
+   cli-listen /run/vpp/cli.sock
    cli-no-pager
 }
 dpdk {

--- a/vagrant/Vagrantfiles/vmware-prod
+++ b/vagrant/Vagrantfiles/vmware-prod
@@ -1,0 +1,275 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'fileutils'
+
+BEGIN {
+  STATEFILE = ".vagrant-state"
+
+  # if there's a state file, set all the envvars in the current environment
+  if File.exist?(STATEFILE)
+    File.read(STATEFILE).lines.map { |x| x.split("=", 2) }.each { |x,y| ENV[x] = y.strip }
+  end
+}
+
+module VagrantPlugins
+    module EnvState
+        class Plugin < Vagrant.plugin('2')
+        name 'EnvState'
+
+        def self.up_hook(arg)
+            unless File.exist?(STATEFILE)
+            f = File.open(STATEFILE, "w") 
+            ENV.each do |x,y|
+                f.puts "%s=%s" % [x,y]
+            end
+            f.close
+            end
+        end
+
+        def self.destroy_hook(arg)
+            if File.exist?(STATEFILE)
+            File.unlink(STATEFILE)
+            end
+        end
+
+        action_hook(:EnvState, :machine_action_up) do |hook|
+            hook.prepend(method(:up_hook))
+        end
+
+        action_hook(:EnvState, :machine_action_destroy) do |hook|
+            hook.prepend(method(:destroy_hook))
+        end
+        end
+    end
+end
+
+# SET ENV
+http_proxy = ENV['HTTP_PROXY'] || ENV['http_proxy'] || ''
+https_proxy = ENV['HTTPS_PROXY'] || ENV['https_proxy'] || ''
+node_os = ENV['K8S_NODE_OS'] || 'ubuntu'
+num_nodes = ENV['K8S_NODES'].to_i == 0 ? 0 : ENV['K8S_NODES'].to_i
+
+provision_every_node = <<SCRIPT
+set -e
+set -x
+## setup the environment file. Export the env-vars passed as args to 'vagrant up'
+# This script will also: add keys, update and install pre-requisites
+
+echo Args passed: [[ $@ ]]
+cat <<EOF >/etc/profile.d/envvar.sh
+export http_proxy='#{http_proxy}'
+export https_proxy='#{https_proxy}'
+EOF
+
+source /etc/profile.d/envvar.sh
+echo "Updating apt lists..."
+apt-get update
+
+echo "Installing dependency packages..."
+apt-get install -y apt-transport-https \
+                   ca-certificates \
+                   curl \
+                   software-properties-common
+
+echo "Adding Kubernetes & Docker repos..."
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+EOF
+
+echo "Updating apt lists..."
+apt-get update
+
+echo "Installing Kubernetes Components..."
+apt-get install -y kubelet kubectl kubeadm kubernetes-cni
+
+echo "Installing Docker-CE..."
+apt-get install -y docker-ce
+systemctl stop docker
+modprobe overlay
+
+echo '{"storage-driver": "overlay2"}' > /etc/docker/daemon.json
+rm -rf /var/lib/docker/*
+systemctl start docker
+
+#Load uio_pci_generic driver and setup the loading on each boot up
+installPCIUIO() {
+   modprobe uio_pci_generic
+      # check if the driver is not already added into the file
+      if ! grep -q "uio_pci_generic" /etc/modules; then
+         echo uio_pci_generic >> /etc/modules
+         echo "Module uio_pci_generic was added into /etc/modules"
+      fi
+}
+
+#Selects an interface that will be used for node interconnect
+createVPPconfig() {
+mkdir -p /etc/vpp
+touch /etc/vpp/contiv-vswitch.conf
+  cat <<EOF >/etc/vpp/contiv-vswitch.conf
+unix {
+   nodaemon
+   cli-listen 0.0.0.0:5002
+   cli-no-pager
+}
+dpdk {
+   dev 0000:03:00.0
+}
+EOF
+
+#shutdown interface
+ip link set ens160 down
+}
+
+kernelModule=$(lsmod | grep uio_pci_generic | wc -l)
+if [[ $kernelModule -gt 0 ]]; then
+    echo "PCI UIO driver is loaded"
+else
+    installPCIUIO
+fi
+createVPPconfig
+
+echo "#auto ens160" >> /etc/network/interfaces
+
+# Pull the latest images
+bash <(curl -s https://raw.githubusercontent.com/contiv/vpp/master/k8s/pull-images.sh)
+
+#Disable swap
+swapoff -a
+sed -e '/swap/ s/^#*/#/' -i /etc/fstab
+SCRIPT
+
+bootstrap_master = <<SCRIPT
+set -e
+set -x
+
+echo Args passed: [[ $@ ]]
+
+# --------------------------------------------------------
+# ---> Create token and export it with kube master IP <---
+# --------------------------------------------------------
+
+echo "Exporting Kube Master IP and Kubeadm Token..."
+echo "export KUBE_MASTER_IP=$(hostname -I | cut -f1 -d' ')" >> /vagrant/config/init
+echo "export KUBEADM_TOKEN=$(kubeadm token generate)" >> /vagrant/config/init
+source /vagrant/config/init
+sed 's/127\.0\.0\.1.*k8s.*/'"$KUBE_MASTER_IP"' '"$1"'/' -i /etc/hosts
+
+echo "export no_proxy='$1,$KUBE_MASTER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
+echo "export no_proxy='$1,$KUBE_MASTER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile
+source /etc/profile.d/envvar.sh
+source /home/vagrant/.profile
+
+# --------------------------------------------------------
+# --------------> Kubeadm & Networking <------------------
+# --------------------------------------------------------
+
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
+systemctl restart kubelet
+echo "$(kubeadm init --token-ttl 0 --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
+
+echo "Create folder to store kubernetes and network configuration"
+mkdir -p /home/vagrant/.kube
+sudo cp -i /etc/kubernetes/admin.conf /home/vagrant/.kube/config
+sudo chown vagrant:vagrant -R /home/vagrant/.kube
+
+echo "Installing Contiv-VPP networking as user"
+sudo -u vagrant -H bash << EOF
+
+echo "Installing Pod Network..."
+kubectl apply -f https://raw.githubusercontent.com/contiv/vpp/master/k8s/contiv-vpp.yaml
+
+echo "Schedule Pods on master"
+kubectl taint nodes --all node-role.kubernetes.io/master-
+EOF
+SCRIPT
+
+bootstrap_worker = <<SCRIPT
+set -e
+set -x
+
+echo Args passed: [[ $@ ]]
+
+source /vagrant/config/init
+export KUBE_WORKER_IP=$(hostname -I | cut -f1 -d' ')
+sed 's/127\.0\.0\.1.*k8s.*/'"$KUBE_WORKER_IP"' '"$1"'/' -i /etc/hosts
+echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
+echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile
+source /etc/profile.d/envvar.sh
+source /home/vagrant/.profile
+
+# Kubeadm join expects kube_master_ip and kubeadm_token
+hash=$(awk 'END {print $NF}' /vagrant/config/cert)
+kubeadm join --token "${KUBEADM_TOKEN}"  "${KUBE_MASTER_IP}":6443 --discovery-token-ca-cert-hash "$hash"
+SCRIPT
+
+VAGRANTFILE_API_VERSION = "2"
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.box_check_update = false
+    if Vagrant.has_plugin?("vagrant-vbguest")
+        config.vbguest.auto_update = false
+    end 
+    if node_os == "ubuntu" then
+        config.vm.box = "puppetlabs/ubuntu-16.04-64-nocm"
+        config.vm.box_version = "1.0.0"
+    else
+        # Nothing for now, later add more OS
+    end
+    config.vm.provider 'vmware_fusion' do |v|
+        v.linked_clone = true if Vagrant::VERSION >= "1.8"
+    end
+
+    config.ssh.insert_key = false
+    node_names = num_nodes.times.collect { |n| "k8s-worker#{n+1}" }
+
+    if Vagrant.has_plugin?("vagrant-cachier")
+        config.cache.scope = :box
+        config.cache.enable :apt
+    end
+    
+    # Configure Master node
+    config.vm.define "k8s-master" do |k8smaster|
+        k8smaster.vm.host_name = "k8s-master"
+        k8smaster.vm.network :private_network, type: "dhcp", auto_config: false
+        k8smaster.vm.provider "vmware_fusion" do |v|
+          v.vmx["memsize"] = "2048"
+          v.vmx["numvcpus"] = "2"
+          v.vmx["ethernet1.virtualdev"] = "vmxnet3"
+        end
+        k8smaster.vm.provision "shell" do |s|
+            s.inline = provision_every_node
+            s.args = [http_proxy, https_proxy]
+        end
+        k8smaster.vm.provision "shell" do |s|
+            s.inline = bootstrap_master
+            s.args = ["k8s-master"]
+        end
+    end
+
+    num_nodes.times do |n|
+        node_name = node_names[n]
+
+        config.vm.define node_name do |node|
+            node.vm.hostname = node_name
+            # Interface for K8s Cluster
+            node.vm.network :private_network, type: "dhcp", auto_config: false
+            node.vm.provider "vmware_fusion" do |v|
+              v.vmx["memsize"] = "2048"
+              v.vmx["numvcpus"] = "2"
+              v.vmx["ethernet1.virtualdev"] = "vmxnet3"
+            end
+            node.vm.provision "shell" do |s|
+                s.inline = provision_every_node
+                s.args = [http_proxy, https_proxy]
+            end
+            node.vm.provision "shell" do |s|
+                s.inline = bootstrap_worker
+                s.args = [node_name]
+            end
+        end
+    end
+end

--- a/vagrant/vagrant-scripts/vagrant-up
+++ b/vagrant/vagrant-scripts/vagrant-up
@@ -4,7 +4,7 @@ set -eo pipefail
 
 export K8S_NODE_OS=${K8S_NODE_OS:-ubuntu}
 export K8S_NODES=${K8S_NODES:-1}
-export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-vmware_fusion}
+export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-virtualbox}
 
 # Default values for environment deploymen
 DEV_ENV="false"

--- a/vagrant/vagrant-scripts/vagrant-up
+++ b/vagrant/vagrant-scripts/vagrant-up
@@ -4,7 +4,7 @@ set -eo pipefail
 
 export K8S_NODE_OS=${K8S_NODE_OS:-ubuntu}
 export K8S_NODES=${K8S_NODES:-1}
-export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-virtualbox}
+export VAGRANT_DEFAULT_PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-vmware_fusion}
 
 # Default values for environment deploymen
 DEV_ENV="false"
@@ -29,14 +29,23 @@ done
 
 if [ "${DEV_ENV}" == "true" ]
 then
-    cp ../Vagrantfile-dev ../Vagrantfile
-    vagrant up
-    exit 1
+    if [ "${VAGRANT_DEFAULT_PROVIDER}" == "vmware_fusion" ]
+    then
+        cp ../Vagrantfiles/vmware-dev ../Vagrantfile
+        vagrant up
+        exit 1
+    else 
+        cp ../Vagrantfiles/virtualbox-dev ../Vagrantfile
+        vagrant up
+        exit 1
+    fi
 fi
   
-if [ "${TEST_ENV}" == "true" ]
+if [ "${VAGRANT_DEFAULT_PROVIDER}" == "vmware_fusion" ]
 then
-    echo "Using testing environment"
-    cp ../Vagrantfile-prod ../Vagrantfile
-    vagrant up 
+    cp ../Vagrantfiles/vmware-prod ../Vagrantfile
+    vagrant up
+else 
+    cp ../Vagrantfiles/virtualbox-prod ../Vagrantfile
+    vagrant up
 fi


### PR DESCRIPTION
* Vagrantfile templates are stored under Vagrantfiles folder.
  Option to choose between a production/development cluster and vmware/virtualbox provider.
* Cleaned up Vagrantfiles:
  - Removed hardcoded IP addresses, hostnames.
  - Deleted unnecessary package installations on production environment.
* Modified vagrant-up script to support both providers.