### PR TITLE
Fix uncofigure container connectivity after restart

### DIFF
--- a/vendor/github.com/ligato/vpp-agent/plugins/linuxplugin/ifplugin/interface_config.go
+++ b/vendor/github.com/ligato/vpp-agent/plugins/linuxplugin/ifplugin/interface_config.go
@@ -685,11 +685,12 @@ func (plugin *LinuxInterfaceConfigurator) deleteVethInterface(ifConfig, peerConf
 // Un-configure TAP interface, set original name and return it to the default namespace (do not delete,
 // the interface will be removed together with the peer (VPP TAP))
 func (plugin *LinuxInterfaceConfigurator) deleteTapInterface(ifConfig *LinuxInterfaceConfig) error {
-	plugin.Log.Debugf("Removing Linux TAP configuration %v from interface %v ", ifConfig.config.Name, ifConfig.config.HostIfName)
 	if ifConfig == nil || ifConfig.config == nil {
 		plugin.Log.Warn("Unable to remove linux TAP configuration: no data available")
 		return nil
 	}
+	plugin.Log.Debugf("Removing Linux TAP configuration %v from interface %v ", ifConfig.config.Name, ifConfig.config.HostIfName)
+
 	if !plugin.isNamespaceAvailable(ifConfig.config.Namespace) {
 		plugin.Log.Warnf("Unable to remove linux TAP configuration: cannot access namespace %v", ifConfig.config.Namespace.Name)
 		return nil


### PR DESCRIPTION
This PR fixes removing of config related to container connectivity (tap, arp, route...) after vswitch restart.

TL;DR

Contiv-vswitch uses `CompositeKVProtoWatcher` where proxied etcd and local client are grouped, as datasource for defaultplugins (see [contiv_flavor.go](https://github.com/contiv/vpp/blob/master/flavors/contiv/contiv_flavor.go)). Each of these sources, etcd and local client, has its own `PrevRevision` instance. `PrevRevision`, as the name suggests, is in-memory structure providing previous value when a change is about to be applied. Retrieved previous value is attached to request and forwarded to subscribers.

E.g: _LocalClient sends a request to add an interface. Previous config of the interface is looked up in prevRevision, attached to the request and forwarded to defaultplugins (subscriber)._

In contiv-vswitch the config is applied using local client - change notifications are forwarded to subscribers. Afterward, the config is persisted into etcd. Change events generated by etcd are filtered out in order to avoid duplicated application.

Usually `PrevRevision` of local client and etcd are in sync and the described approach works as expected. However, after restart the items that have been configured in previous run are not present in local client's `PrevRevisions`. In this scenario it is desired to forward change notifications generated by etcd.