### PR TITLE
Fix attempt: Do not release node ID in Close

### DIFF
--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -30,7 +30,6 @@ data:
     CleanupIdleNATSessions: True
     TCPNATSessionTimeout: 180
     OtherNATSessionTimeout: 5
-    StealInterface: enp0s3
     IPAMConfig:
       PodSubnetCIDR: 10.1.0.0/16
       PodNetworkPrefixLen: 24

--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -30,6 +30,7 @@ data:
     CleanupIdleNATSessions: True
     TCPNATSessionTimeout: 180
     OtherNATSessionTimeout: 5
+    StealInterface: enp0s3
     IPAMConfig:
       PodSubnetCIDR: 10.1.0.0/16
       PodNetworkPrefixLen: 24

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -217,7 +217,7 @@ func (plugin *Plugin) AfterInit() error {
 func (plugin *Plugin) Close() error {
 	plugin.ctxCancelFunc()
 	plugin.cniServer.close()
-	plugin.nodeIDAllocator.releaseID()
+	//plugin.nodeIDAllocator.releaseID()
 	_, err := safeclose.CloseAll(plugin.govppCh, plugin.nodeIDwatchReg, plugin.watchReg)
 	return err
 }


### PR DESCRIPTION
Releasing node-id allocation may be quite dangerous in case that the rest of the agent config is still persited in ETCD. The only drawback of not releasing it is running out of node-id space, but that should not happen, since KSR releases old node IDs upon 'delete node' event.