### PR TITLE
Clean up processing of nodeID events

### DIFF
--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -176,6 +176,13 @@ type remoteCNIserver struct {
 	// the map holds containerID of pods that have been configured in this vswitch run
 	// this structure is intentionally not persisted
 	configuredInThisRun map[string]bool
+
+	// nodeIDResyncRev is the latest revision in the resync event. Buffered changes generated
+	// before the resync revision are ignore
+	nodeIDResyncRev int64
+
+	// nodeIDChangeEvs is buffer where change events are stored until resync event is processed
+	nodeIDChangeEvs []datasync.ChangeEvent
 }
 
 // vswitchConfig holds base vSwitch VPP configuration.

--- a/plugins/contiv/remote_cni_server_test.go
+++ b/plugins/contiv/remote_cni_server_test.go
@@ -551,5 +551,6 @@ func (e nodeAddDelEvent) GetPrevValue(prevValue proto.Message) (prevValueExist b
 }
 
 func (e nodeAddDelEvent) GetRevision() int64 {
-	return 0
+	// return revision should be bigger than resync Rev in order to apply the change
+	return 1
 }


### PR DESCRIPTION
PR fixes race condition during init process where nodeID's change event might be delivered before resync.

Events should be processed in the following order:
- changeEvents delivered before resync are buffered
- process nodeID resync event first
- during resync process buffered changes
- skip change events with revision smaller than resync rev