### PR TITLE
docker: build images using new Dockerfiles

### DIFF
--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -49,6 +49,6 @@ done
 cd ubuntu-based
 ./build.sh
 
-# builds all Alpine Linux -based images
-cd ../alpine-based
-./build.sh
+# builds the new images (vpp-cni, vpp-ksr, vpp-cri)
+cd ..
+./build-new.sh

--- a/docker/build-new.sh
+++ b/docker/build-new.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# fail in case of error
+set -euo pipefail
+
+# obtain the current git tag for tagging the Docker images
+TAG=`git describe --tags`
+DOCKER_BUILD_ARGS=${DOCKER_BUILD_ARGS-}
+
+cd ..
+
+docker build -t prod-contiv-cni:${TAG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-cni/Dockerfile .
+docker build -t prod-contiv-ksr:${TAG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-ksr/Dockerfile .
+docker build -t prod-contiv-cri:${TAG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-cri/Dockerfile .


### PR DESCRIPTION
This change makes the scripts build images basedon the new Dockerfiles.

The new images which are built using the new associated Dockerfile are:
- vpp-cni
- vpp-ksr
- vpp-cri

The other images are left as they are. Those need to be handled
separately.

Please keep in mind that I haven't removed the old Dockerfiles and their associated dev/prod directories. We need to check if the automated builds rely on those individual scripts. If they do rely on those individual scripts, I have to break up the build-new.sh script into multiple scripts which are stored in the directory of every image.