### PR TITLE
Contiv plugin: add missing namespace name.

### DIFF
--- a/plugins/contiv/pod.go
+++ b/plugins/contiv/pod.go
@@ -272,6 +272,7 @@ func (s *remoteCNIserver) veth1FromRequest(request *cni.CNIRequest, podIP string
 		},
 		IpAddresses: []string{podIP},
 		Namespace: &linux_intf.LinuxInterfaces_Interface_Namespace{
+			Name:     request.ContainerId,
 			Type:     linux_intf.LinuxInterfaces_Interface_Namespace_FILE_REF_NS,
 			Filepath: request.NetworkNamespace,
 		},
@@ -343,6 +344,7 @@ func (s *remoteCNIserver) podTAP(request *cni.CNIRequest, podIPNet *net.IPNet) *
 		},
 		HostIfName: s.tapHostNameFromRequest(request),
 		Namespace: &linux_intf.LinuxInterfaces_Interface_Namespace{
+			Name:     request.ContainerId,
 			Type:     linux_intf.LinuxInterfaces_Interface_Namespace_FILE_REF_NS,
 			Filepath: request.NetworkNamespace,
 		},
@@ -399,6 +401,7 @@ func (s *remoteCNIserver) vppArpEntry(podIfName string, podIP net.IP, macAddr st
 
 func (s *remoteCNIserver) podArpEntry(request *cni.CNIRequest, ifName string, macAddr string) *linux_l3.LinuxStaticArpEntries_ArpEntry {
 	containerNs := &linux_l3.LinuxStaticArpEntries_ArpEntry_Namespace{
+		Name:     request.ContainerId,
 		Type:     linux_l3.LinuxStaticArpEntries_ArpEntry_Namespace_FILE_REF_NS,
 		Filepath: request.NetworkNamespace,
 	}
@@ -419,6 +422,7 @@ func (s *remoteCNIserver) podArpEntry(request *cni.CNIRequest, ifName string, ma
 
 func (s *remoteCNIserver) podLinkRouteFromRequest(request *cni.CNIRequest, ifName string) *linux_l3.LinuxStaticRoutes_Route {
 	containerNs := &linux_l3.LinuxStaticRoutes_Route_Namespace{
+		Name:     request.ContainerId,
 		Type:     linux_l3.LinuxStaticRoutes_Route_Namespace_FILE_REF_NS,
 		Filepath: request.NetworkNamespace,
 	}
@@ -436,6 +440,7 @@ func (s *remoteCNIserver) podLinkRouteFromRequest(request *cni.CNIRequest, ifNam
 
 func (s *remoteCNIserver) podDefaultRouteFromRequest(request *cni.CNIRequest, ifName string) *linux_l3.LinuxStaticRoutes_Route {
 	containerNs := &linux_l3.LinuxStaticRoutes_Route_Namespace{
+		Name:     request.ContainerId,
 		Type:     linux_l3.LinuxStaticRoutes_Route_Namespace_FILE_REF_NS,
 		Filepath: request.NetworkNamespace,
 	}


### PR DESCRIPTION
This pull request indirectly fixes LUNAR-1445:
The default route is configured only if the GW is reachable. This is checked by [networkReachable function](https://github.com/ligato/vpp-agent/blob/contiv/plugins/linuxplugin/l3plugin/route_config.go#L761-L777) from vpp-agent. It searches for routes targeting GW in the same namespace. Namespaces are considered equal if their names match. But up until now we were configuring all namespaces with an empty name. networkReachable thus could incorrectly pick up link-local route for the same GW from another pod (actually, all pods have the same GW) and conclude that the default route is ready to be configured.  