### PR TITLE
Run nodeport DNAT already on the source node.

### DIFF
--- a/plugins/contiv/node_events.go
+++ b/plugins/contiv/node_events.go
@@ -65,7 +65,7 @@ func (s *remoteCNIserver) nodeResync(dataResyncEv datasync.ResyncEvent) error {
 	data := dataResyncEv.GetValues()
 
 	for prefix, it := range data {
-		if prefix == allocatedIDsKeyPrefix {
+		if prefix == AllocatedIDsKeyPrefix {
 			for {
 				kv, stop := it.GetNext()
 				if stop {
@@ -109,7 +109,7 @@ func (s *remoteCNIserver) nodeChangePropageteEvent(dataChngEv datasync.ChangeEve
 	key := dataChngEv.GetKey()
 	var err error
 
-	if strings.HasPrefix(key, allocatedIDsKeyPrefix) {
+	if strings.HasPrefix(key, AllocatedIDsKeyPrefix) {
 		nodeInfo := &node.NodeInfo{}
 		err = dataChngEv.GetValue(nodeInfo)
 		if err != nil {

--- a/plugins/contiv/node_id_allocator.go
+++ b/plugins/contiv/node_id_allocator.go
@@ -30,8 +30,11 @@ import (
 )
 
 const (
-	allocatedIDsKeyPrefix = "allocatedIDs/"
-	maxAttempts           = 10
+	// AllocatedIDsKeyPrefix is a key prefix used in ETCD to store information
+	// about node ID and its IP addresses.
+	AllocatedIDsKeyPrefix = "allocatedIDs/"
+
+	maxAttempts = 10
 )
 
 var (
@@ -195,7 +198,7 @@ func (ia *idAllocator) writeIfNotExists(id uint32) (succeeded bool, err error) {
 // to the serviceLabel
 func (ia *idAllocator) findExistingEntry(broker keyval.ProtoBroker) (id *node.NodeInfo, err error) {
 	var existingEntry *node.NodeInfo
-	it, err := broker.ListValues(allocatedIDsKeyPrefix)
+	it, err := broker.ListValues(AllocatedIDsKeyPrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +242,7 @@ func findFirstAvailableIndex(ids []int) int {
 
 // listAllIDs returns slice that contains allocated ids i.e.: ids assigned to a node
 func listAllIDs(broker keyval.ProtoBroker) (ids []int, err error) {
-	it, err := broker.ListKeys(allocatedIDsKeyPrefix)
+	it, err := broker.ListKeys(AllocatedIDsKeyPrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -263,8 +266,8 @@ func listAllIDs(broker keyval.ProtoBroker) (ids []int, err error) {
 }
 
 func extractIndexFromKey(key string) (int, error) {
-	if strings.HasPrefix(key, allocatedIDsKeyPrefix) {
-		return strconv.Atoi(strings.Replace(key, allocatedIDsKeyPrefix, "", 1))
+	if strings.HasPrefix(key, AllocatedIDsKeyPrefix) {
+		return strconv.Atoi(strings.Replace(key, AllocatedIDsKeyPrefix, "", 1))
 
 	}
 	return 0, errInvalidKey
@@ -272,5 +275,5 @@ func extractIndexFromKey(key string) (int, error) {
 
 func createKey(index uint32) string {
 	str := strconv.FormatUint(uint64(index), 10)
-	return allocatedIDsKeyPrefix + str
+	return AllocatedIDsKeyPrefix + str
 }

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -152,7 +152,7 @@ func (plugin *Plugin) Init() error {
 	plugin.resyncCh = make(chan datasync.ResyncEvent)
 	plugin.changeCh = make(chan datasync.ChangeEvent)
 
-	plugin.nodeIDwatchReg, err = plugin.Watcher.Watch("contiv-plugin-ids", plugin.nodeIDSchangeChan, plugin.nodeIDsresyncChan, allocatedIDsKeyPrefix)
+	plugin.nodeIDwatchReg, err = plugin.Watcher.Watch("contiv-plugin-ids", plugin.nodeIDSchangeChan, plugin.nodeIDsresyncChan, AllocatedIDsKeyPrefix)
 	if err != nil {
 		return err
 	}

--- a/plugins/contiv/remote_cni_server_test.go
+++ b/plugins/contiv/remote_cni_server_test.go
@@ -525,7 +525,7 @@ func (e nodeAddDelEvent) GetChangeType() datasync.PutDel {
 }
 
 func (e nodeAddDelEvent) GetKey() string {
-	return allocatedIDsKeyPrefix
+	return AllocatedIDsKeyPrefix
 }
 
 func (e nodeAddDelEvent) GetValue(value proto.Message) error {

--- a/plugins/service/plugin_impl_service.go
+++ b/plugins/service/plugin_impl_service.go
@@ -32,7 +32,6 @@ import (
 	"github.com/contiv/vpp/plugins/service/processor"
 
 	epmodel "github.com/contiv/vpp/plugins/ksr/model/endpoints"
-	nodemodel "github.com/contiv/vpp/plugins/ksr/model/node"
 	podmodel "github.com/contiv/vpp/plugins/ksr/model/pod"
 	svcmodel "github.com/contiv/vpp/plugins/ksr/model/service"
 )
@@ -136,7 +135,7 @@ func (p *Plugin) AfterInit() error {
 func (p *Plugin) subscribeWatcher() (err error) {
 	p.watchConfigReg, err = p.Watcher.
 		Watch("K8s services", p.changeChan, p.resyncChan,
-			epmodel.KeyPrefix(), podmodel.KeyPrefix(), svcmodel.KeyPrefix(), nodemodel.KeyPrefix())
+			epmodel.KeyPrefix(), podmodel.KeyPrefix(), svcmodel.KeyPrefix(), contiv.AllocatedIDsKeyPrefix)
 	return err
 }
 

--- a/plugins/service/processor/data_resync.go
+++ b/plugins/service/processor/data_resync.go
@@ -18,13 +18,14 @@ package processor
 
 import (
 	"fmt"
-	"net"
+	"strings"
 
 	"github.com/ligato/cn-infra/datasync"
 	"github.com/ligato/cn-infra/logging"
 
+	"github.com/contiv/vpp/plugins/contiv"
+	nodemodel "github.com/contiv/vpp/plugins/contiv/model/node"
 	epmodel "github.com/contiv/vpp/plugins/ksr/model/endpoints"
-	nodemodel "github.com/contiv/vpp/plugins/ksr/model/node"
 	podmodel "github.com/contiv/vpp/plugins/ksr/model/pod"
 	svcmodel "github.com/contiv/vpp/plugins/ksr/model/service"
 )
@@ -32,15 +33,16 @@ import (
 // ResyncEventData wraps an entire state of K8s services that should be reflected
 // into VPP.
 type ResyncEventData struct {
-	NodeInternalIP net.IP
-	Pods           []*podmodel.Pod
-	Endpoints      []*epmodel.Endpoints
-	Services       []*svcmodel.Service
+	Nodes     map[int]*nodemodel.NodeInfo
+	Pods      []*podmodel.Pod
+	Endpoints []*epmodel.Endpoints
+	Services  []*svcmodel.Service
 }
 
 // NewResyncEventData creates an empty instance of ResyncEventData.
 func NewResyncEventData() *ResyncEventData {
 	return &ResyncEventData{
+		Nodes:     make(map[int]*nodemodel.NodeInfo),
 		Pods:      []*podmodel.Pod{},
 		Endpoints: []*epmodel.Endpoints{},
 		Services:  []*svcmodel.Service{},
@@ -70,16 +72,17 @@ func (red ResyncEventData) String() string {
 			services += ", "
 		}
 	}
-	return fmt.Sprintf("ResyncEventData <NodeInternalIP:%s Pods:[%s] Endpoint:[%s] Services:[%s]>",
-		red.NodeInternalIP.String(), pods, endpoints, services)
+	return fmt.Sprintf("ResyncEventData <Nodes:%v Pods:[%s] Endpoint:[%s] Services:[%s]>",
+		red.Nodes, pods, endpoints, services)
 }
 
 func (sc *ServiceProcessor) parseResyncEv(resyncEv datasync.ResyncEvent) *ResyncEventData {
 	var (
-		numPod int
-		numEps int
-		numSvc int
-		err    error
+		numNodes int
+		numPod   int
+		numEps   int
+		numSvc   int
+		err      error
 	)
 
 	event := NewResyncEventData()
@@ -94,6 +97,17 @@ func (sc *ServiceProcessor) parseResyncEv(resyncEv datasync.ResyncEvent) *Resync
 				break
 			}
 			key := evData.GetKey()
+
+			// Parse node RESYNC event
+			if strings.HasPrefix(key, contiv.AllocatedIDsKeyPrefix) {
+				value := &nodemodel.NodeInfo{}
+				err := evData.GetValue(value)
+				if err == nil {
+					event.Nodes[int(value.Id)] = value
+					numNodes++
+				}
+				continue
+			}
 
 			// Parse pod RESYNC event
 			_, _, err = podmodel.ParsePodFromKey(key)
@@ -130,25 +144,14 @@ func (sc *ServiceProcessor) parseResyncEv(resyncEv datasync.ResyncEvent) *Resync
 				}
 				continue
 			}
-
-			// Parse node RESYNC event
-			nodeName, err := nodemodel.ParseNodeFromKey(key)
-			if err == nil && nodeName == sc.ServiceLabel.GetAgentLabel() {
-				value := &nodemodel.Node{}
-				err := evData.GetValue(value)
-				if err == nil {
-					event.NodeInternalIP = sc.getNodeInternalIP(value)
-				}
-				continue
-			}
 		}
 	}
 
 	sc.Log.WithFields(logging.Fields{
-		"num-pods":         numPod,
-		"num-endpoints":    numEps,
-		"num-services":     numSvc,
-		"node-internal-IP": event.NodeInternalIP,
+		"num-nodes":     numNodes,
+		"num-pods":      numPod,
+		"num-endpoints": numEps,
+		"num-services":  numSvc,
 	}).Debug("Parsed RESYNC event")
 
 	return event


### PR DESCRIPTION
DNAT for nodeport services has to execute already on the source node. If run on the destination node instead and the selected backend is not on the destination node, then the response takes a different route and does not get SNATed before reaching the source pod.