### PR TITLE
Makefile,{cni,cri,ksr,stn}: strip built binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include Makeroutines.mk
 
 VERSION=$(shell git rev-parse HEAD)
 DATE=$(shell date +'%Y-%m-%dT%H:%M%:z')
-LDFLAGS=-ldflags '-X github.com/contiv/vpp/vendor/github.com/ligato/cn-infra/core.BuildVersion=$(VERSION) -X github.com/contiv/vpp/vendor/github.com/ligato/cn-infra/core.BuildDate=$(DATE)'
+LDFLAGS=-ldflags '-X github.com/contiv/vpp/vendor/github.com/ligato/cn-infra/core.BuildVersion=$(VERSION) -X github.com/contiv/vpp/vendor/github.com/ligato/cn-infra/core.BuildDate=$(DATE) -s -w'
 COVER_DIR=/tmp/
 
 

--- a/docker/vpp-cni/Dockerfile
+++ b/docker/vpp-cni/Dockerfile
@@ -20,7 +20,7 @@ RUN export CGO_ENABLED=0 \
  && cp /cni/loopback /output/ \
  && cp /go/src/github.com/contiv/vpp/docker/vpp-cni/10-contiv-vpp.conf /output/ \
  && cp /go/src/github.com/contiv/vpp/docker/vpp-cni/install.sh /output/ \
- && go build -o /output/contiv-cni contiv_cni.go
+ && go build -ldflags '-s -w' -o /output/contiv-cni contiv_cni.go
 
 FROM alpine:3.7
 

--- a/docker/vpp-cri/Dockerfile
+++ b/docker/vpp-cri/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/contiv/vpp
 
 WORKDIR /go/src/github.com/contiv/vpp/cmd/contiv-cri
 
-RUN go build -o /cri main.go
+RUN go build -ldflags '-s -w' -o /cri main.go
 
 FROM ubuntu:16.04
 

--- a/docker/vpp-ksr/Dockerfile
+++ b/docker/vpp-ksr/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/contiv/vpp
 
 WORKDIR /go/src/github.com/contiv/vpp/cmd/contiv-ksr
 
-RUN go build -o /ksr main.go
+RUN go build -ldflags '-s -w' -o /ksr main.go
 
 FROM scratch
 

--- a/docker/vpp-stn/Dockerfile
+++ b/docker/vpp-stn/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/contiv/vpp
 
 WORKDIR /go/src/github.com/contiv/vpp/cmd/contiv-stn
 
-RUN go build -o /stn .
+RUN go build -ldflags '-s -w' -o /stn .
 
 FROM scratch
 


### PR DESCRIPTION
This change shrinks the built Go binaries. These binaries are able to print stacktraces on panic.

before:
```
prod-contiv-stn       0.0.1-1529-gd7314aa            76fc406f77d3        2 days ago          11.5MB
prod-contiv-cri       0.0.1-1529-gd7314aa            8399c950dfda        2 days ago          165MB
prod-contiv-ksr       0.0.1-1529-gd7314aa            2c5aa3a8e795        2 days ago          39.2MB
prod-contiv-cni       0.0.1-1529-gd7314aa            68c2ecef21fc        2 days ago          18.5MB
prod-contiv-vswitch   0.0.1-1529-gd7314aa            a91a3f6909ce        2 days ago          324MB
```
after:
```
prod-contiv-stn       0.0.1-1565-gd79b7be            1e5b12f7b841        25 minutes ago      7.6MB
prod-contiv-cri       0.0.1-1565-gd79b7be            0f3b436a5e4c        25 minutes ago      145MB
prod-contiv-ksr       0.0.1-1565-gd79b7be            8f6c63d5ad73        26 minutes ago      24.3MB
prod-contiv-cni       0.0.1-1565-gd79b7be            a95d75e3c43b        27 minutes ago      14.9MB
prod-contiv-vswitch   0.0.1-1565-gd79b7be            fe87a70282c7        27 minutes ago      289MB
```