### PR TITLE
Fix local data only being collected on master node

### DIFF
--- a/scripts/contiv-vpp-bug-report.sh
+++ b/scripts/contiv-vpp-bug-report.sh
@@ -391,7 +391,7 @@ then
                 get_shell_data_ssh "$CMD_INDEX" ${LOCAL_COMMANDS[$CMD_INDEX]} </dev/null
             done
 
-            save_container_nw_report
+            save_container_nw_report </dev/null
 
             echo
             popd >/dev/null


### PR DESCRIPTION
The external while loop was getting it's stdin read out by the
save_container_nw_report command, so on the next loop it didn't
find any more nodes.