### PR TITLE
Enhance contiv-vpp-bug-report.sh to generate container NW report

### DIFF
--- a/scripts/contiv-vpp-bug-report.sh
+++ b/scripts/contiv-vpp-bug-report.sh
@@ -157,7 +157,7 @@ save_container_nw_report() {
         if [[ $ADDR = *"vpp1:"* ]]; then
             echo "Host networking" >> "${CONTAINER_NW_REPORT_FILE}"
         else
-            echo "$ADDR" >> container-report.txt
+            echo "$ADDR" >> "${CONTAINER_NW_REPORT_FILE}"
             read_node_shell_data "sudo nsenter -t ${PID} -n ip route" >> "${CONTAINER_NW_REPORT_FILE}"
             read_node_shell_data "sudo nsenter -t ${PID} -n arp -na" >> "${CONTAINER_NW_REPORT_FILE}"
         fi
@@ -186,7 +186,7 @@ WARNINGS=1
 TIMESTAMP="$(date '+%Y-%m-%d-%H-%M')"
 REPORT_DIR="contiv-vpp-bug-report-$TIMESTAMP"
 STDERR_LOGFILE="script-stderr.log"
-CONTAINER_NW_REPORT_FILE="container-report.txt"
+CONTAINER_NW_REPORT_FILE="container-nw-report.txt"
 
 # What we want to collect is defined globally in arrays, because sometimes we need to use multiple methods of
 # collection.  The array key is the name of the log file for the given command.

--- a/scripts/contiv-vpp-bug-report.sh
+++ b/scripts/contiv-vpp-bug-report.sh
@@ -150,7 +150,7 @@ save_container_nw_report() {
 
     for container_data in "${containers[@]}"
     do
-        # split CONTAINER_DATA to container ID and container Name
+        # split $container_data to an array with container ID, name and image
         IFS=' ' read -ra cinfo <<< "$container_data"
 
         echo >> "$CONTAINER_NW_REPORT_FILE"


### PR DESCRIPTION
This MR extends the the `contiv-vpp-bug-report.sh` script to generate container NW report containing Linux interfaces, routes and ARP table dump for each running Docker container, e.g.:

```
Container k8s_POD_kube-dns-6f4fd4bdf-86cwd_kube-system_fc638360-748a-11e8-aedc-080027de08ea_0
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
77: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN group default qlen 1000
    link/ether 00:00:00:00:00:02 brd ff:ff:ff:ff:ff:ff
    inet 10.1.1.2/32 brd 10.1.1.2 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::bca4:51ff:fe01:956c/64 scope link 
       valid_lft forever preferred_lft forever
default via 10.1.1.1 dev eth0 
10.1.1.1 dev eth0  scope link 
? (10.1.1.1) at 02:fe:fc:07:21:82 [ether] PERM on eth0
```