### PR TITLE
Kube-proxy has to learn the Pod CIDR.

### DIFF
--- a/docs/MANUAL_INSTALL.md
+++ b/docs/MANUAL_INSTALL.md
@@ -187,15 +187,23 @@ previously installed K8s components. Then, proceed with master initialization
 as described in the [kubeadm manual][3]. Execute the following command as
 root:
 ```
-kubeadm init --token-ttl 0
+kubeadm init --token-ttl 0 --pod-network-cidr=10.1.0.0/16
 ```
-Note that the above command will autodetect the network interface to advertise
+The CIDR specified with the flag `--pod-network-cidr` is used by kube-proxy
+and must match `PodSubnetCIDR` from the `IPAMConfig` section of the `contiv.yaml`
+configuration file, defined in the Contiv-VPP [deployment YAML file](../k8s/contiv-vpp.yaml).
+A special case are pods in the host network namespace, which will share interfaces
+and their IP addresses with the host. For services with backends running in the host
+it is therefore required to select node management IP from `PodSubnetCIDR`
+for proxying to work properly.
+
+Also note that `kubeadm init` will autodetect the network interface to advertise
 the master on as the interface with the default gateway. If you want to use a
 different interface (i.e. a custom management network setup), specify the
 `--apiserver-advertise-address=<ip-address>` argument to kubeadm init. For
 example:
 ```
-kubeadm init --token-ttl 0  --apiserver-advertise-address=192.168.56.106
+kubeadm init --token-ttl 0 --pod-network-cidr=10.1.0.0/16 --apiserver-advertise-address=192.168.56.106
 ```
 If Kubernetes was initialized successfully, it prints out this message:
 ```


### PR DESCRIPTION
This pull request updates manual with new findings about kube-proxy. Re-wording with cleaner english is of course welcomed. We will have to update vagrantfiles to reflect this.

It is necessary to pass pod CIDR to `kubeadm init` via the `--pod-network-cidr` flag.  Kubeadm will store this value to `/var/lib/kube-proxy/config.conf` in the kube-proxy container as `clusterCIDR`. Kube-proxy needs to know the range of pod IP addresses in order to know which connections should be proxied (if unset nothing is proxied and connections initiated from the same host work only by accident).

For service backends deployed in the host network namespace to be proxied as well, the node management IP, which they have assigned, must also fall into the pod CIDR (TBD in IPAM: avoid collisions with pods). This is the case of the following two tests:
```
k8s_tests/connectivity/test_ping.py::test_wget_to_service_variants_from_pod_variants[pod{hostNetwork,master}-webserver{hostNetwork,master}]
k8s_tests/connectivity/test_ping.py::test_wget_to_service_variants_from_pod_variants[pod{hostNetwork}-webserver{hostNetwork}]
```

For example, for Pod CIDR `10.1.0.0/16`, I have selected `10.1.200.1` for master and `10.1.200.2` for worker to have everything proxied properly (notice the first two pods which are in the host net ns and their IPs):

```
NAMESPACE     NAME                               READY     STATUS     RESTARTS   AGE       IP           NODE
default       k8s-systest-test                   1/1       Running    0          21m       10.1.200.2   lubuntu2
default       k8s-systest-webserver-test         1/1       Running    0          23m       10.1.200.2   lubuntu2
kube-system   contiv-etcd-d5dxh                  1/1       Running    0          26m       10.1.200.1   lubuntu1
kube-system   contiv-ksr-wshtz                   1/1       Running    1          26m       10.1.200.1   lubuntu1
kube-system   contiv-vswitch-hf4qz               2/2       Running    0          25m       10.1.200.2   lubuntu2
kube-system   contiv-vswitch-ksc66               2/2       Running    0          26m       10.1.200.1   lubuntu1
kube-system   etcd-lubuntu1                      1/1       Running    0          26m       10.1.200.1   lubuntu1
kube-system   kube-apiserver-lubuntu1            1/1       Running    0          25m       10.1.200.1   lubuntu1
kube-system   kube-controller-manager-lubuntu1   1/1       Running    0          25m       10.1.200.1   lubuntu1
kube-system   kube-dns-6f4fd4bdf-nkp5p           3/3       Running    0          26m       10.1.1.2     lubuntu1
kube-system   kube-proxy-ckvq5                   1/1       Running    0          25m       10.1.200.2   lubuntu2
kube-system   kube-proxy-wkg9k                   1/1       Running    0          26m       10.1.200.1   lubuntu1
kube-system   kube-scheduler-lubuntu1            1/1       Running    0          26m       10.1.200.1   lubuntu1
```