### PR TITLE
 Fix vppctl for K8s 1.10

### DIFF
--- a/docker/ubuntu-based/prod/vswitch/vppctl
+++ b/docker/ubuntu-based/prod/vswitch/vppctl
@@ -4,12 +4,11 @@
 
 set -euo pipefail
 
-get_vswitch_container_ID() {
+get_vswitch_container_id() {
     # There may be more than one vswitch container if an upgrade/redeploy is
     # happening, so go for the newest one.
-    CID=$(docker ps --format '{{.CreatedAt}} {{.Image}} {{.ID}}' | grep -E " $1@?[^ ]* [^ ]+$" | sort -nr | \
-        head -n 1 | sed -e 's|.* ||g') || [ -z "$CID" ]
-    echo "$CID"
+    docker ps --format '{{.CreatedAt}} {{.Image}} {{.ID}}' | grep -E " $1@?[^ ]* [^ ]+$" | sort -nr | \
+        head -n 1 | sed -e 's|.* ||g'
 }
 
 IMAGE="contivvpp/vswitch"
@@ -21,21 +20,19 @@ then
     exit 1
 fi
 
-ID=$(get_vswitch_container_ID "$IMAGE")
-
 # In K8s 1.10 only Image IDs are displayed by 'docker ps' instead of Image
 # names. If we can't get the vswitch container by its name, try using Image
 # ID, which we get from listing docker images and looking for the latest
 # vswitch image.
-if [ ! "$ID" ] ; then
+if ! ID=$(get_vswitch_container_id "$IMAGE") || [ -z "$ID" ]
+then
     # Just grab the latest (by date) image for now. Will have to be replaced
     # later with grabbing an image with a specific tag.
-    IMG=$(docker images --format '{{.CreatedAt}};{{.ID}};{{.Repository}}' | grep "$IMAGE" | sort -nr | head -n 1) \
-        || [ -z "$IMG" ]
-    if [ "$IMG" ] ; then
+    if IMG=$(docker images --format '{{.CreatedAt}};{{.ID}};{{.Repository}}' | grep "$IMAGE" | sort -nr | head -n 1)
+    then
         IFS=';' read -ra IMG_FIELDS <<< "$IMG"
-        ID=$(get_vswitch_container_ID "${IMG_FIELDS[1]}")
-        if [ "$ID" == "" ] ; then
+        if ! ID=$(get_vswitch_container_id "${IMG_FIELDS[1]}") || [ -z "$ID" ]
+        then
             echo "Error finding a running container derived from the $IMAGE image." >&2
             exit 1
         fi
@@ -51,4 +48,4 @@ then
     DOCKER_ARGS="-t"
 fi
 
-exec docker exec -i $DOCKER_ARGS "$ID" /usr/bin/vppctl
+exec docker exec -i "$DOCKER_ARGS" "$ID" /usr/bin/vppctl


### PR DESCRIPTION
In K8s 1.10 only Image IDs are displayed by 'docker ps' instead of Image names. The vppctl script is modified to try to get an Image ID for the contivvpp/vswitch image name and then use the Image ID
to try to get the running vswitch container.