### PR TITLE
Load-balance equally between localy and remotely deployed pods.

### DIFF
--- a/plugins/service/configurator/configurator_impl.go
+++ b/plugins/service/configurator/configurator_impl.go
@@ -38,7 +38,7 @@ import (
 
 // LocalVsRemoteProbRatio tells how much more likely a local backend is to receive
 // traffic as opposed to a remote backend.
-const LocalVsRemoteProbRatio uint32 = 2
+const LocalVsRemoteProbRatio uint32 = 1
 
 const (
 	// Label for DNAT with identities; used to exclude VXLAN port and main interface IP

--- a/plugins/service/service_test.go
+++ b/plugins/service/service_test.go
@@ -331,12 +331,12 @@ func TestResyncAndSingleService(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        8080,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod2IP),
 				Port:        8080,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 		},
 	}
@@ -729,12 +729,12 @@ func TestMultipleServicesWithMultiplePortsAndResync(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        8080,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod2IP),
 				Port:        8080,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 		},
 	}
@@ -746,12 +746,12 @@ func TestMultipleServicesWithMultiplePortsAndResync(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        8443,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod2IP),
 				Port:        8443,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 		},
 	}
@@ -773,7 +773,7 @@ func TestMultipleServicesWithMultiplePortsAndResync(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        10053,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod3IP),
@@ -790,7 +790,7 @@ func TestMultipleServicesWithMultiplePortsAndResync(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        10053,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod3IP),
@@ -847,12 +847,12 @@ func TestMultipleServicesWithMultiplePortsAndResync(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        8443,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod2IP),
 				Port:        8443,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 		},
 	}
@@ -864,12 +864,12 @@ func TestMultipleServicesWithMultiplePortsAndResync(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        8443,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod2IP),
 				Port:        8443,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 		},
 	}
@@ -1502,12 +1502,12 @@ func TestServiceUpdates(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        8080,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod2IP),
 				Port:        8080,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod3IP),
@@ -1622,7 +1622,7 @@ func TestServiceUpdates(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        8080,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod3IP),
@@ -1689,7 +1689,7 @@ func TestServiceUpdates(t *testing.T) {
 			{
 				IP:          net.ParseIP(pod1IP),
 				Port:        8443,
-				Probability: 2,
+				Probability: uint8(svc_configurator.LocalVsRemoteProbRatio),
 			},
 			{
 				IP:          net.ParseIP(pod3IP),


### PR DESCRIPTION
For the next release we will make the weight of localy vs. remotely deployed pods configurable.
For now we set it to 1, i.e. equal probabilities (default kube-proxy behaviour).

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>