### PR TITLE
Delete CNI GRPC socket file before starting agent

### DIFF
--- a/cmd/contiv-init/main.go
+++ b/cmd/contiv-init/main.go
@@ -276,7 +276,7 @@ func main() {
 	logger.Debugf("Starting contiv-agent")
 	// remove CNI server socket file
 	// TODO: this should be done automatically by CNI-infra before socket bind, remove once implemented
-	os.Remove("/var/run/contiv/cni.sock")
+	os.Remove(contiv.DefaultSTNSocketFile)
 	_, err = client.StartProcess(contivAgentProcessName, false)
 	if err != nil {
 		logger.Errorf("Error by starting contiv-agent process: %v", err)

--- a/cmd/contiv-init/main.go
+++ b/cmd/contiv-init/main.go
@@ -274,6 +274,9 @@ func main() {
 
 	// start contiv-agent
 	logger.Debugf("Starting contiv-agent")
+	// remove CNI server socket file
+	// TODO: this should be done automatically by CNI-infra before socket bind, remove once implemented
+	os.Remove("/var/run/contiv/cni.sock")
 	_, err = client.StartProcess(contivAgentProcessName, false)
 	if err != nil {
 		logger.Errorf("Error by starting contiv-agent process: %v", err)

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -58,7 +58,9 @@ const (
 	vethHostEndName               = "vpp1"
 	vethVPPEndLogicalName         = "veth-vpp2"
 	vethVPPEndName                = "vpp2"
-	defaultSTNSocketFile          = "/var/run/contiv/stn.sock"
+
+	// DefaultSTNSocketFile is the default socket file path where CNI GRPC server listens for incoming CNI requests.
+	DefaultSTNSocketFile = "/var/run/contiv/stn.sock"
 
 	// TapHostEndLogicalName is the logical name of the VPP-host interconnect TAP interface (host end)
 	TapHostEndLogicalName = "tap-vpp1"

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -529,7 +529,7 @@ func (s *remoteCNIserver) getSTNInterfaceIP(ifName string) (ip string, gw string
 
 	// connect to STN GRPC server
 	if s.config.STNSocketFile == "" {
-		s.config.STNSocketFile = defaultSTNSocketFile
+		s.config.STNSocketFile = DefaultSTNSocketFile
 	}
 	conn, err := grpc.Dial(
 		s.config.STNSocketFile,


### PR DESCRIPTION
It seems that in some cases of vswitch container failure and restart, the init container is not beeing executed and the CNI socket file ia not deleted. Although it eventually should be solved at the ligato/cn-infra level, this deletes the socket file before starting the agent.