### PR TITLE
Enable ipv6 in the container namespace

### DIFF
--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -849,10 +849,12 @@ func (s *remoteCNIserver) configurePodInterface(request *cni.CNIRequest, podIP n
 	// OS assigns automatically ipv6 addr to a newly created TAP. We
 	// try to reassign all IPs once interfaces is moved to a namespace. Without explicitly enabled ipv6,
 	// we receive an error while moving interface to a namespace.
-	err := s.enableIPv6(request)
-	if err != nil {
-		s.Logger.Error("unable to enable ipv6 in the namespace")
-		return err
+	if !s.test {
+		err := s.enableIPv6(request)
+		if err != nil {
+			s.Logger.Error("unable to enable ipv6 in the namespace")
+			return err
+		}
 	}
 
 	podIPCIDR := podIP.String() + "/32"
@@ -897,7 +899,7 @@ func (s *remoteCNIserver) configurePodInterface(request *cni.CNIRequest, podIP n
 	txn1.LinuxArpEntry(config.PodARPEntry)
 
 	// execute the config transaction
-	err = txn1.Send().ReceiveReply()
+	err := txn1.Send().ReceiveReply()
 	if err != nil {
 		s.Logger.Error(err)
 		return err

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -845,6 +845,16 @@ func (s *remoteCNIserver) unconfigureContainerConnectivity(request *cni.CNIReque
 // configurePodInterface configures POD's network interface and its routes + ARPs.
 func (s *remoteCNIserver) configurePodInterface(request *cni.CNIRequest, podIP net.IP, config *containeridx.Config) error {
 
+	// this is necessary for the latest docker where ipv6 is disabled by default.
+	// OS assigns automatically ipv6 addr to a newly created TAP. We
+	// try to reassign all IPs once interfaces is moved to a namespace. Without explicitly enabled ipv6,
+	// we receive an error while moving interface to a namespace.
+	err := s.enableIPv6(request)
+	if err != nil {
+		s.Logger.Error("unable to enable ipv6 in the namespace")
+		return err
+	}
+
 	podIPCIDR := podIP.String() + "/32"
 	podIPNet := &net.IPNet{
 		IP:   podIP,
@@ -887,7 +897,7 @@ func (s *remoteCNIserver) configurePodInterface(request *cni.CNIRequest, podIP n
 	txn1.LinuxArpEntry(config.PodARPEntry)
 
 	// execute the config transaction
-	err := txn1.Send().ReceiveReply()
+	err = txn1.Send().ReceiveReply()
 	if err != nil {
 		s.Logger.Error(err)
 		return err

--- a/vendor/github.com/ligato/vpp-agent/plugins/linuxplugin/ifplugin/linuxcalls/ns_linuxcalls.go
+++ b/vendor/github.com/ligato/vpp-agent/plugins/linuxplugin/ifplugin/linuxcalls/ns_linuxcalls.go
@@ -143,9 +143,6 @@ func SetInterfaceNamespace(ctx *NamespaceMgmtCtx, ifName string, namespace *intf
 		if err != nil {
 			if err.Error() == "file exists" {
 				continue
-			} else if len(ip) == net.IPv6len {
-				log.Warn("failed to add IPv6 addr", err)
-				continue
 			}
 			return fmt.Errorf("failed to assign IPv4 address to a Linux interface `%s`: %v", ifName, err)
 		}


### PR DESCRIPTION
 this replaces workaround introduced by #615
Calls `sysctl net.ipv6.conf.all.disable_ipv6=0` in namespace of pods. 