### PR TITLE
Fix vagrants - disable hugePage feature in the latest k8s

### DIFF
--- a/vagrant/Vagrantfiles/virtualbox-dev
+++ b/vagrant/Vagrantfiles/virtualbox-dev
@@ -193,7 +193,7 @@ source /home/vagrant/.profile
 # --------------> Kubeadm & Networking <------------------
 # --------------------------------------------------------
 
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
 cd /home/vagrant/gopath/src/github.com/contiv/vpp/k8s
@@ -224,6 +224,11 @@ echo Args passed: [[ $@ ]]
 
 source /vagrant/config/init
 export KUBE_WORKER_IP=$2
+
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_WORKER_IP --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
+systemctl restart kubelet
+
 sed 's/127\.0\.0\.1.*k8s.*/'"$2"' '"$1"'/' -i /etc/hosts
 echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
 echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile

--- a/vagrant/Vagrantfiles/virtualbox-prod
+++ b/vagrant/Vagrantfiles/virtualbox-prod
@@ -174,7 +174,7 @@ source /home/vagrant/.profile
 # --------------> Kubeadm & Networking <------------------
 # --------------------------------------------------------
 
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
 curl --silent https://raw.githubusercontent.com/contiv/vpp/master/k8s/contiv-vpp.yaml > /tmp/contiv-vpp.yaml
@@ -205,6 +205,11 @@ echo Args passed: [[ $@ ]]
 
 source /vagrant/config/init
 export KUBE_WORKER_IP=$2
+
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_WORKER_IP --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
+systemctl restart kubelet
+
 sed 's/127\.0\.0\.1.*k8s.*/'"$2"' '"$1"'/' -i /etc/hosts
 echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
 echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile

--- a/vagrant/Vagrantfiles/vmware-dev
+++ b/vagrant/Vagrantfiles/vmware-dev
@@ -192,7 +192,7 @@ source /home/vagrant/.profile
 # --------------> Kubeadm & Networking <------------------
 # --------------------------------------------------------
 
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
 cd /home/vagrant/gopath/src/github.com/contiv/vpp/k8s
@@ -223,6 +223,11 @@ echo Args passed: [[ $@ ]]
 
 source /vagrant/config/init
 export KUBE_WORKER_IP=$(hostname -I | cut -f1 -d' ')
+
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_WORKER_IP --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
+systemctl restart kubelet
+
 sed 's/127\.0\.0\.1.*k8s.*/'"$KUBE_WORKER_IP"' '"$1"'/' -i /etc/hosts
 echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
 echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile

--- a/vagrant/Vagrantfiles/vmware-prod
+++ b/vagrant/Vagrantfiles/vmware-prod
@@ -167,7 +167,7 @@ source /home/vagrant/.profile
 # --------------> Kubeadm & Networking <------------------
 # --------------------------------------------------------
 
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_MASTER_IP --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 systemctl daemon-reload
 systemctl restart kubelet
 curl --silent https://raw.githubusercontent.com/contiv/vpp/master/k8s/contiv-vpp.yaml > /tmp/contiv-vpp.yaml
@@ -198,6 +198,11 @@ echo Args passed: [[ $@ ]]
 
 source /vagrant/config/init
 export KUBE_WORKER_IP=$(hostname -I | cut -f1 -d' ')
+
+sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip=$KUBE_WORKER_IP --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
+systemctl restart kubelet
+
 sed 's/127\.0\.0\.1.*k8s.*/'"$KUBE_WORKER_IP"' '"$1"'/' -i /etc/hosts
 echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /etc/profile.d/envvar.sh
 echo "export no_proxy='$1,$KUBE_MASTER_IP,$KUBE_WORKER_IP,localhost,127.0.0.1'" >> /home/vagrant/.profile


### PR DESCRIPTION
In kubernetes 1.10.0 a new feature for hugepages was added, the PR disables it in order to allow starting vpp with default deployment file.