### PR TITLE
prod/vswitch/Dockerfile: copy bins in one step

### DIFF
--- a/docker/ubuntu-based/prod/vswitch/Dockerfile
+++ b/docker/ubuntu-based/prod/vswitch/Dockerfile
@@ -18,8 +18,7 @@ RUN mkdir /etc/supervisord
 WORKDIR /root/
 
 # add the agent binaries
-COPY binaries/contiv-init /usr/bin/
-COPY binaries/contiv-agent /usr/bin/
+COPY binaries/contiv-init binaries/contiv-agent /usr/bin/
 
 # add VPP binaries (add also extracts from .tar.gz)
 ADD binaries/vpp.tar.gz .


### PR DESCRIPTION
This change reduces the number of layers of the image. This should help speed up the download.
