### PR TITLE
Enhance NIC revert procedure in STN plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ endef
 # build contiv-stn only
 define build_contiv_stn_only
     @echo "# building contiv-stn"
-    @cd cmd/contiv-stn && go build -v -i ${LDFLAGS}
+    @cd cmd/contiv-stn && go build -v -i -ldflags '-X main.BuildVersion=$(VERSION) -X main.BuildDate=$(DATE) -s -w'
     @echo "# done"
 endef
 

--- a/cmd/contiv-init/vppcfg.go
+++ b/cmd/contiv-init/vppcfg.go
@@ -228,7 +228,7 @@ func configureVpp(contivCfg *contiv.Config, stnData *stn.STNReply, useDHCP bool)
 			Version:    uint32(contivCfg.TAPInterfaceVersion),
 		}, ch, nil)
 	if err != nil {
-		logger.Errorf("Error by adding TAP intrerface: %v", err)
+		logger.Errorf("Error by adding TAP interface: %v", err)
 		return nil, err
 	}
 
@@ -240,19 +240,19 @@ func configureVpp(contivCfg *contiv.Config, stnData *stn.STNReply, useDHCP bool)
 
 	err = if_vppcalls.SetInterfaceMtu(tapIdx, contivCfg.MTUSize, ch, nil)
 	if err != nil {
-		logger.Errorf("Error by setting the MTU for TAP: %v", cfg.mainIfName, err)
+		logger.Errorf("Error by setting the MTU on TAP interface: %v", err)
 		return nil, err
 	}
 
 	err = if_vppcalls.InterfaceAdminUp(tapIdx, ch, nil)
 	if err != nil {
-		logger.Errorf("Error by enabling the TAP intrerface: %v", err)
+		logger.Errorf("Error by enabling the TAP interface: %v", err)
 		return nil, err
 	}
 
 	if_vppcalls.SetUnnumberedIP(tapIdx, cfg.mainIfIdx, ch, nil)
 	if err != nil {
-		logger.Errorf("Error by setting the TAP intrerface as unnumbered: %v", err)
+		logger.Errorf("Error by setting the TAP interface as unnumbered: %v", err)
 		return nil, err
 	}
 

--- a/cmd/contiv-stn/main.go
+++ b/cmd/contiv-stn/main.go
@@ -48,8 +48,10 @@ const (
 )
 
 var (
-	BuildVersion string // set by the Makefile using ldflags
-	BuildDate    string // set by the Makefile using ldflags
+	// BuildVersion contains git version hash, set by the Makefile using ldflags during build.
+	BuildVersion string
+	// BuildDate contains date of the build, set by the Makefile using ldflags during build.
+	BuildDate string
 
 	grpcServerPort  = flag.Int("grpc", defaultGRPCServerPort, "port where the GRPC STN server listens for client connections")
 	statusCheckPort = flag.Int("statuscheck", defaultStatusCheckPort, "port that STN server is checking to determine contive-agent liveness")


### PR DESCRIPTION
After bringing a stolen interface back to kernel and configuring it, STN will periodically re-check the interface state and try to re-apply reverted interface config until it is in desired state.