### PR TITLE
docker/ubuntu-based/dev: refactor Dockerfile

### DIFF
--- a/docker/ubuntu-based/dev/Dockerfile
+++ b/docker/ubuntu-based/dev/Dockerfile
@@ -1,16 +1,27 @@
-# update the version tag when moving to a new version of the vpp-agent
-FROM ligato/dev-vpp-agent:pantheon-dev
+FROM ubuntu:16.04
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    sudo wget git gdb nano python \
+    iproute2 iputils-ping inetutils-traceroute libapr1 supervisor \
+    telnet netcat software-properties-common \
+    make autoconf automake libtool curl unzip \
+    ethtool\
+ && apt-get remove -y --purge gcc \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /opt/vpp-agent/dev/vpp /opt/vpp-agent/plugin
+
+# install Go
+ENV GOLANG_VERSION 1.9.3
+RUN wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz" \
+ && tar -C /usr/local -xzf go.tgz \
+ && rm go.tgz
 
 # optional argument - a specific VPP commit ID
 ARG VPP_COMMIT_ID="xxx"
 
 # optional argument - skips debug build
 ARG SKIP_DEBUG_BUILD=0
-
-# install ethtool - required for disabling TCP checksum offload in containers
-RUN apt-get update \
- && apt-get install -y ethtool \
- && rm -rf /var/lib/apt/lists/*
 
 # set work directory
 WORKDIR /root/
@@ -22,22 +33,8 @@ ENV VPP_LIB_DIR $VPP_DIR/build-root/install-vpp_debug-native/vpp/lib64
 ENV VPP_BIN $VPP_BIN_DIR/vpp
 ENV LD_PRELOAD_LIB_DIR $VPP_LIB_DIR
 
-# if VPP comit ID is specified, update to specific VPP commit ID & rebuild
-RUN /bin/bash -c "if [ '${VPP_COMMIT_ID}' != 'xxx' ]; then \
-        cd ${VPP_DIR} && \
-        git checkout master && \
-        git pull && \
-        git checkout ${VPP_COMMIT_ID} && \
-        rm -rf build-root/ && \
-        git reset --hard HEAD && \
-        UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom' install-dep bootstrap dpdk-install-dev pkg-deb; \
-    fi"
-
-# if VPP comit ID is specified and debug build is not skipped, run the debug build too
-RUN /bin/bash -c "if [ '${VPP_COMMIT_ID}' != 'xxx' ] && [ '${SKIP_DEBUG_BUILD}' -eq 0 ]; then \
-        cd ${VPP_DIR} && \
-        make build; \
-    fi"
+COPY docker/ubuntu-based/dev/build-vpp.sh /
+RUN /build-vpp.sh
 
 # copy source files to the container
 COPY / /root/go/src/github.com/contiv/vpp
@@ -48,9 +45,9 @@ ENV GOPATH /root/go
 ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
 
 # build
-RUN cd $GOPATH/src/github.com/contiv/vpp && \
-    make && \
-    make install
+RUN cd $GOPATH/src/github.com/contiv/vpp \
+ && make \
+ && make install
 
 # add supervisord config file
 COPY docker/ubuntu-based/dev/supervisord.conf /etc/supervisord.conf

--- a/docker/ubuntu-based/dev/build-vpp.sh
+++ b/docker/ubuntu-based/dev/build-vpp.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd /opt/vpp-agent/dev/
+git clone https://gerrit.fd.io/r/vpp
+cd ${VPP_DIR}
+git checkout master
+git pull
+# check out a specific commit if specified
+# continue and ignore the error if the commit ID isn't specified
+git checkout ${VPP_COMMIT_ID} || true
+rm -rf build-root/
+git reset --hard HEAD
+UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom' install-dep
+apt-get remove --purge -y gcc gcc-5 g++ cpp-5
+add-apt-repository -y ppa:ubuntu-toolchain-r/test
+apt-get update
+apt-get install -y gcc-7 g++-7
+cd /usr/bin/
+ln -s gcc-7 gcc
+ln -s g++-7 g++
+ln -s cpp-7 cpp
+rm -rf /var/lib/apt/lists/*
+cd ${VPP_DIR}
+UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom' bootstrap dpdk-install-dev pkg-deb
+add-apt-repository -y ppa:ubuntu-toolchain-r/test
+cd build-root
+rm -rf .ccache \
+	build-vpp-native/vpp/vpp-api/vom \
+	build-vpp_debug-native/vpp/vpp-api/vom \
+	build-vpp_debug-native/vpp/vpp-api/java
+rm *java*.deb
+dpkg -i vpp_*.deb vpp-dev_*.deb vpp-lib_*.deb vpp-plugins_*.deb vpp-dbg_*.deb
+# run the debug build too if:
+# VPP commit ID is specified AND
+# the SKIP_DEBUG_BUILD env var is 0
+if [ '${VPP_COMMIT_ID}' != 'xxx' ] && [ '${SKIP_DEBUG_BUILD}' -eq 0 ]; then
+	cd ${VPP_DIR}
+	make build
+fi
+cd ${VPP_DIR}
+cd build-root
+rm -rf .ccache \
+	build-vpp-native/vpp/vpp-api/vom \
+	build-vpp_debug-native/vpp/vpp-api/vom \
+	build-vpp_debug-native/vpp/vpp-api/java
+find . -name '*.o' -exec rm '{}' \;
+
+apt-get remove --purge -y openjdk*
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This change refactors the Dockerfile to make the resulting image smaller. The resulting image is ~4.3 GB and there's no need to pull the large ligato image any more.