### PR TITLE
Enable portmap plugin to support hostPort on the host IP (not VPP IP).

### DIFF
--- a/docker/alpine-based/prod/cni/Dockerfile
+++ b/docker/alpine-based/prod/cni/Dockerfile
@@ -8,7 +8,7 @@ ADD binaries/contiv-cni .
 ADD binaries/loopback .
 
 # add default CNI config
-ADD cni/10-contiv-vpp.conf .
+ADD cni/10-contiv-vpp.conflist .
 
 # add CNI installation script
 ADD cni/install.sh .

--- a/docker/alpine-based/prod/cni/install.sh
+++ b/docker/alpine-based/prod/cni/install.sh
@@ -35,7 +35,7 @@ rm -rf ${HOST_CNI_NET_DIR}/*
 
 # Install our CNI config file.
 echo "Installing new CNI config to ${HOST_CNI_NET_DIR}"
-cp /root/10-contiv-vpp.conf ${HOST_CNI_NET_DIR}
+cp /root/10-contiv-vpp.conflist ${HOST_CNI_NET_DIR}
 
 # Unless told otherwise via SLEEP env. variable, sleep forever. This prevents k8s from restarting the pod repeatedly.
 should_sleep=${SLEEP:-"true"}

--- a/docker/vpp-cni/10-contiv-vpp.conf
+++ b/docker/vpp-cni/10-contiv-vpp.conf
@@ -1,6 +1,0 @@
-{
-	"cniVersion": "0.3.1",
-	"type": "contiv-cni",
-	"grpcServer": "127.0.0.1:9111"
-}
-

--- a/docker/vpp-cni/10-contiv-vpp.conflist
+++ b/docker/vpp-cni/10-contiv-vpp.conflist
@@ -11,7 +11,7 @@
 			"capabilities": {
 				"portMappings": true
 			},
-			"snat": true
+			"externalSetMarkChain": "KUBE-MARK-MASQ"
 		}
 	]
 }

--- a/docker/vpp-cni/10-contiv-vpp.conflist
+++ b/docker/vpp-cni/10-contiv-vpp.conflist
@@ -1,0 +1,18 @@
+{
+    "name": "k8s-pod-network",
+	"cniVersion": "0.3.1",
+	"plugins": [
+		{
+			"type": "contiv-cni",
+			"grpcServer": "127.0.0.1:9111"
+		},
+		{
+			"type": "portmap",
+			"capabilities": {
+				"portMappings": true
+			},
+			"snat": true
+		}
+	]
+}
+

--- a/docker/vpp-cni/Dockerfile
+++ b/docker/vpp-cni/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /go/src/github.com/contiv/vpp/cmd/contiv-cni
 RUN export CGO_ENABLED=0 \
  && mkdir /output/ \
  && cp /cni/loopback /output/ \
- && cp /go/src/github.com/contiv/vpp/docker/vpp-cni/10-contiv-vpp.conf /output/ \
+ && cp /go/src/github.com/contiv/vpp/docker/vpp-cni/10-contiv-vpp.conflist /output/ \
  && cp /go/src/github.com/contiv/vpp/docker/vpp-cni/install.sh /output/ \
  && go build -ldflags '-s -w' -o /output/contiv-cni contiv_cni.go
 

--- a/docker/vpp-cni/Dockerfile
+++ b/docker/vpp-cni/Dockerfile
@@ -11,6 +11,17 @@ RUN apk add --update wget \
  && rm /cni.tgz
 COPY . /go/src/github.com/contiv/vpp
 
+# Build a custom version of the portmap plugin, modified for VPP-based networking.
+RUN apk add --update git gcc linux-headers libc-dev \
+ && export CGO_ENABLED=0 \
+ && export CNI_PLUGIN_VERSION=0.7 \
+ && mkdir -p /go/src/github.com/containernetworking \
+ && cd /go/src/github.com/containernetworking \
+ && git clone https://github.com/containernetworking/plugins.git -b v$CNI_PLUGIN_VERSION \
+ && cd plugins/plugins/meta/portmap/ \
+ && git apply /go/src/github.com/contiv/vpp/docker/vpp-cni/portmap.diff \
+ && go build -ldflags '-s -w' -o /portmap
+
 WORKDIR /go/src/github.com/contiv/vpp/cmd/contiv-cni
 
 # we collect & store all files in one folder to make the resulting
@@ -20,7 +31,9 @@ RUN export CGO_ENABLED=0 \
  && cp /cni/loopback /output/ \
  && cp /go/src/github.com/contiv/vpp/docker/vpp-cni/10-contiv-vpp.conflist /output/ \
  && cp /go/src/github.com/contiv/vpp/docker/vpp-cni/install.sh /output/ \
+ && cp /portmap /output/ \
  && go build -ldflags '-s -w' -o /output/contiv-cni contiv_cni.go
+
 
 FROM alpine:3.7
 

--- a/docker/vpp-cni/install.sh
+++ b/docker/vpp-cni/install.sh
@@ -29,6 +29,10 @@ fi
 echo "Installing contiv CNI binary to ${HOST_CNI_BIN_DIR}"
 cp /root/contiv-cni ${HOST_CNI_BIN_DIR}
 
+# Install modified portmap plugin.
+echo "Installing portmap plugin to ${HOST_CNI_BIN_DIR}"
+cp /root/portmap ${HOST_CNI_BIN_DIR}
+
 # Erase all existing CNI config files.
 echo "Erasing old CNI config in ${HOST_CNI_NET_DIR}"
 rm -rf ${HOST_CNI_NET_DIR}/*

--- a/docker/vpp-cni/install.sh
+++ b/docker/vpp-cni/install.sh
@@ -35,7 +35,7 @@ rm -rf ${HOST_CNI_NET_DIR}/*
 
 # Install our CNI config file.
 echo "Installing new CNI config to ${HOST_CNI_NET_DIR}"
-cp /root/10-contiv-vpp.conf ${HOST_CNI_NET_DIR}
+cp /root/10-contiv-vpp.conflist ${HOST_CNI_NET_DIR}
 
 # Unless told otherwise via SLEEP env. variable, sleep forever. This prevents k8s from restarting the pod repeatedly.
 should_sleep=${SLEEP:-"true"}

--- a/docker/vpp-cni/portmap.diff
+++ b/docker/vpp-cni/portmap.diff
@@ -1,0 +1,26 @@
+diff --git a/plugins/meta/portmap/portmap.go b/plugins/meta/portmap/portmap.go
+index 870552f..814835c 100644
+--- a/plugins/meta/portmap/portmap.go
++++ b/plugins/meta/portmap/portmap.go
+@@ -198,11 +198,12 @@ func fillDnatRules(c *chain, config *PortMapConf, containerIP net.IP) {
+ 			copy(hpRule, ruleBase)
+ 
+ 			hpRule = append(hpRule,
+-				"-s", containerIP.String(),
++				//"-s", containerIP.String(),
+ 				"-j", setMarkChainName,
+ 			)
+ 			c.rules = append(c.rules, hpRule)
+ 
++			/*
+ 			if !isV6 {
+ 				// localhost
+ 				localRule := make([]string, len(ruleBase), len(ruleBase)+4)
+@@ -214,6 +215,7 @@ func fillDnatRules(c *chain, config *PortMapConf, containerIP net.IP) {
+ 				)
+ 				c.rules = append(c.rules, localRule)
+ 			}
++			*/
+ 		}
+ 
+ 		// The actual dnat rule

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -1379,11 +1379,17 @@ func (s *remoteCNIserver) parseCniExtraArgs(input string) map[string]string {
 
 // generateCniReply fills the CNI reply with the data of an interface.
 func (s *remoteCNIserver) generateCniReply(config *PodConfig, nsName string, podIP string) *cni.CNIReply {
+	var ifName string
+	if s.useTAPInterfaces {
+		ifName = config.PodTap.HostIfName
+	} else {
+		ifName = config.Veth1.HostIfName
+	}
 	return &cni.CNIReply{
 		Result: resultOk,
 		Interfaces: []*cni.CNIReply_Interface{
 			{
-				Name:    config.VppIf.Name,
+				Name:    ifName,
 				Sandbox: nsName,
 				IpAddresses: []*cni.CNIReply_Interface_IP{
 					{


### PR DESCRIPTION
We need to decide whether we want to enable hostPort access also for VPP IP, which would then have to be implemented using VPP/NAT similar to the nodePort. 