### PR TITLE
VPP-side POD interface configurable CIDR and invalid VPP-side interface address fix

### DIFF
--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -28,6 +28,7 @@ data:
     IPAMConfig:
       PodSubnetCIDR: 10.1.0.0/16
       PodNetworkPrefixLen: 24
+      PodIfIPCIDR: 10.2.1.0/24
       VPPHostSubnetCIDR: 172.30.0.0/16
       VPPHostNetworkPrefixLen: 24
       NodeInterconnectCIDR: 192.168.16.0/24

--- a/plugins/contiv/ipam/ipam.go
+++ b/plugins/contiv/ipam/ipam.go
@@ -181,8 +181,11 @@ func (i *IPAM) VPPHostNetwork() *net.IPNet {
 }
 
 // VPPIfIPPrefix returns VPP-side interface IP address prefix.
-func (i *IPAM) VPPIfIPPrefix() net.IP {
-	return i.podIfIPCIDR.IP
+func (i *IPAM) VPPIfIPPrefix() *net.IP {
+	i.mutex.RLock()
+	defer i.mutex.RUnlock()
+	podIfIPPrefix := newIPNet(i.podIfIPCIDR) // defensive copy
+	return &podIfIPPrefix.IP
 }
 
 // OtherNodeVPPHostNetwork returns VPP-host network of another node identified by nodeID.

--- a/plugins/contiv/ipam/ipam_test.go
+++ b/plugins/contiv/ipam/ipam_test.go
@@ -41,6 +41,7 @@ var (
 
 func newDefaultConfig() *ipam.Config {
 	return &ipam.Config{
+		PodIfIPCIDR:             "10.2.1.0/24",
 		PodSubnetCIDR:           "1.2." + str(b10000000) + ".2/17",
 		PodNetworkPrefixLen:     29, // 3 bits left -> 6 free IP addresses (gateway IP + zero ending IP is reserved)
 		VPPHostSubnetCIDR:       "2.3." + str(b11000000) + ".2/18",

--- a/plugins/contiv/pod.go
+++ b/plugins/contiv/pod.go
@@ -145,7 +145,7 @@ func (s *remoteCNIserver) loopbackNameFromRequest(request *cni.CNIRequest) strin
 }
 
 func (s *remoteCNIserver) ipAddrForPodVPPIf(podIP string) string {
-	tapPrefix, _ := ipv4ToUint32(s.ipam.VPPIfIPPrefix())
+	tapPrefix, _ := ipv4ToUint32(*s.ipam.VPPIfIPPrefix())
 
 	podAddr, _ := ipv4ToUint32(net.ParseIP(podIP))
 	podMask, _ := ipv4ToUint32(net.IP(s.ipam.PodNetwork().Mask))

--- a/plugins/contiv/pod.go
+++ b/plugins/contiv/pod.go
@@ -144,8 +144,16 @@ func (s *remoteCNIserver) loopbackNameFromRequest(request *cni.CNIRequest) strin
 	return "loop" + s.veth2NameFromRequest(request)
 }
 
-func (s *remoteCNIserver) ipAddrForPodVPPIf() string {
-	return podIfIPPrefix + "." + strconv.Itoa(s.counter+1) + "/32"
+func (s *remoteCNIserver) ipAddrForPodVPPIf(podIP string) string {
+	tapPrefix, _ := ipv4ToUint32(s.ipam.VPPIfIPPrefix())
+
+	podAddr, _ := ipv4ToUint32(net.ParseIP(podIP))
+	podMask, _ := ipv4ToUint32(net.IP(s.ipam.PodNetwork().Mask))
+	podSuffix := podAddr &^ podMask
+
+	tapAddress := uint32ToIpv4(tapPrefix + podSuffix)
+
+	return net.IP.String(tapAddress) + "/32"
 }
 
 func (s *remoteCNIserver) hwAddrForContainer() string {
@@ -190,7 +198,7 @@ func (s *remoteCNIserver) veth2FromRequest(request *cni.CNIRequest) *linux_intf.
 	}
 }
 
-func (s *remoteCNIserver) afpacketFromRequest(request *cni.CNIRequest, configureContainerProxy bool, containerProxyIP string) *vpp_intf.Interfaces_Interface {
+func (s *remoteCNIserver) afpacketFromRequest(request *cni.CNIRequest, podIP string, configureContainerProxy bool, containerProxyIP string) *vpp_intf.Interfaces_Interface {
 	af := &vpp_intf.Interfaces_Interface{
 		Name:    s.afpacketNameFromRequest(request),
 		Type:    vpp_intf.InterfaceType_AF_PACKET_INTERFACE,
@@ -198,7 +206,7 @@ func (s *remoteCNIserver) afpacketFromRequest(request *cni.CNIRequest, configure
 		Afpacket: &vpp_intf.Interfaces_Interface_Afpacket{
 			HostIfName: s.veth2HostIfNameFromRequest(request),
 		},
-		IpAddresses: []string{s.ipAddrForPodVPPIf()},
+		IpAddresses: []string{s.ipAddrForPodVPPIf(podIP)},
 		PhysAddress: s.generateHwAddrForPodVPPIf(),
 	}
 	if configureContainerProxy {
@@ -207,7 +215,7 @@ func (s *remoteCNIserver) afpacketFromRequest(request *cni.CNIRequest, configure
 	return af
 }
 
-func (s *remoteCNIserver) tapFromRequest(request *cni.CNIRequest, configureContainerProxy bool, containerProxyIP string) *vpp_intf.Interfaces_Interface {
+func (s *remoteCNIserver) tapFromRequest(request *cni.CNIRequest, podIP string, configureContainerProxy bool, containerProxyIP string) *vpp_intf.Interfaces_Interface {
 	tap := &vpp_intf.Interfaces_Interface{
 		Name:    s.tapNameFromRequest(request),
 		Type:    vpp_intf.InterfaceType_TAP_INTERFACE,
@@ -215,7 +223,7 @@ func (s *remoteCNIserver) tapFromRequest(request *cni.CNIRequest, configureConta
 		Tap: &vpp_intf.Interfaces_Interface_Tap{
 			HostIfName: s.tapTmpHostNameFromRequest(request),
 		},
-		IpAddresses: []string{s.ipAddrForPodVPPIf()},
+		IpAddresses: []string{s.ipAddrForPodVPPIf(podIP)},
 		PhysAddress: s.generateHwAddrForPodVPPIf(),
 	}
 	if s.tapVersion == 2 {
@@ -345,4 +353,22 @@ func (s *remoteCNIserver) podDefaultRouteFromRequest(request *cni.CNIRequest, if
 		},
 		GwAddr: s.ipam.PodGatewayIP().String(),
 	}
+}
+
+// ipv4ToUint32 is simple utility function for conversion between IPv4 and uint32.
+func ipv4ToUint32(ip net.IP) (uint32, error) {
+	ip = ip.To4()
+	if ip == nil {
+		return 0, fmt.Errorf("Ip address %v is not ipv4 address (or ipv6 convertible to ipv4 address)", ip)
+	}
+	var tmp uint32
+	for _, bytePart := range ip {
+		tmp = tmp<<8 + uint32(bytePart)
+	}
+	return tmp, nil
+}
+
+// uint32ToIpv4 is simple utility function for conversion between IPv4 and uint32.
+func uint32ToIpv4(ip uint32) net.IP {
+	return net.IPv4(byte(ip>>24), byte(ip>>16), byte(ip>>8), byte(ip)).To4()
 }

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -59,7 +59,6 @@ const (
 	tapHostEndName                = "vpp1"
 	tapVPPEndLogicalName          = "tap-vpp2"
 	tapVPPEndName                 = "vpp2"
-	podIfIPPrefix                 = "10.2.1"
 	// HostInterconnectMAC is MAC address of tap that interconnects VPP with host stack
 	HostInterconnectMAC = "01:23:45:67:89:42"
 )
@@ -882,7 +881,7 @@ func (s *remoteCNIserver) configurePodInterface(request *cni.CNIRequest, podIP n
 	// create VPP to POD interconnect interface
 	if s.useTAPInterfaces {
 		// TAP interface
-		config.VppIf = s.tapFromRequest(request, !s.disableTCPstack, podIPCIDR)
+		config.VppIf = s.tapFromRequest(request, podIP.String(), !s.disableTCPstack, podIPCIDR)
 		config.PodTap = s.podTAP(request, podIPNet)
 
 		podIfName = config.PodTap.Name
@@ -893,7 +892,7 @@ func (s *remoteCNIserver) configurePodInterface(request *cni.CNIRequest, podIP n
 		// veth pair + AF_PACKET
 		config.Veth1 = s.veth1FromRequest(request, podIPCIDR)
 		config.Veth2 = s.veth2FromRequest(request)
-		config.VppIf = s.afpacketFromRequest(request, !s.disableTCPstack, podIPCIDR)
+		config.VppIf = s.afpacketFromRequest(request, podIP.String(), !s.disableTCPstack, podIPCIDR)
 
 		txn1.LinuxInterface(config.Veth1).
 			LinuxInterface(config.Veth2).

--- a/plugins/contiv/remote_cni_server_test.go
+++ b/plugins/contiv/remote_cni_server_test.go
@@ -77,6 +77,7 @@ var (
 		IPAMConfig: ipam.Config{
 			PodSubnetCIDR:           "10.1.0.0/16",
 			PodNetworkPrefixLen:     24,
+			PodIfIPCIDR:             "10.2.1.0/24",
 			VPPHostSubnetCIDR:       "172.30.0.0/16",
 			VPPHostNetworkPrefixLen: 24,
 			NodeInterconnectCIDR:    "192.168.16.0/24",
@@ -89,6 +90,7 @@ var (
 		IPAMConfig: ipam.Config{
 			PodSubnetCIDR:           "10.1.0.0/16",
 			PodNetworkPrefixLen:     24,
+			PodIfIPCIDR:             "10.2.1.0/24",
 			VPPHostSubnetCIDR:       "172.30.0.0/16",
 			VPPHostNetworkPrefixLen: 24,
 			NodeInterconnectCIDR:    "192.168.16.0/24",


### PR DESCRIPTION
This PR provides a way to configure through the contiv-vpp yaml file the
VPP-side POD interface CIDR.

Also fixes a bug where the same interface would get invalid addresses (>>255)
With this fix, addresses on the vpp-side (tap or afpacket) interface will mirror the last octet
of the POD ip address while using the subnet configured in the contiv-vpp yaml file.