### PR TITLE
Vagrantfile fix for kubelet's configuration file location change

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -246,7 +246,7 @@ source /home/vagrant/.profile
 # --------------> Kubeadm & Networking <------------------
 # --------------------------------------------------------
 
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip='"$KUBE_MASTER_IP"' --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -i '1s/.*/KUBELET_EXTRA_ARGS=--node-ip='"$KUBE_MASTER_IP"' --feature-gates HugePages=false/' /etc/default/kubelet
 systemctl daemon-reload
 systemctl restart kubelet
 echo "$(kubeadm init --token-ttl 0 --pod-network-cidr="10.0.0.0/8" --apiserver-advertise-address="${KUBE_MASTER_IP}" --token="${KUBEADM_TOKEN}")" >> /vagrant/config/cert
@@ -293,7 +293,7 @@ else
   export KUBE_WORKER_IP=$2
 fi
 
-sed -i '4 a Environment="KUBELET_EXTRA_ARGS=--node-ip='"$KUBE_WORKER_IP"' --feature-gates HugePages=false"' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -i '1s/.*/KUBELET_EXTRA_ARGS=--node-ip='"$KUBE_WORKER_IP"' --feature-gates HugePages=false/' /etc/default/kubelet
 systemctl daemon-reload
 systemctl restart kubelet
 


### PR DESCRIPTION
In Kubernetes v1.11.0 kubelet's configuration file location changed
to /etc/default/kubelet. KUBELET_EXTRA_ARGS need to be added to that
file moving forward.