### PR TITLE
Add MTU Size support and Configuration edit through Helm charts

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -54,6 +54,7 @@ To use the development image for testing with specific version of VPP, see
     - `StealTheNIC`: enable Steal The NIC feature on the first interface on each node;
     - `TAPv2RxRingSize`: number of entries to allocate for TAPv2 Rx ring (default is 256);
     - `TAPv2TxRingSize`: number of entries to allocate for TAPv2 Tx ring (default is 256).
+    - `MTUSize`: maximum transmission unit (MTU) size (default is 1500)
 
   * IPAM (section `IPAMConfig`)
     - `PodSubnetCIDR`: subnet used for all pods across all nodes;

--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -34,6 +34,7 @@ data:
       NodeInterconnectCIDR: 192.168.16.0/24
       VxlanCIDR: 192.168.30.0/24
       NodeInterconnectDHCP: False
+      MTUSize: 1500
   logs.conf: |
     defaultlevel: debug
 

--- a/k8s/contiv-vpp/README.md
+++ b/k8s/contiv-vpp/README.md
@@ -53,6 +53,7 @@ The following tables lists the configurable parameters of the Contiv-VPP chart a
 
 Parameter | Description | Default
 --------- | ----------- | -------
+`contiv.mtuSize` | MTU Size | 1500
 `contiv.tcpStackDisabled` | Disable TCP stack | `True`
 `contiv.useTAPInterfaces` | Enable TAP interfaces | `True`
 `contiv.tapInterfaceVersion`| TAP interface version | 1

--- a/k8s/contiv-vpp/templates/vpp.yaml
+++ b/k8s/contiv-vpp/templates/vpp.yaml
@@ -25,6 +25,7 @@ data:
     TAPInterfaceVersion: {{ .Values.contiv.tapInterfaceVersion }}
     {{- if .Values.contiv.stealTheNIC }}
     StealTheNIC: True
+    MTUSize: {{ .Values.contiv.mtuSize }}
     {{- end }}
     IPAMConfig:
       PodSubnetCIDR: {{ .Values.contiv.ipamConfig.podSubnetCIDR }}

--- a/k8s/contiv-vpp/templates/vpp.yaml
+++ b/k8s/contiv-vpp/templates/vpp.yaml
@@ -25,8 +25,8 @@ data:
     TAPInterfaceVersion: {{ .Values.contiv.tapInterfaceVersion }}
     {{- if .Values.contiv.stealTheNIC }}
     StealTheNIC: True
-    MTUSize: {{ .Values.contiv.mtuSize }}
     {{- end }}
+    MTUSize: {{ .Values.contiv.mtuSize }}
     IPAMConfig:
       PodSubnetCIDR: {{ .Values.contiv.ipamConfig.podSubnetCIDR }}
       PodNetworkPrefixLen: {{ .Values.contiv.ipamConfig.podNetworkPrefixLen }}

--- a/k8s/contiv-vpp/values.yaml
+++ b/k8s/contiv-vpp/values.yaml
@@ -3,6 +3,7 @@ contiv:
   useTAPInterfaces: True
   tapInterfaceVersion: 1
   stealTheNIC: False
+  mtuSize: 1500
   ipamConfig:
     podSubnetCIDR: "10.1.0.0/16"
     podNetworkPrefixLen: 24

--- a/plugins/contiv/host.go
+++ b/plugins/contiv/host.go
@@ -113,6 +113,7 @@ func (s *remoteCNIserver) interconnectTap() *vpp_intf.Interfaces_Interface {
 	tap := &vpp_intf.Interfaces_Interface{
 		Name:    TapVPPEndLogicalName,
 		Type:    vpp_intf.InterfaceType_TAP_INTERFACE,
+		Mtu:     s.config.MTUSize,
 		Enabled: true,
 		Tap: &vpp_intf.Interfaces_Interface_Tap{
 			HostIfName: TapHostEndName,
@@ -133,6 +134,7 @@ func (s *remoteCNIserver) interconnectTapHost() *linux_intf.LinuxInterfaces_Inte
 	size, _ := s.ipam.VPPHostNetwork().Mask.Size()
 	return &linux_intf.LinuxInterfaces_Interface{
 		Name:        TapHostEndLogicalName,
+		Mtu:         s.config.MTUSize,
 		HostIfName:  TapHostEndName,
 		Type:        linux_intf.LinuxInterfaces_AUTO_TAP,
 		Enabled:     true,
@@ -145,6 +147,7 @@ func (s *remoteCNIserver) interconnectVethHost() *linux_intf.LinuxInterfaces_Int
 	return &linux_intf.LinuxInterfaces_Interface{
 		Name:       vethHostEndLogicalName,
 		Type:       linux_intf.LinuxInterfaces_VETH,
+		Mtu:        s.config.MTUSize,
 		Enabled:    true,
 		HostIfName: vethHostEndName,
 		Veth: &linux_intf.LinuxInterfaces_Interface_Veth{
@@ -158,6 +161,7 @@ func (s *remoteCNIserver) interconnectVethVpp() *linux_intf.LinuxInterfaces_Inte
 	return &linux_intf.LinuxInterfaces_Interface{
 		Name:       vethVPPEndLogicalName,
 		Type:       linux_intf.LinuxInterfaces_VETH,
+		Mtu:        s.config.MTUSize,
 		Enabled:    true,
 		HostIfName: vethVPPEndName,
 		Veth: &linux_intf.LinuxInterfaces_Interface_Veth{
@@ -175,6 +179,7 @@ func (s *remoteCNIserver) interconnectAfpacket() *vpp_intf.Interfaces_Interface 
 	return &vpp_intf.Interfaces_Interface{
 		Name:    s.interconnectAfpacketName(),
 		Type:    vpp_intf.InterfaceType_AF_PACKET_INTERFACE,
+		Mtu:     s.config.MTUSize,
 		Enabled: true,
 		Afpacket: &vpp_intf.Interfaces_Interface_Afpacket{
 			HostIfName: vethVPPEndName,

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"net"
 
+	"strings"
+
 	"git.fd.io/govpp.git/api"
 	"github.com/contiv/vpp/plugins/contiv/containeridx"
 	"github.com/contiv/vpp/plugins/contiv/ipam"
@@ -39,7 +41,6 @@ import (
 	linuxlocalclient "github.com/ligato/vpp-agent/clientv1/linux/localclient"
 	"github.com/ligato/vpp-agent/plugins/defaultplugins"
 	"github.com/ligato/vpp-agent/plugins/govppmux"
-	"strings"
 )
 
 // Plugin represents the instance of the Contiv network plugin, that transforms CNI requests recieved over
@@ -90,6 +91,7 @@ type Config struct {
 	TAPInterfaceVersion        uint8
 	TAPv2RxRingSize            uint16
 	TAPv2TxRingSize            uint16
+	MTUSize                    uint32
 	StealTheNIC                bool
 	IPAMConfig                 ipam.Config
 	NodeConfig                 []OneNodeConfig

--- a/plugins/contiv/pod.go
+++ b/plugins/contiv/pod.go
@@ -172,6 +172,7 @@ func (s *remoteCNIserver) veth1FromRequest(request *cni.CNIRequest, podIP string
 	return &linux_intf.LinuxInterfaces_Interface{
 		Name:        s.veth1NameFromRequest(request),
 		Type:        linux_intf.LinuxInterfaces_VETH,
+		Mtu:         s.config.MTUSize,
 		Enabled:     true,
 		HostIfName:  s.veth1HostIfNameFromRequest(request),
 		PhysAddress: s.hwAddrForContainer(),
@@ -190,6 +191,7 @@ func (s *remoteCNIserver) veth2FromRequest(request *cni.CNIRequest) *linux_intf.
 	return &linux_intf.LinuxInterfaces_Interface{
 		Name:       s.veth2NameFromRequest(request),
 		Type:       linux_intf.LinuxInterfaces_VETH,
+		Mtu:        s.config.MTUSize,
 		Enabled:    true,
 		HostIfName: s.veth2HostIfNameFromRequest(request),
 		Veth: &linux_intf.LinuxInterfaces_Interface_Veth{
@@ -202,6 +204,7 @@ func (s *remoteCNIserver) afpacketFromRequest(request *cni.CNIRequest, podIP str
 	af := &vpp_intf.Interfaces_Interface{
 		Name:    s.afpacketNameFromRequest(request),
 		Type:    vpp_intf.InterfaceType_AF_PACKET_INTERFACE,
+		Mtu:     s.config.MTUSize,
 		Enabled: true,
 		Afpacket: &vpp_intf.Interfaces_Interface_Afpacket{
 			HostIfName: s.veth2HostIfNameFromRequest(request),
@@ -219,6 +222,7 @@ func (s *remoteCNIserver) tapFromRequest(request *cni.CNIRequest, podIP string, 
 	tap := &vpp_intf.Interfaces_Interface{
 		Name:    s.tapNameFromRequest(request),
 		Type:    vpp_intf.InterfaceType_TAP_INTERFACE,
+		Mtu:     s.config.MTUSize,
 		Enabled: true,
 		Tap: &vpp_intf.Interfaces_Interface_Tap{
 			HostIfName: s.tapTmpHostNameFromRequest(request),
@@ -241,6 +245,7 @@ func (s *remoteCNIserver) podTAP(request *cni.CNIRequest, podIPNet *net.IPNet) *
 	return &linux_intf.LinuxInterfaces_Interface{
 		Name:    "pod-" + s.tapTmpHostNameFromRequest(request),
 		Type:    linux_intf.LinuxInterfaces_AUTO_TAP,
+		Mtu:     s.config.MTUSize,
 		Enabled: true,
 		Tap: &linux_intf.LinuxInterfaces_Interface_Tap{
 			TempIfName: s.tapTmpHostNameFromRequest(request),


### PR DESCRIPTION
This PR adds support to make MTU size configurable through Helm charts and contiv-vpp.yaml. 

Added MTU field on Af_packet and tap interface configuration to support different MTU sizes. 
Field was added to Pod-VPP and interconnectAfpacket/interconnectTapHost interfaces 