### PR TITLE
Configure vpp-TAP for pod in a separate txn

### DIFF
--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -1066,8 +1066,15 @@ func (s *remoteCNIserver) configurePodInterface(request *cni.CNIRequest, podIP n
 
 		podIfName = config.PodTap.Name
 
-		txn1.VppInterface(config.VppIf).
-			LinuxInterface(config.PodTap)
+		// configure vpp TAP interface in a separate transaction otherwise the AUTO_TAP
+		// might try to configure the other end before VPP is finished
+		err := s.vppTxnFactory().Put().VppInterface(config.VppIf).Send().ReceiveReply()
+		if err != nil {
+			s.Logger.Error(err)
+			return err
+		}
+
+		txn1.LinuxInterface(config.PodTap)
 	} else {
 		// veth pair + AF_PACKET
 		config.Veth1 = s.veth1FromRequest(request, podIPCIDR)

--- a/plugins/contiv/remote_cni_server_test.go
+++ b/plugins/contiv/remote_cni_server_test.go
@@ -232,7 +232,7 @@ func TestAddDelTap(t *testing.T) {
 	gomega.Expect(reply).NotTo(gomega.BeNil())
 
 	gomega.Expect(len(txns.PendingTxns)).To(gomega.BeEquivalentTo(0))
-	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(3))
+	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(4))
 	// TODO add asserts for txns(one linux plugin txn and one default plugins txn) / currently applied config
 
 	res := configuredContainers.LookupPodName(podName)


### PR DESCRIPTION
Configure vpp TAP interface in a separate transaction otherwise the AUTO_TAP
might try to configure the other end before VPP is finished.

This should fix issues `tap_connect_reply returned -17`, and `tap_connect_reply returned -14`.