### PR TITLE
Make STN more robust in failure cases

### DIFF
--- a/cmd/contiv-init/main.go
+++ b/cmd/contiv-init/main.go
@@ -42,6 +42,9 @@ const (
 	defaultEtcdCfgFile    = "/etc/etcd/etcd.conf"
 	defaultSupervisorPort = 9001
 	defaultStnServerPort  = 50051
+
+	vppProcessName = "vpp"
+	contivAgentProcessName = "contiv-agent"
 )
 
 var (
@@ -225,7 +228,7 @@ func main() {
 
 	// start VPP
 	logger.Debug("Starting VPP")
-	_, err = client.StartProcess("vpp", false)
+	_, err = client.StartProcess(vppProcessName, false)
 	if err != nil {
 		logger.Errorf("Error by starting VPP process: %v", err)
 		os.Exit(-1)
@@ -236,6 +239,7 @@ func main() {
 		vppCfg, err := configureVpp(contivCfg, stnData, useDHCP)
 		if err != nil {
 			logger.Errorf("Error by configuring VPP: %v", err)
+			client.StopProcess(vppProcessName, false)
 			os.Exit(-1)
 		}
 
@@ -243,15 +247,17 @@ func main() {
 		err = persistVppConfig(contivCfg, stnData, vppCfg, useDHCP)
 		if err != nil {
 			logger.Errorf("Error by persisting VPP config in ETCD: %v", err)
+			client.StopProcess(vppProcessName, false)
 			os.Exit(-1)
 		}
 	}
 
 	// start contiv-agent
 	logger.Debugf("Starting contiv-agent")
-	_, err = client.StartProcess("contiv-agent", false)
+	_, err = client.StartProcess(contivAgentProcessName, false)
 	if err != nil {
 		logger.Errorf("Error by starting contiv-agent process: %v", err)
+		client.StopProcess(vppProcessName, false)
 		os.Exit(-1)
 	}
 

--- a/cmd/contiv-init/main.go
+++ b/cmd/contiv-init/main.go
@@ -43,7 +43,7 @@ const (
 	defaultSupervisorPort = 9001
 	defaultStnServerPort  = 50051
 
-	vppProcessName = "vpp"
+	vppProcessName         = "vpp"
 	contivAgentProcessName = "contiv-agent"
 )
 

--- a/cmd/contiv-stn/main.go
+++ b/cmd/contiv-stn/main.go
@@ -39,7 +39,7 @@ const (
 	defaultGRPCServerPort  = 50051 // port where the GRPC STN server listens for client connections
 	defaultStatusCheckPort = 9999  // port that STN server is checking to determine contive-agent liveness
 
-	initStatusCheckTimeout = 10 * time.Second // initial timeout after which the STN server starts checking of the contiv-agent state
+	initStatusCheckTimeout = 30 * time.Second // initial timeout after which the STN server starts checking of the contiv-agent state
 	statusCheckInterval    = 1 * time.Second  // periodic interval in which the STN server checks for contiv-agent state
 
 	configRetryCount = 20                     // number of config attempts in case that an error is returned / config is not applied correctly


### PR DESCRIPTION
- kill VPP in case the vpp-agent is not able to start properly to allow proper interface rollback
- extend initial timeout before STN plugins starts healthchecking the agent