### PR TITLE
Add arm64 support for Contiv/VPP docker images building

### DIFF
--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -25,6 +25,7 @@ source ../vpp.env
 export DOCKER_BUILD_ARGS=""
 export SKIP_DEBUG_BUILD=0
 
+
 # override defaults from arguments
 while [ "$1" != "" ]; do
     case $1 in

--- a/docker/build-new.sh
+++ b/docker/build-new.sh
@@ -22,7 +22,54 @@ DOCKER_BUILD_ARGS=${DOCKER_BUILD_ARGS-}
 
 cd ..
 
-docker build -t prod-contiv-cni:${TAG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-cni/Dockerfile .
-docker build -t prod-contiv-ksr:${TAG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-ksr/Dockerfile .
-#docker build -t prod-contiv-cri:${TAG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-cri/Dockerfile .
-docker build -t prod-contiv-stn:${TAG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-stn/Dockerfile .
+
+#To prepare for future fat manifest image by multi-arch manifest,
+#now build the docker image with its arch
+#For fat manifest, please refer
+#https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list
+
+DOCKERFILE_tag=""
+
+BUILDARCH=`uname -m`
+
+if [ ${BUILDARCH} = "aarch64" ] ; then
+  DOCKERFILE_tag=".arm64"
+  BUILDARCH="arm64"
+fi
+
+
+if [ ${BUILDARCH} = "x86_64" ] ; then
+  BUILDARCH="amd64"
+fi
+
+
+DOCKERFILE=Dockerfile${DOCKERFILE_tag}
+#ALL_ARCH = amd64 arm64
+
+
+CNIDEFAULTIMG="prod-contiv-cni":${TAG}
+KSRDEFAULTIMG="prod-contiv-ksr":${TAG}
+CRIDEFAULTIMG="prod-contiv-cri":${TAG}
+STNDEFAULTIMG="prod-contiv-stn":${TAG}
+
+CNIBUILDIMG="prod-contiv-cni"-${BUILDARCH}:${TAG}
+KSRBUILDIMG="prod-contiv-ksr"-${BUILDARCH}:${TAG}
+CRIBUILDIMG="prod-contiv-cri"-${BUILDARCH}:${TAG}
+STNBUILDIMG="prod-contiv-stn"-${BUILDARCH}:${TAG}
+
+
+
+docker build -t ${CNIBUILDIMG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-cni/${DOCKERFILE} .
+docker build -t ${KSRBUILDIMG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-ksr/${DOCKERFILE} .
+docker build -t ${CRIBUILDIMG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-cri/${DOCKERFILE} .
+docker build -t ${STNBUILDIMG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-stn/${DOCKERFILE} .
+
+
+
+if [ ${BUILDARCH} = "amd64" ] ; then
+  docker tag  ${CNIBUILDIMG} ${CNIDEFAULTIMG}
+  docker tag  ${KSRBUILDIMG} ${KSRDEFAULTIMG}
+  docker tag  ${CRIBUILDIMG} ${CRIDEFAULTIMG}
+  docker tag  ${STNBUILDIMG} ${STNDEFAULTIMG}
+fi
+

--- a/docker/push-all.sh
+++ b/docker/push-all.sh
@@ -27,6 +27,21 @@ IMAGES=()
 #IMAGES_VPP=("cni" "ksr" "cri" "stn" "vswitch")
 IMAGES_VPP=("cni" "ksr" "stn" "vswitch")
 
+IMAGEARCH=""
+RUNARCH=""
+BUILDARCH=`uname -m`
+
+if [ ${BUILDARCH} = "aarch64" ] ; then
+  IMAGEARCH="-arm64"
+  BUILDARCH="arm64"
+  RUNARCH="-arm64"
+fi
+
+if [ ${BUILDARCH} = "x86_64" ] ; then
+  IMAGEARCH="-amd64"
+  BUILDARCH="amd64"
+fi
+
 # override defaults from arguments
 while [ "$1" != "" ]; do
     case $1 in
@@ -57,7 +72,7 @@ done
 # obtain the current git tag for tagging the Docker images
 export TAG=`git describe --tags`
 echo "exported TAG=$TAG"
-export VPP=$(docker run --rm dev-contiv-vswitch:$TAG bash -c "cd \$VPP_DIR && git rev-parse --short HEAD")
+export VPP=$(docker run --rm dev-contiv-vswitch${RUNARCH}:$TAG bash -c "cd \$VPP_DIR && git rev-parse --short HEAD")
 echo "exported VPP=$VPP"
 
 # tag and push each image
@@ -67,26 +82,45 @@ do
     then
         # master branch - tag with the git tag + "latest"
         echo "Tagging as contivvpp/${IMAGE}:${TAG} + contivvpp/${IMAGE}:latest"
-        docker tag prod-contiv-${IMAGE}:${TAG} contivvpp/${IMAGE}:${TAG}
-        docker tag prod-contiv-${IMAGE}:${TAG} contivvpp/${IMAGE}:latest
+        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${TAG}
+        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:latest
+ 
+        if [ ${BUILDARCH} = "amd64" ] ; then
+            echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${TAG} + contivvpp/${IMAGE}${IMAGEARCH}:latest as default"
+            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${TAG}
+            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:latest
+        fi
 
         # push the images
         if [ "${SKIP_UPLOAD}" != "true" ]
         then
-            docker push contivvpp/${IMAGE}:${TAG}
-            docker push contivvpp/${IMAGE}:latest
+            docker push contivvpp/${IMAGE}${IMAGEARCH}:${TAG}
+            docker push contivvpp/${IMAGE}${IMAGEARCH}:latest
+            if [ ${BUILDARCH} = "amd64" ] ; then
+                docker push contivvpp/${IMAGE}:${TAG}
+                docker push contivvpp/${IMAGE}:latest
+            fi
         fi
     else
         # other branch - tag with the branch name
-        echo "Tagging as contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG} + contivvpp/${IMAGE}:${BRANCH_NAME}"
-        docker tag prod-contiv-${IMAGE}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}
-        docker tag prod-contiv-${IMAGE}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}
+        echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG} + contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}"
+        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}
+        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}
+        if [ ${BUILDARCH} = "amd64" ] ; then
+            echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG} + contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME} as default"
+            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}
+            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}
+        fi
 
         # push the images
         if [ "${SKIP_UPLOAD}" != "true" ]
         then
-            docker push contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}
-            docker push contivvpp/${IMAGE}:${BRANCH_NAME}
+            docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}
+            docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}
+            if [ ${BUILDARCH} = "amd64" ] ; then
+                docker push contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}
+                docker push contivvpp/${IMAGE}:${BRANCH_NAME}
+            fi
         fi
     fi
 done
@@ -96,27 +130,46 @@ do
     if [ "${BRANCH_NAME}" == "master" ]
     then
         # master branch - tag with the git tag + "latest"
-        echo "Tagging as contivvpp/${IMAGE}:${TAG}-${VPP} + contivvpp/${IMAGE}:latest"
-        docker tag prod-contiv-${IMAGE}:${TAG} contivvpp/${IMAGE}:${TAG}-${VPP}
-        docker tag prod-contiv-${IMAGE}:${TAG} contivvpp/${IMAGE}:latest
+        echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${TAG}-${VPP} + contivvpp/${IMAGE}${IMAGEARCH}:latest"
+        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${TAG}-${VPP}
+        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:latest
+
+        if [ ${BUILDARCH} = "amd64" ] ; then
+            echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${TAG}-${VPP} + contivvpp/${IMAGE}${IMAGEARCH}:latest as default"
+            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${TAG}-${VPP}
+            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:latest
+        fi
 
         # push the images
         if [ "${SKIP_UPLOAD}" != "true" ]
         then
-            docker push contivvpp/${IMAGE}:${TAG}-${VPP}
-            docker push contivvpp/${IMAGE}:latest
+            docker push contivvpp/${IMAGE}${IMAGEARCH}:${TAG}-${VPP}
+            docker push contivvpp/${IMAGE}${IMAGEARCH}:latest
+            if [ ${BUILDARCH} = "amd64" ] ; then
+                docker push contivvpp/${IMAGE}:${TAG}-${VPP}
+                docker push contivvpp/${IMAGE}:latest
+            fi
         fi
     else
         # other branch - tag with the branch name
-        echo "Tagging as contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}-${VPP} + contivvpp/${IMAGE}:${BRANCH_NAME}"
-        docker tag prod-contiv-${IMAGE}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}
-        docker tag prod-contiv-${IMAGE}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}-${VPP}
+        echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP} + contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}"
+        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}
+        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP}
 
+        if [ ${BUILDARCH} = "amd64" ] ; then
+            echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP} + contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME} as default"
+            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}
+            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}-${VPP}
+        fi
         # push the images
         if [ "${SKIP_UPLOAD}" != "true" ]
         then
-            docker push contivvpp/${IMAGE}:${BRANCH_NAME}
-            docker push contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}-${VPP}
+            docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}
+            docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP}
+            if [ ${BUILDARCH} = "amd64" ] ; then
+                docker push contivvpp/${IMAGE}:${BRANCH_NAME}
+                docker push contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}-${VPP}
+            fi
         fi
     fi
 done
@@ -126,27 +179,43 @@ then
     if [ "${BRANCH_NAME}" == "master" ]
     then
         # master branch - tag with the git tag + "latest"
-        echo "Tagging as contivvpp/dev-vswitch:${TAG}-${VPP} + contivvpp/dev-vswitch:latest"
-        docker tag dev-contiv-vswitch:${TAG} contivvpp/dev-vswitch:${TAG}-${VPP}
-        docker tag dev-contiv-vswitch:${TAG} contivvpp/dev-vswitch:latest
+        echo "Tagging as contivvpp/dev-vswitch${IMAGEARCH}:${TAG}-${VPP} + contivvpp/dev-vswitch${IMAGEARCH}:latest"
+        docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch${IMAGEARCH}:${TAG}-${VPP}
+        docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch${IMAGEARCH}:latest
+        if [ ${BUILDARCH} = "amd64" ] ; then
+            docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch:${TAG}-${VPP}
+            docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch:latest
+        fi
 
         # push the images
         if [ "${SKIP_UPLOAD}" != "true" ]
         then
-            docker push contivvpp/dev-vswitch:${TAG}-${VPP}
-            docker push contivvpp/dev-vswitch:latest
+            docker push contivvpp/dev-vswitch${IMAGEARCH}:${TAG}-${VPP}
+            docker push contivvpp/dev-vswitch${IMAGEARCH}:latest
+            if [ ${BUILDARCH} = "amd64" ] ; then
+                docker push contivvpp/dev-vswitch:${TAG}-${VPP}
+                docker push contivvpp/dev-vswitch:latest
+            fi
         fi
     else
         # other branch - tag with the branch name
-        echo "Tagging as contivvpp/dev-vswitch:${BRANCH_NAME}-${TAG}-${VPP} + contivvpp/dev-vswitch:${BRANCH_NAME}"
-        docker tag dev-contiv-vswitch:${TAG} contivvpp/dev-vswitch:${BRANCH_NAME}
-        docker tag dev-contiv-vswitch:${TAG} contivvpp/dev-vswitch:${BRANCH_NAME}-${TAG}-${VPP}
+        echo "Tagging as contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP} + contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}"
+        docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}
+        docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP}
+        if [ ${BUILDARCH} = "amd64" ] ; then
+            docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch:${BRANCH_NAME}
+            docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch:${BRANCH_NAME}-${TAG}-${VPP}
+        fi
 
         # push the images
         if [ "${SKIP_UPLOAD}" != "true" ]
         then
-            docker push contivvpp/dev-vswitch:${BRANCH_NAME}
-            docker push contivvpp/dev-vswitch:${BRANCH_NAME}-${TAG}-${VPP}
+            docker push contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}
+            docker push contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP}
+            if [ ${BUILDARCH} = "amd64" ] ; then
+                docker push contivvpp/dev-vswitch:${BRANCH_NAME}
+                docker push contivvpp/dev-vswitch:${BRANCH_NAME}-${TAG}-${VPP}
+            fi
         fi
     fi
 fi

--- a/docker/save.sh
+++ b/docker/save.sh
@@ -43,8 +43,17 @@ echo "Using Images Tag: ${IMAGE_TAG}"
 
 # this script exports the built images as a tarball to be loaded
 
-images="contivvpp/ksr:${IMAGE_TAG} contivvpp/cni:${IMAGE_TAG} contivvpp/stn:${IMAGE_TAG} contivvpp/vswitch:${IMAGE_TAG}"
+IMAGEARCH=""
+BUILDARCH=`uname -m`
+
+if [ ${BUILDARCH} = "aarch64" ]; then
+  IMAGEARCH="-arm64"
+  echo "Using Images Arch: ${IMAGEARCH}"
+fi
+
+images="contivvpp/ksr${IMAGEARCH}:${IMAGE_TAG} contivvpp/cni${IMAGEARCH}:${IMAGE_TAG} contivvpp/stn${IMAGEARCH}:${IMAGE_TAG} contivvpp/vswitch${IMAGEARCH}:${IMAGE_TAG}"
 echo $images
+
 if [ -f ../vagrant/images.tar ]; then
   rm ../vagrant/images.tar
 fi

--- a/docker/ubuntu-based/dev/Dockerfile.arm64
+++ b/docker/ubuntu-based/dev/Dockerfile.arm64
@@ -1,0 +1,27 @@
+ARG VPP_IMAGE
+FROM ${VPP_IMAGE}
+
+# copy source files to the container
+COPY / /root/go/src/github.com/contiv/vpp
+
+# set env. variables required for go build
+ENV GOROOT /usr/local/go
+ENV GOPATH /root/go
+ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
+
+# build
+RUN cd $GOPATH/src/github.com/contiv/vpp \
+ && make \
+ && make install
+
+# add supervisord config file
+COPY docker/ubuntu-based/dev/supervisord.conf /etc/supervisord.conf
+
+# add debug govpp.conf with larger timeouts
+COPY docker/ubuntu-based/dev/govpp.conf /opt/vpp-agent/dev/govpp.conf
+
+# add vppctl script
+COPY docker/ubuntu-based/prod/vswitch/vppctl /usr/local/bin/vppctl
+
+# run supervisord as the default executable
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/docker/ubuntu-based/prod/cri/Dockerfile.arm64
+++ b/docker/ubuntu-based/prod/cri/Dockerfile.arm64
@@ -1,0 +1,14 @@
+FROM arm64v8/ubuntu:16.04
+
+# install iproute2 - required by dockershim
+RUN apt-get update && apt-get install -y iproute2 &&\
+    rm -rf /var/lib/apt/lists/*
+
+# set work directory
+WORKDIR /root/
+
+# copy the binary
+ADD binaries/contiv-cri .
+
+# run cri by default
+CMD ["/root/contiv-cri"]

--- a/docker/ubuntu-based/prod/vswitch/Dockerfile.arm64
+++ b/docker/ubuntu-based/prod/vswitch/Dockerfile.arm64
@@ -1,0 +1,35 @@
+FROM arm64v8/ubuntu:16.04
+
+RUN apt-get update \
+ && apt-get install -y \
+        # general tools
+        iproute2 iputils-ping inetutils-traceroute \
+        # vpp requirements
+        openssl python libapr1 libnuma1 \
+        supervisor \
+        # required for disabling TCP checksum offload in containers
+	ethtool \
+ && rm -rf /var/lib/apt/lists/*
+
+# use /opt/vpp-agent/dev as the working directory
+RUN mkdir /etc/supervisord
+
+# set work directory
+WORKDIR /root/
+
+# add the agent binaries
+COPY binaries/contiv-init binaries/contiv-agent /usr/bin/
+
+# add VPP binaries (add also extracts from .tar.gz)
+ADD binaries/vpp.tar.gz .
+RUN dpkg -i vpp/vpp-lib_*.deb vpp/vpp_*.deb vpp/vpp-plugins_*.deb && \
+    rm -rf vpp
+
+# add defualt VPP startup config as contiv-vswitch.conf
+COPY vswitch/vpp.conf /etc/vpp/contiv-vswitch.conf
+COPY vswitch/govpp.conf /etc/govpp/govpp.conf
+COPY vswitch/supervisord.conf /etc/supervisord.conf
+COPY vswitch/vppctl /usr/local/bin/vppctl
+
+# run supervisord as the default executable
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/docker/ubuntu-based/vpp/Dockerfile.arm64
+++ b/docker/ubuntu-based/vpp/Dockerfile.arm64
@@ -1,0 +1,43 @@
+FROM arm64v8/ubuntu:16.04
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    sudo wget git gdb nano python \
+    iproute2 iputils-ping inetutils-traceroute libapr1 supervisor \
+    telnet netcat software-properties-common \
+    make autoconf automake libtool curl unzip \
+    ethtool\
+ && apt-get remove -y --purge gcc \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /opt/vpp-agent/dev/vpp /opt/vpp-agent/plugin
+
+# install Go
+ENV GOLANG_VERSION 1.9.3
+RUN wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz" \
+ && tar -C /usr/local -xzf go.tgz \
+ && rm go.tgz
+
+# input arguments
+ARG VPP_REPO_URL
+ARG VPP_BRANCH_NAME
+ARG VPP_COMMIT_ID
+
+# optional argument - skips debug build
+ARG SKIP_DEBUG_BUILD=0
+
+# set work directory
+WORKDIR /root/
+
+# Path to VPP ws root directory
+ENV VPP_DIR /opt/vpp-agent/dev/vpp
+ENV VPP_BIN_DIR $VPP_DIR/build-root/install-vpp_debug-native/vpp/bin
+ENV VPP_LIB_DIR $VPP_DIR/build-root/install-vpp_debug-native/vpp/lib64
+ENV VPP_BIN $VPP_BIN_DIR/vpp
+ENV LD_PRELOAD_LIB_DIR $VPP_LIB_DIR
+
+ENV VPP_PATCH_DIR /opt/vpp-agent/dev/vpp-patches
+COPY ./patches $VPP_PATCH_DIR
+
+COPY ./build-vpp.sh /
+RUN /build-vpp.sh
+

--- a/docker/ubuntu-based/vpp/build-vpp.sh
+++ b/docker/ubuntu-based/vpp/build-vpp.sh
@@ -32,6 +32,11 @@ git reset --hard HEAD
 cp ${VPP_PATCH_DIR}/*.diff . || true
 git apply -v *.diff || true
 
+
+if [ "$(uname -m)" = "aarch64" ] ; then
+  sed -i 's/lib\/x86_64-linux-gnu/lib\/aarch64-linux-gnu/g' build-data/platforms.mk
+fi
+
 # run the production build
 UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom' install-dep
 rm -rf /var/lib/apt/lists/*

--- a/docker/ubuntu-based/vpp/build.sh
+++ b/docker/ubuntu-based/vpp/build.sh
@@ -16,21 +16,48 @@
 # fail in case of error
 set -e
 
+DOCKERFILETAG=""
+
+BUILDARCH=`uname -m`
+
+if [ ${BUILDARCH} = "aarch64" ] ; then
+  DOCKERFILETAG=".arm64"
+  BUILDARCH="arm64"
+fi
+
+
+if [ ${BUILDARCH} = "x86_64" ] ; then
+  BUILDARCH="amd64"
+fi
+
+
+DOCKERFILE=Dockerfile${DOCKERFILETAG}
+#ALL_ARCH = amd64 arm64
+
+
 # execute the build
 if [ -z "${VPP_COMMIT_ID}" ]
 then
     # no specific VPP commit ID
-    docker build -t dev-contiv-vpp:latest \
+    docker build -t dev-contiv-vpp-${BUILDARCH}:latest \
+        -f ${DOCKERFILE} \
         --build-arg VPP_REPO_URL=${VPP_REPO_URL} \
         --build-arg VPP_BRANCH_NAME=${VPP_BRANCH_NAME} \
         --build-arg SKIP_DEBUG_BUILD=${SKIP_DEBUG_BUILD} \
         ${DOCKER_BUILD_ARGS} --force-rm=true .
+    if [ ${BUILDARCH} = "amd64" ] ; then
+       docker tag  dev-contiv-vpp-${BUILDARCH}:latest dev-contiv-vpp:latest
+    fi
 else
     # specific VPP commit ID
-    docker build -t dev-contiv-vpp:${VPP_COMMIT_ID} \
+    docker build -t dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_ID} \
+        -f ${DOCKERFILE} \
         --build-arg VPP_REPO_URL=${VPP_REPO_URL} \
         --build-arg VPP_BRANCH_NAME=${VPP_BRANCH_NAME} \
         --build-arg VPP_COMMIT_ID=${VPP_COMMIT_ID} \
         --build-arg SKIP_DEBUG_BUILD=${SKIP_DEBUG_BUILD} \
         ${DOCKER_BUILD_ARGS} --force-rm=true .
+    if [ ${BUILDARCH} = "amd64" ] ; then
+       docker tag  dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_ID} dev-contiv-vpp:${VPP_COMMIT_ID}
+    fi
 fi

--- a/docker/vpp-cni/Dockerfile.arm64
+++ b/docker/vpp-cni/Dockerfile.arm64
@@ -1,0 +1,46 @@
+FROM arm64v8/golang:1.9.3-alpine3.7 as builder
+
+# we need the loopback binary from CNI
+# this binary can be obtained from the cni tarball
+RUN apk add --update wget \
+ && export CNI_VERSION=0.5.1 \
+ && wget https://github.com/containernetworking/cni/releases/download/v$CNI_VERSION/cni-arm64-v$CNI_VERSION.tgz \
+    -O /cni.tgz \
+ && mkdir /cni \
+ && tar -xvf /cni.tgz -C /cni \
+ && rm /cni.tgz
+COPY . /go/src/github.com/contiv/vpp
+
+# Build a custom version of the portmap plugin, modified for VPP-based networking.
+RUN apk add --update git gcc linux-headers libc-dev \
+ && export CGO_ENABLED=0 \
+ && export CNI_PLUGIN_VERSION=0.7 \
+ && mkdir -p /go/src/github.com/containernetworking \
+ && cd /go/src/github.com/containernetworking \
+ && git clone https://github.com/containernetworking/plugins.git -b v$CNI_PLUGIN_VERSION \
+ && cd plugins/plugins/meta/portmap/ \
+ && git apply /go/src/github.com/contiv/vpp/docker/vpp-cni/portmap.diff \
+ && go build -ldflags '-s -w' -o /portmap
+
+WORKDIR /go/src/github.com/contiv/vpp/cmd/contiv-cni
+
+# we collect & store all files in one folder to make the resulting
+# image smaller when we copy them all in one single operation
+RUN export CGO_ENABLED=0 \
+ && mkdir /output/ \
+ && cp /cni/loopback /output/ \
+ && cp /go/src/github.com/contiv/vpp/docker/vpp-cni/10-contiv-vpp.conflist /output/ \
+ && cp /go/src/github.com/contiv/vpp/docker/vpp-cni/install.sh /output/ \
+ && cp /portmap /output/ \
+ && go build -ldflags '-s -w' -o /output/contiv-cni contiv_cni.go
+
+
+FROM arm64v8/alpine:3.7
+
+# set work directory
+WORKDIR /root/
+
+COPY --from=builder /output/* /root/
+
+# run install script by default
+CMD ["/root/install.sh"]

--- a/docker/vpp-cri/Dockerfile.arm64
+++ b/docker/vpp-cri/Dockerfile.arm64
@@ -1,0 +1,21 @@
+FROM arm64v8/golang:1.9.3-alpine3.7 as builder
+
+# we want a static binary
+ENV CGO_ENABLED=0
+
+COPY . /go/src/github.com/contiv/vpp
+
+WORKDIR /go/src/github.com/contiv/vpp/cmd/contiv-cri
+
+RUN go build -ldflags '-s -w' -o /cri main.go
+
+FROM arm64v8/ubuntu:16.04
+
+# install iproute2 - required by dockershim
+RUN apt-get update && \
+	apt-get install -y --allow-unauthenticated iproute2 && \
+	rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /cri /cri
+
+ENTRYPOINT ["/cri"]

--- a/docker/vpp-ksr/Dockerfile.arm64
+++ b/docker/vpp-ksr/Dockerfile.arm64
@@ -1,0 +1,16 @@
+FROM arm64v8/golang:1.9.3-alpine3.7 as builder
+
+# we want a static binary
+ENV CGO_ENABLED=0
+
+COPY . /go/src/github.com/contiv/vpp
+
+WORKDIR /go/src/github.com/contiv/vpp/cmd/contiv-ksr
+
+RUN go build -ldflags '-s -w' -o /ksr main.go
+
+FROM scratch
+
+COPY --from=builder /ksr /ksr
+
+ENTRYPOINT ["/ksr"]

--- a/docker/vpp-stn/Dockerfile.arm64
+++ b/docker/vpp-stn/Dockerfile.arm64
@@ -1,0 +1,18 @@
+FROM arm64v8/golang:1.9.3-alpine3.7 as builder
+
+# we want a static binary
+ENV CGO_ENABLED=0
+
+RUN apk add --update git make
+
+COPY . /go/src/github.com/contiv/vpp
+
+WORKDIR /go/src/github.com/contiv/vpp
+
+RUN make contiv-stn
+
+FROM scratch
+
+COPY --from=builder /go/src/github.com/contiv/vpp/cmd/contiv-stn/contiv-stn /contiv-stn
+
+ENTRYPOINT ["/contiv-stn"]


### PR DESCRIPTION
Add arm64 support for contiv/vpp docker images building
The naming rules of the built docker images is given below:
For a built image named as ${repo}:${tag}, or
${repo}/${component}:${tag},
1. For x86_64 arch, it would be named as:
 ${repo}-amd64:${tag}, or ${repo}/${component}-amd64:${tag}
2. For arm64 arch, it would be named as:
    ${repo}-arm64:${tag}, or ${repo}/${component}-arm64:${tag}
3. The docker images built for amd64 are tagged as the default:
    ${repo}-amd64:${tag}--->${repo}:${tag}
    ${repo}/${component}-amd64:${tag}--->${repo}/${component}:${tag}
    
The purpose of doing it in this way is to prepare the enablement of the multi-arch support with fat manifest in a certain template like:
     --template ${image}-ARCH:${tag}.
in the future.
    
In addition to build scripts and dockerfiles, the corresponding utility scripts, such as push-all.sh,
save.sh are also updated to reflect the change.
    
This building process for this commit is tested through both arm64 and x86_64.
    
More detailed information about adding arm64 support for contiv/vpp, please refer:
https://github.com/contiv/vpp/issues/786