### PR TITLE
.dockeringore,.gitignore: ignore vagrant/images.tar

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+vagrant/images.tar

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cmd/contiv-cri/contiv-cri
 cmd/contiv-init/contiv-init
 cmd/contiv-stn/contiv-stn
 cmd/tools/ldpreload-label-injector/ldpreload-label-injector
+vagrant/images.tar


### PR DESCRIPTION
This change makes Docker and git ignore vagrant/images.tar. This shouldn't be added to git and there's also no point in including this in any of the images we build.

These ignore lines should've been part of the PR which added docker/save.sh.