### PR TITLE
Add Contiv-VPP global interface name option for steal NIC

### DIFF
--- a/cmd/contiv-init/main.go
+++ b/cmd/contiv-init/main.go
@@ -143,18 +143,28 @@ func parseSTNConfig() (config *contiv.Config, nicToSteal string, useDHCP bool, e
 		useDHCP = true
 	}
 
+	// look for node-specific config first
 	for _, nc := range config.NodeConfig {
 		if nc.NodeName == nodeName {
-			logger.Debugf("Found interface to be stolen: %s", nc.StealInterface)
 			nicToSteal = nc.StealInterface
-			if nc.MainVPPInterface.UseDHCP == true {
-				useDHCP = true
+			if nicToSteal != "" {
+				logger.Debugf("Found interface to be stolen: %s", nc.StealInterface)
+				if nc.MainVPPInterface.UseDHCP == true {
+					useDHCP = true
+				}
 			}
-			return
+			break
 		}
 	}
 
-	if nicToSteal == "" && config.StealTheNIC {
+	// global config - interface name
+	if nicToSteal == "" && config.StealInterface != "" {
+		nicToSteal = config.StealInterface
+		logger.Debugf("Found interface to be stolen: %s", nicToSteal)
+	}
+
+	// global config - first interface
+	if nicToSteal == "" && config.StealFirstNIC {
 		// the first NIC will be stolen
 		nicToSteal = getFirstInterfaceName()
 		if nicToSteal != "" {

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -51,7 +51,8 @@ To use the development image for testing with specific version of VPP, see
       (VETH is still used to connect VPP with the host stack);
     - `TAPInterfaceVersion`: select `1` to use the standard VPP TAP interface or `2`
       for a faster, virtio-based, VPP TAPv2 interface (default);
-    - `StealTheNIC`: enable Steal The NIC feature on the first interface on each node;
+    - `StealInterface`: enable Steal The NIC feature on the specified interface on each node;
+    - `StealFirstNIC`: enable Steal The NIC feature on the first interface on each node;
     - `TAPv2RxRingSize`: number of entries to allocate for TAPv2 Rx ring (default is 256);
     - `TAPv2TxRingSize`: number of entries to allocate for TAPv2 Tx ring (default is 256).
     - `NatExternalTraffic`: if enabled, traffic with cluster-outside destination is S-NATed

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -51,7 +51,7 @@ To use the development image for testing with specific version of VPP, see
       (VETH is still used to connect VPP with the host stack);
     - `TAPInterfaceVersion`: select `1` to use the standard VPP TAP interface or `2`
       for a faster, virtio-based, VPP TAPv2 interface (default);
-    - `StealInterface`: enable Steal The NIC feature on the specified interface on each node;
+    - `StealInterface`: enable Steal The NIC feature on the specified interface on each node;``
     - `StealFirstNIC`: enable Steal The NIC feature on the first interface on each node;
     - `TAPv2RxRingSize`: number of entries to allocate for TAPv2 Rx ring (default is 256);
     - `TAPv2TxRingSize`: number of entries to allocate for TAPv2 Tx ring (default is 256).

--- a/k8s/contiv-vpp/README.md
+++ b/k8s/contiv-vpp/README.md
@@ -57,7 +57,8 @@ Parameter | Description | Default
 `contiv.tcpStackDisabled` | Disable TCP stack | `True`
 `contiv.useTAPInterfaces` | Enable TAP interfaces | `True`
 `contiv.tapInterfaceVersion`| TAP interface version | 1
-`contiv.stealTheNIC` | Enable Steal The NIC feature on the first interface on each node | `False`
+`contiv.stealInterface` | Enable Steal The NIC feature on the specified interface on each node | `""`
+`contiv.stealFirstNIC` | Enable Steal The NIC feature on the first interface on each node | `False`
 `contiv.natExternalTraffic`| NAT cluster-external traffic | `True`
 `contiv.ipamConfig.podSubnetCIDR` | Pod subnet CIDR | `10.1.0.0/16`
 `contiv.ipamConfig.podNetworkPrefixLen` | Pod network prefix length | `24`

--- a/k8s/contiv-vpp/templates/vpp.yaml
+++ b/k8s/contiv-vpp/templates/vpp.yaml
@@ -23,8 +23,11 @@ data:
     TCPstackDisabled: {{ .Values.contiv.tcpStackDisabled }}
     UseTAPInterfaces: {{ .Values.contiv.useTAPInterfaces }}
     TAPInterfaceVersion: {{ .Values.contiv.tapInterfaceVersion }}
-    {{- if .Values.contiv.stealTheNIC }}
-    StealTheNIC: True
+    {{- if .Values.contiv.stealInterface }}
+    StealInterface: {{ .Values.contiv.stealInterface }}
+    {{- end }}
+    {{- if .Values.contiv.stealFirstNIC }}
+    StealFirstNIC: True
     {{- end }}
     NatExternalTraffic: {{ .Values.contiv.natExternalTraffic }}
     MTUSize: {{ .Values.contiv.mtuSize }}

--- a/k8s/contiv-vpp/values.yaml
+++ b/k8s/contiv-vpp/values.yaml
@@ -2,7 +2,7 @@ contiv:
   tcpStackDisabled: True
   useTAPInterfaces: True
   tapInterfaceVersion: 1
-  stealTheNIC: False
+  stealFirstNIC: False
   natExternalTraffic: True
   mtuSize: 1500
   ipamConfig:

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -93,7 +93,8 @@ type Config struct {
 	TAPv2RxRingSize            uint16
 	TAPv2TxRingSize            uint16
 	MTUSize                    uint32
-	StealTheNIC                bool
+	StealFirstNIC              bool
+	StealInterface			   string
 	NatExternalTraffic         bool // if enabled, traffic with cluster-outside destination is SNATed on node output (for all nodes)
 	IPAMConfig                 ipam.Config
 	NodeConfig                 []OneNodeConfig

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -94,7 +94,7 @@ type Config struct {
 	TAPv2TxRingSize            uint16
 	MTUSize                    uint32
 	StealFirstNIC              bool
-	StealInterface			   string
+	StealInterface             string
 	NatExternalTraffic         bool // if enabled, traffic with cluster-outside destination is SNATed on node output (for all nodes)
 	IPAMConfig                 ipam.Config
 	NodeConfig                 []OneNodeConfig

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -299,7 +299,7 @@ func (s *remoteCNIserver) configureVswitchConnectivity() error {
 	} else {
 		expectedIfName = s.interconnectAfpacketName()
 	}
-	if s.config.StealTheNIC || (s.nodeConfig != nil && s.nodeConfig.StealInterface != "") {
+	if s.config.StealFirstNIC || s.config.StealInterface != "" || (s.nodeConfig != nil && s.nodeConfig.StealInterface != "") {
 		// For STN case, do not rely on TAP interconnect, since it has been pre-configured by contiv-init.
 		// Let's relay on VXLAN BVI interface name. Note that this may not work in case that VXLANs are disabled.
 		expectedIfName = vxlanBVIInterfaceName
@@ -426,7 +426,7 @@ func (s *remoteCNIserver) configureMainVPPInterface(config *vswitchConfig, nicNa
 	txn1 := s.vppTxnFactory().Put()
 
 	useSTN := false
-	if s.config.StealTheNIC || (s.nodeConfig != nil && s.nodeConfig.StealInterface != "") {
+	if s.config.StealFirstNIC || s.config.StealInterface != "" || (s.nodeConfig != nil && s.nodeConfig.StealInterface != "") {
 		useSTN = true
 
 		// get IP address of the STN interface
@@ -434,6 +434,9 @@ func (s *remoteCNIserver) configureMainVPPInterface(config *vswitchConfig, nicNa
 		if s.nodeConfig != nil && s.nodeConfig.StealInterface != "" {
 			s.Logger.Infof("STN of the host interface %s requested.", s.nodeConfig.StealInterface)
 			nicIP, gwIP, err = s.getSTNInterfaceIP(s.nodeConfig.StealInterface)
+		} else if s.config.StealInterface != "" {
+			s.Logger.Infof("STN of the interface %s requested.", s.config.StealInterface)
+			nicIP, gwIP, err = s.getSTNInterfaceIP(s.config.StealInterface)
 		} else {
 			s.Logger.Infof("STN of the first interface (%s) requested.", nicName)
 			nicIP, gwIP, err = s.getSTNInterfaceIP("")


### PR DESCRIPTION
This MR adds the global STN interface name option `StealInterface` that will be applied on all nodes. If node-local config is present, it takes precedence.