### PR TITLE
Install dpdk during vpp build

### DIFF
--- a/docker/ubuntu-based/dev/Dockerfile
+++ b/docker/ubuntu-based/dev/Dockerfile
@@ -30,7 +30,7 @@ RUN /bin/bash -c "if [ '${VPP_COMMIT_ID}' != 'xxx' ]; then \
         git checkout ${VPP_COMMIT_ID} && \
         rm -rf build-root/ && \
         git reset --hard HEAD && \
-        UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom' install-dep bootstrap pkg-deb; \
+        UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom' install-dep bootstrap dpdk-install-dev pkg-deb; \
     fi"
 
 # if VPP comit ID is specified and debug build is not skipped, run the debug build too


### PR DESCRIPTION
if the base ligato image is too old there might be old dpdk install the current version