### PR TITLE
Fix: Skip ipv6 addr errors while moving if to ns

### DIFF
--- a/vendor/github.com/ligato/vpp-agent/plugins/linuxplugin/ifplugin/linuxcalls/ns_linuxcalls.go
+++ b/vendor/github.com/ligato/vpp-agent/plugins/linuxplugin/ifplugin/linuxcalls/ns_linuxcalls.go
@@ -143,6 +143,9 @@ func SetInterfaceNamespace(ctx *NamespaceMgmtCtx, ifName string, namespace *intf
 		if err != nil {
 			if err.Error() == "file exists" {
 				continue
+			} else if len(ip) == net.IPv6len {
+				log.Warn("failed to add IPv6 addr", err)
+				continue
 			}
 			return fmt.Errorf("failed to assign IPv4 address to a Linux interface `%s`: %v", ifName, err)
 		}


### PR DESCRIPTION
 When a TAP is created OS might automatically assigns an IPv6 address. Once TAP is moved to container namespace we're trying to reassing all its IPs. The IPv6 addr can not be added due to the latest docker where  ipv6 disabled by default. Thus an attempt to assign ipv6 address results into error.

 This is a workaround in vendor that skips this kind of errors since we dont actually use the auto assigned IP.