### PR TITLE
Expose NodePort services also on the internal (host) node IP

### DIFF
--- a/plugins/service/configurator/configurator_api.go
+++ b/plugins/service/configurator/configurator_api.go
@@ -44,6 +44,10 @@ type ServiceConfiguratorAPI interface {
 	// service.
 	DeleteService(service *ContivService) error
 
+	// UpdateNodePortServices updates configuration of nodeport services to reflect
+	// changed internal node IP (IP used by Kubernetes).
+	UpdateNodePortServices(nodeInternalIP net.IP, npServices []*ContivService) error
+
 	// UpdateLocalFrontendIfs updates the list of interfaces connecting clients
 	// with VPP (enabled out2in VPP/NAT feature).
 	UpdateLocalFrontendIfs(oldIfNames, newIfNames Interfaces) error
@@ -328,6 +332,9 @@ func (ifs Interfaces) String() string {
 
 // ResyncEventData wraps an entire state of K8s services.
 type ResyncEventData struct {
+	// NodeInternalIP is the IP address of the node as used by Kubernetes (including kube-proxy).
+	NodeInternalIP net.IP
+
 	// ExternalSNAT contains configuration of SNAT, installed to allow access outside the cluster network.
 	ExternalSNAT ExternalSNATConfig
 
@@ -359,8 +366,9 @@ func (red ResyncEventData) String() string {
 			services += ", "
 		}
 	}
-	return fmt.Sprintf("ResyncEventData <%s Services:[%s], FrontendIfs:%s BackendIfs:%s>",
-		red.ExternalSNAT.String(), services, red.FrontendIfs.String(), red.BackendIfs.String())
+	return fmt.Sprintf("ResyncEventData <NodeInternalIP:%s %s Services:[%s], FrontendIfs:%s BackendIfs:%s>",
+		red.NodeInternalIP.String(), red.ExternalSNAT.String(), services, red.FrontendIfs.String(),
+		red.BackendIfs.String())
 }
 
 // ExternalSNATConfig encapsulates configuration concerning SNAT, installed to allow Internet access for pods.

--- a/plugins/service/plugin_impl_service.go
+++ b/plugins/service/plugin_impl_service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/contiv/vpp/plugins/service/processor"
 
 	epmodel "github.com/contiv/vpp/plugins/ksr/model/endpoints"
+	nodemodel "github.com/contiv/vpp/plugins/ksr/model/node"
 	podmodel "github.com/contiv/vpp/plugins/ksr/model/pod"
 	svcmodel "github.com/contiv/vpp/plugins/ksr/model/service"
 )
@@ -135,7 +136,7 @@ func (p *Plugin) AfterInit() error {
 func (p *Plugin) subscribeWatcher() (err error) {
 	p.watchConfigReg, err = p.Watcher.
 		Watch("K8s services", p.changeChan, p.resyncChan,
-			epmodel.KeyPrefix(), podmodel.KeyPrefix(), svcmodel.KeyPrefix())
+			epmodel.KeyPrefix(), podmodel.KeyPrefix(), svcmodel.KeyPrefix(), nodemodel.KeyPrefix())
 	return err
 }
 


### PR DESCRIPTION
NodePort services should be accessible on both the VPP node IP and the host node IP (without STN these are two different interfaces).