### PR TITLE
StatefulSet scheduling fixes

### DIFF
--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -95,6 +95,12 @@ spec:
         effect: NoSchedule
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
       # Only run this pod on the master.
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/k8s/contiv-vpp/templates/vpp.yaml
+++ b/k8s/contiv-vpp/templates/vpp.yaml
@@ -129,6 +129,12 @@ spec:
         effect: NoSchedule
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
       # Only run this pod on the master.
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
DaemonSet had extra tolerations that StatefulSet doesn't by default.
This can cause an intermittent scheduling problem, as the default
tolerations are only valid for 300s, which means pods can get
evicted after that.  See:
https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/