### PR TITLE
 Add timeout test for the HTTP client in processor

### DIFF
--- a/plugins/crd/cache/cache_impl.go
+++ b/plugins/crd/cache/cache_impl.go
@@ -139,6 +139,7 @@ func (ctc *ContivTelemetryCache) ClearCache() {
 	ctc.Cache.gigEIPMap = make(map[string]*Node)
 	ctc.Cache.loopMACMap = make(map[string]*Node)
 	ctc.Cache.loopIPMap = make(map[string]*Node)
+	ctc.Cache.report = []string{}
 }
 
 //NewCache returns a pointer to a new node cache

--- a/plugins/crd/cache/cache_impl.go
+++ b/plugins/crd/cache/cache_impl.go
@@ -126,7 +126,16 @@ func (c *Cache) addNode(ID uint32, nodeName, IPAdr, ManIPAdr string) error {
 
 //ClearCache with delete all the values in each of the individual cache maps.
 func (ctc *ContivTelemetryCache) ClearCache() {
-	ctc.Cache.nMap = make(map[string]*Node)
+	// Clear collected data for each node
+	for _, node := range ctc.Cache.nMap {
+		node.NodeInterfaces = nil
+		node.NodeBridgeDomains = nil
+		node.NodeL2Fibs = nil
+		node.NodeLiveness = nil
+		node.NodeTelemetry = nil
+		node.NodeIPArp = nil
+	}
+	// Clear secondary index maps
 	ctc.Cache.gigEIPMap = make(map[string]*Node)
 	ctc.Cache.loopMACMap = make(map[string]*Node)
 	ctc.Cache.loopIPMap = make(map[string]*Node)

--- a/plugins/crd/cache/node_db_processor.go
+++ b/plugins/crd/cache/node_db_processor.go
@@ -27,7 +27,7 @@ func (p *ContivTelemetryProcessor) ProcessNodeResponses() {
 			p.SetNodeData()
 			p.ValidateNodeInfo()
 			p.dtoList = p.dtoList[0:0]
-			p.ContivTelemetryCache.ClearCache()
+			p.validationInProgress = false
 		}
 	}
 }


### PR DESCRIPTION
Fix ClearCache() - do not delete the node map when clearing the cacheAdd timeout test for the HTTP client in processor  …
Refactor processor to support timeout testability
Cleanup cache cleaning functions - clean the cache when processing
starts rather than ends