### PR TITLE
Fix build of debug vswitch image

### DIFF
--- a/docker/ubuntu-based/dev/build-vpp.sh
+++ b/docker/ubuntu-based/dev/build-vpp.sh
@@ -23,12 +23,14 @@ rm -rf .ccache \
 	build-vpp_debug-native/vpp/vpp-api/java
 rm *java*.deb
 dpkg -i vpp_*.deb vpp-dev_*.deb vpp-lib_*.deb vpp-plugins_*.deb vpp-dbg_*.deb
-# run the debug build too if:
-# VPP commit ID is specified AND
-# the SKIP_DEBUG_BUILD env var is 0
-if [ '${VPP_COMMIT_ID}' != 'xxx' ] && [ '${SKIP_DEBUG_BUILD}' -eq 0 ]; then
+
+# run the debug build too unless the SKIP_DEBUG_BUILD env var is set to non-0 value
+if [ "${SKIP_DEBUG_BUILD}" == "" ] || [ "${SKIP_DEBUG_BUILD}" -eq 0 ]; then
 	cd ${VPP_DIR}
-	make build
+	make vpp_configure_args_vpp='--disable-japi --disable-vom' build
+	# overwrite prod plugins with debug plugins
+	rm -rf /usr/lib/{vpp_plugins,vpp_api_test_plugins}
+	cp -r build-root/install-vpp_debug-native/vpp/lib64/{vpp_plugins,vpp_api_test_plugins} /usr/lib
 fi
 cd ${VPP_DIR}
 cd build-root


### PR DESCRIPTION
This MR fixed build of the debug vswitch image:
- `SKIP_DEBUG_BUILD` couldn't be empty,
- `make build` was not working without disabling japi,
- debug VPP plugins should be used in the debug image.