### PR TITLE
Properly cleanup NAT configuration after pod removal

### DIFF
--- a/plugins/contiv/plugin_api_contiv.go
+++ b/plugins/contiv/plugin_api_contiv.go
@@ -6,6 +6,8 @@ import (
 	"github.com/contiv/vpp/plugins/contiv/containeridx"
 )
 
+// PodActionHook defines parameters and the return value of a callback triggered
+// during an event associated with a pod.
 type PodActionHook func(podNamespace string, podName string) error
 
 // API for other plugins to query network-related information.

--- a/plugins/contiv/plugin_api_contiv.go
+++ b/plugins/contiv/plugin_api_contiv.go
@@ -6,6 +6,8 @@ import (
 	"github.com/contiv/vpp/plugins/contiv/containeridx"
 )
 
+type PodActionHook func(podNamespace string, podName string) error
+
 // API for other plugins to query network-related information.
 type API interface {
 	// GetIfName looks up logical interface name that corresponds to the interface
@@ -59,4 +61,8 @@ type API interface {
 	// GetDefaultGatewayIP returns the IP address of the default gateway for external traffic.
 	// If the default GW is not configured, the function returns nil.
 	GetDefaultGatewayIP() net.IP
+
+	// RegisterPodPreRemovalHook allows to register callback that will be run for each
+	// pod immediately before its removal.
+	RegisterPodPreRemovalHook(hook PodActionHook)
 }

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -311,6 +311,12 @@ func (plugin *Plugin) GetDefaultGatewayIP() net.IP {
 	return plugin.cniServer.GetDefaultGatewayIP()
 }
 
+// RegisterPodPreRemovalHook allows to register callback that will be run for each
+// pod immediately before its removal.
+func (plugin *Plugin) RegisterPodPreRemovalHook(hook PodActionHook) {
+	plugin.cniServer.RegisterPodPreRemovalHook(hook)
+}
+
 // handleResync handles resync events of the plugin. Called automatically by the plugin infra.
 func (plugin *Plugin) handleResync(resyncChan chan resync.StatusEvent) {
 	for {

--- a/plugins/service/processor/data_change.go
+++ b/plugins/service/processor/data_change.go
@@ -30,7 +30,7 @@ func (sc *ServiceProcessor) propagateDataChangeEv(dataChngEv datasync.ChangeEven
 	sc.Log.Debug("Received CHANGE key ", key)
 
 	// Process Pod CHANGE event
-	podName, podNs, err := podmodel.ParsePodFromKey(key)
+	_, _, err := podmodel.ParsePodFromKey(key)
 	if err == nil {
 		var value, prevValue podmodel.Pod
 
@@ -42,11 +42,11 @@ func (sc *ServiceProcessor) propagateDataChangeEv(dataChngEv datasync.ChangeEven
 			return err
 		}
 
-		// Process notification about a new/updated or deleted pod (add/del frontend).
-		if datasync.Delete == dataChngEv.GetChangeType() {
-			return sc.processDeletedPod(podmodel.ID{Name: podName, Namespace: podNs})
+		// Process notification about a new or updated pod.
+		if datasync.Delete != dataChngEv.GetChangeType() {
+			return sc.processUpdatedPod(&value)
 		}
-		return sc.processUpdatedPod(&value)
+		return nil
 	}
 
 	// Process Endpoints CHANGE event


### PR DESCRIPTION
NAT features have to be unassigned from interfaces BEFORE
they are removed. This is now enabled through hooks, registered
via Contiv plugin API, called immediatelly before a pod is removed.