### PR TITLE
Allow setting updateStrategy as helm value

### DIFF
--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -145,6 +145,8 @@ spec:
   # Match contiv-etcd DaemonSet.
   selector:
     k8s-app: contiv-etcd
+  updateStrategy:
+    type: RollingUpdate
   ports:
   - port: 12379
     nodePort: 32379

--- a/k8s/contiv-vpp/templates/vpp.yaml
+++ b/k8s/contiv-vpp/templates/vpp.yaml
@@ -260,6 +260,8 @@ spec:
   # Match contiv-etcd DaemonSet.
   selector:
     k8s-app: contiv-etcd
+  updateStrategy:
+    type: {{ .Values.etcd.updateStrategy }}
   ports:
   - port: 12379
     nodePort: {{ .Values.etcd.service.nodePort }}
@@ -327,7 +329,7 @@ spec:
     matchLabels:
       k8s-app: contiv-vswitch
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.vswitch.updateStrategy }}
   template:
     metadata:
       labels:
@@ -550,7 +552,7 @@ metadata:
     k8s-app: contiv-ksr
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.vswitch.updateStrategy }}
   template:
     metadata:
       labels:

--- a/k8s/contiv-vpp/values.yaml
+++ b/k8s/contiv-vpp/values.yaml
@@ -69,6 +69,7 @@ etcd:
     serverKey: server-key.pem
     clientCert: client.pem
     clientKey: client-key.pem
+  updateStrategy: RollingUpdate
 
 vswitch:
   image:
@@ -80,6 +81,7 @@ vswitch:
   defineMemoryLimits: false
   hugePages2miLimit: 1024Mi
   memoryLimit: 1024Mi
+  updateStrategy: RollingUpdate
 
 cni:
   image:
@@ -94,6 +96,7 @@ ksr:
     # tag defaults to chart version
     #tag:
     pullPolicy: IfNotPresent
+  updateStrategy: RollingUpdate
 
 # GoVPP configuration
 # It contains time intervals used for VPP health probing (in nanoseconds).


### PR DESCRIPTION
According to
https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/

"The RollingUpdate update strategy implements automated, rolling
update for the Pods in a StatefulSet. It is the default strategy
when .spec.updateStrategy is left unspecified."

So, this change will not introduce any behavior change unless the
defaults of the new values are overwritten.