### PR TITLE
Add pod-network-cidr flag on kubeadm init.

### DIFF
--- a/vagrant/Vagrantfiles/virtualbox-dev
+++ b/vagrant/Vagrantfiles/virtualbox-dev
@@ -196,7 +196,9 @@ source /home/vagrant/.profile
 sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
-echo "$(kubeadm init --token-ttl 0 --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
+cd /home/vagrant/gopath/src/github.com/contiv/vpp/k8s
+POD_SUBNET_CIDR=$(grep -A0 'PodSubnetCIDR:' contiv-vpp.yaml | tail -n1 | awk '{ print $2}')
+echo "$(kubeadm init --token-ttl 0 --pod-network-cidr="${POD_SUBNET_CIDR}" --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
 
 echo "Create folder to store kubernetes and network configuration"
 mkdir -p /home/vagrant/.kube
@@ -207,7 +209,7 @@ echo "Installing Contiv-VPP networking as user"
 sudo -u vagrant -H bash << EOF
 
 echo "Installing Pod Network..."
-kubectl apply -f https://raw.githubusercontent.com/contiv/vpp/master/k8s/contiv-vpp.yaml
+kubectl apply -f /home/vagrant/gopath/src/github.com/contiv/vpp/k8s/contiv-vpp.yaml
 
 echo "Schedule Pods on master"
 kubectl taint nodes --all node-role.kubernetes.io/master-

--- a/vagrant/Vagrantfiles/virtualbox-prod
+++ b/vagrant/Vagrantfiles/virtualbox-prod
@@ -177,7 +177,9 @@ source /home/vagrant/.profile
 sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
-echo "$(kubeadm init --token-ttl 0 --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
+curl --silent https://raw.githubusercontent.com/contiv/vpp/master/k8s/contiv-vpp.yaml > /tmp/contiv-vpp.yaml
+POD_SUBNET_CIDR=$(grep -A0 'PodSubnetCIDR:' /tmp/contiv-vpp.yaml | tail -n1 | awk '{ print $2}')
+echo "$(kubeadm init --token-ttl 0 --pod-network-cidr="${POD_SUBNET_CIDR}" --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
 
 echo "Create folder to store kubernetes and network configuration"
 mkdir -p /home/vagrant/.kube

--- a/vagrant/Vagrantfiles/vmware-dev
+++ b/vagrant/Vagrantfiles/vmware-dev
@@ -195,7 +195,9 @@ source /home/vagrant/.profile
 sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
-echo "$(kubeadm init --token-ttl 0 --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
+cd /home/vagrant/gopath/src/github.com/contiv/vpp/k8s
+POD_SUBNET_CIDR=$(grep -A0 'PodSubnetCIDR:' contiv-vpp.yaml | tail -n1 | awk '{ print $2}')
+echo "$(kubeadm init --token-ttl 0 --pod-network-cidr="${POD_SUBNET_CIDR}" --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
 
 echo "Create folder to store kubernetes and network configuration"
 mkdir -p /home/vagrant/.kube
@@ -206,7 +208,7 @@ echo "Installing Contiv-VPP networking as user"
 sudo -u vagrant -H bash << EOF
 
 echo "Installing Pod Network..."
-kubectl apply -f https://raw.githubusercontent.com/contiv/vpp/master/k8s/contiv-vpp.yaml
+kubectl apply -f /home/vagrant/gopath/src/github.com/contiv/vpp/k8s/contiv-vpp.yaml
 
 echo "Schedule Pods on master"
 kubectl taint nodes --all node-role.kubernetes.io/master-

--- a/vagrant/Vagrantfiles/vmware-prod
+++ b/vagrant/Vagrantfiles/vmware-prod
@@ -170,7 +170,9 @@ source /home/vagrant/.profile
 sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
-echo "$(kubeadm init --token-ttl 0 --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
+curl --silent https://raw.githubusercontent.com/contiv/vpp/master/k8s/contiv-vpp.yaml > /tmp/contiv-vpp.yaml
+POD_SUBNET_CIDR=$(grep -A0 'PodSubnetCIDR:' /tmp/contiv-vpp.yaml | tail -n1 | awk '{ print $2}')
+echo "$(kubeadm init --token-ttl 0 --pod-network-cidr="${POD_SUBNET_CIDR}" --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
 
 echo "Create folder to store kubernetes and network configuration"
 mkdir -p /home/vagrant/.kube


### PR DESCRIPTION
This PR updates the Vagrantfiles to reflect the changes in #649,
where kube-proxy has to learn the Pod CIDR.