### PR TITLE
docker/ubuntu.../dev/Dockerfile: clean apt lists

### DIFF
--- a/docker/ubuntu-based/dev/Dockerfile
+++ b/docker/ubuntu-based/dev/Dockerfile
@@ -8,7 +8,9 @@ ARG VPP_COMMIT_ID="xxx"
 ARG SKIP_DEBUG_BUILD=0
 
 # install ethtool - required for disabling TCP checksum offload in containers
-RUN apt-get update && apt-get install -y ethtool
+RUN apt-get update \
+ && apt-get install -y ethtool \
+ && rm -rf /var/lib/apt/lists/*
 
 # set work directory
 WORKDIR /root/


### PR DESCRIPTION
This PR removes the apt lists from the built dev image. These weren't removed before.