### PR TITLE
Add k8s contiv/vpp yaml file for deployment on arm64 platform

### DIFF
--- a/k8s/contiv-vpp-arm64.yaml
+++ b/k8s/contiv-vpp-arm64.yaml
@@ -1,0 +1,530 @@
+---
+# Source: contiv-vpp/templates/vpp.yaml
+# Contiv-VPP deployment YAML file. This deploys Contiv VPP networking on a Kuberntes cluster.
+# The deployment consists of the following components:
+#   - contiv-etcd - deployed on k8s master
+#   - contiv-vswitch - deployed on each k8s node
+#   - contiv-ksr - deployed on k8s master
+
+###########################################################
+#  Configuration
+###########################################################
+
+# This config map contains contiv-agent configuration. The most important part is the IPAMConfig,
+# which may be updated in case the default IPAM settings do not match your needs.
+# NodeConfig may be used in case your nodes have more than 1 VPP interface. In that case, one
+# of them needs to be marked as the main inter-node interface, and the rest of them can be
+# configured with any IP addresses (the IPs cannot conflict with the main IPAM config).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contiv-agent-cfg
+  namespace: kube-system
+data:
+  contiv.yaml: |-
+    TCPstackDisabled: true
+    UseTAPInterfaces: true
+    TAPInterfaceVersion: 2
+    NatExternalTraffic: true
+    MTUSize: 1450
+    CleanupIdleNATSessions: True
+    TCPNATSessionTimeout: 180
+    OtherNATSessionTimeout: 5
+    ScanIPNeighbors: true
+    IPNeighborScanInterval: 1
+    IPNeighborStaleThreshold: 4
+    ServiceLocalEndpointWeight: 1
+    DisableNATVirtualReassembly: true
+    IPAMConfig:
+      PodSubnetCIDR: 10.1.0.0/16
+      PodNetworkPrefixLen: 24
+      PodIfIPCIDR: 10.2.1.0/24
+      VPPHostSubnetCIDR: 172.30.0.0/16
+      VPPHostNetworkPrefixLen: 24
+      NodeInterconnectCIDR: 192.168.16.0/24
+      VxlanCIDR: 192.168.30.0/24
+      NodeInterconnectDHCP: False
+  logs.conf: |
+    defaultlevel: debug
+  grpc.conf: |
+    network: unix
+    endpoint: /var/run/contiv/cni.sock
+  http.conf: |
+      endpoint: 0.0.0.0:9999
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: govpp-cfg
+  namespace: kube-system
+data:
+  govpp.conf: |
+    health-check-probe-interval: 3000000000
+    health-check-reply-timeout: 500000000
+    health-check-threshold: 3
+    reply-timeout: 3000000000
+
+---
+
+###########################################################
+#
+# !!! DO NOT EDIT THINGS BELOW THIS LINE !!!
+#
+###########################################################
+
+
+###########################################################
+#  Components and other resources
+###########################################################
+
+# This installs the contiv-etcd (ETCD server to be used by Contiv) on the master node in a Kubernetes cluster.
+# In odrer to dump the content of ETCD, you can use the kubectl exec command similar to this:
+#   kubectl exec contiv-etcd-cxqhr -n kube-system etcdctl -- get --endpoints=[127.0.0.1:12379] --prefix="true" ""
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: contiv-etcd
+  namespace: kube-system
+  labels:
+    k8s-app: contiv-etcd
+spec:
+  serviceName: contiv-etcd
+  selector:
+    matchLabels:
+      k8s-app: contiv-etcd
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: contiv-etcd
+      annotations:
+        # Marks this pod as a critical add-on.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      # We need this to schedule on the master no matter what else is going on, so tolerate everything.
+      - key: ''
+        operator: Exists
+        effect: ''
+      # This likely isn't needed due to the above wildcard, but keep it in for now.
+      - key: CriticalAddonsOnly
+        operator: Exists
+      # Only run this pod on the master.
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      hostNetwork: true
+
+      containers:
+        - name: contiv-etcd
+          image: quay.io/coreos/etcd:v3.3.5-arm64
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CONTIV_ETCD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: ETCDCTL_API
+              value: "3"
+            - name: ETCD_UNSUPPORTED_ARCH
+              value: "arm64"
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - /usr/local/bin/etcd --name=contiv-etcd --data-dir=/var/etcd/contiv-data
+              --advertise-client-urls=http://0.0.0.0:12379 --listen-client-urls=http://0.0.0.0:12379 --listen-peer-urls=http://0.0.0.0:12380
+          volumeMounts:
+            - name: var-etcd
+              mountPath: /var/etcd/
+      volumes:
+        - name: var-etcd
+          hostPath:
+             path: /var/etcd
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: contiv-etcd
+  namespace: kube-system
+spec:
+  type: NodePort
+  # Match contiv-etcd DaemonSet.
+  selector:
+    k8s-app: contiv-etcd
+  ports:
+  - port: 12379
+    nodePort: 32379
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contiv-ksr-http-cfg
+  namespace: kube-system
+data:
+  http.conf: |
+    endpoint: 0.0.0.0:9191
+
+---
+# This config map contains ETCD configuration for connecting to the contiv-etcd defined above.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contiv-etcd-cfg
+  namespace: kube-system
+data:
+  etcd.conf: |
+    insecure-transport: true
+    dial-timeout: 10000000000
+    endpoints:
+      - "127.0.0.1:32379"
+
+---
+
+# This config map contains ETCD configuration for connecting to the contiv-etcd defined above with auto comapact.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contiv-etcd-withcompact-cfg
+  namespace: kube-system
+data:
+  etcd.conf: |
+    insecure-transport: true
+    dial-timeout: 10000000000
+    auto-compact: 600000000000
+    endpoints:
+      - "127.0.0.1:32379"
+
+---
+
+# This installs contiv-vswitch on each master and worker node in a Kubernetes cluster.
+# It consists of the following containers:
+#   - contiv-vswitch container: contains VPP and its management agent
+#   - contiv-cni container: installs CNI on the host
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contiv-vswitch
+  namespace: kube-system
+  labels:
+    k8s-app: contiv-vswitch
+spec:
+  selector:
+    matchLabels:
+      k8s-app: contiv-vswitch
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: contiv-vswitch
+      annotations:
+        # Marks this pod as a critical add-on.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+      hostNetwork: true
+      hostPID: true
+
+      # Init containers are executed before regular containers, must finish successfully before regular ones are started.
+      initContainers:
+      # This container installs the Contiv CNI binaries
+      # and CNI network config file on each node.
+      - name: contiv-cni
+        image: contivvpp/cni-arm64:latest
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SLEEP
+            value: "false"
+        volumeMounts:
+          - mountPath: /opt/cni/bin
+            name: cni-bin-dir
+          - mountPath: /etc/cni/net.d
+            name: cni-net-dir
+      # This init container waits until etcd is started
+      - name: wait-foretcd
+        env:
+          - name: ETCDPORT
+            value: "32379"
+        image: busybox:latest
+        command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
+      # This init container extracts/copies VPP LD_PRELOAD libs and default VPP config to the host.
+      - name: vpp-init
+        image: contivvpp/vswitch-arm64:latest
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - |
+          set -eu
+          chmod 700 /run/vpp
+          rm -rf /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api
+          if [ ! -e /host/etc/vpp/contiv-vswitch.conf ]; then
+              cp /etc/vpp/contiv-vswitch.conf /host/etc/vpp/
+          fi
+          if [ ! -d /var/run/contiv ]; then
+              mkdir /var/run/contiv
+          fi
+          chmod 700 /var/run/contiv
+          rm -f /var/run/contiv/cni.sock
+          if ip link show vpp1 >/dev/null 2>&1; then
+               ip link del vpp1
+          fi
+          cp -f /usr/local/bin/vppctl /host/usr/local/bin/vppctl
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: usr-local-bin
+            mountPath: /host/usr/local/bin
+          - name: vpp-lib64
+            mountPath: /vpp-lib64/
+          - name: vpp-cfg
+            mountPath: /host/etc/vpp
+          - name: shm
+            mountPath: /dev/shm
+          - name: vpp-run
+            mountPath: /run/vpp
+          - name: contiv-run
+            mountPath: /var/run/contiv
+
+      containers:
+        # Runs contiv-vswitch container on each Kubernetes node.
+        # It contains the vSwitch VPP and its management agent.
+        - name: contiv-vswitch
+          image: contivvpp/vswitch-arm64:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          ports:
+            # readiness + liveness probe
+            - containerPort: 9999
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9999
+            periodSeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 3
+            initialDelaySeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9999
+            periodSeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 3
+            initialDelaySeconds: 60
+          env:
+            - name: MICROSERVICE_LABEL
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: ETCD_CONFIG
+              value: "/etc/etcd/etcd.conf"
+          volumeMounts:
+            - name: etcd-cfg
+              mountPath: /etc/etcd
+            - name: vpp-cfg
+              mountPath: /etc/vpp
+            - name: shm
+              mountPath: /dev/shm
+            - name: dev
+              mountPath: /dev
+            - name: vpp-run
+              mountPath: /run/vpp
+            - name: contiv-run
+              mountPath: /var/run/contiv
+            - name: contiv-plugin-cfg
+              mountPath: /etc/agent
+            - name: govpp-plugin-cfg
+              mountPath: /etc/govpp
+
+      volumes:
+        # Used to connect to contiv-etcd.
+        - name: etcd-cfg
+          configMap:
+            name: contiv-etcd-cfg
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        # VPP startup config folder.
+        - name: vpp-cfg
+          hostPath:
+            path: /etc/vpp
+        # To install vppctl.
+        - name: usr-local-bin
+          hostPath:
+            path: /usr/local/bin
+        # LD_PRELOAD library.
+        - name: vpp-lib64
+          hostPath:
+            path: /tmp/ldpreload/vpp-lib64
+        # /dev mount is required for DPDK-managed NICs on VPP (/dev/uio0) and for shared memory communication with VPP (/dev/shm)
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: shm
+          hostPath:
+            path: /dev/shm
+        # For CLI unix socket.
+        - name: vpp-run
+          hostPath:
+            path: /run/vpp
+        # For CNI / STN unix domain socket
+        - name: contiv-run
+          hostPath:
+            path: /var/run/contiv
+        # Used to configure contiv plugin.
+        - name: contiv-plugin-cfg
+          configMap:
+            name: contiv-agent-cfg
+        # Used to configure govpp plugin.
+        - name: govpp-plugin-cfg
+          configMap:
+            name: govpp-cfg
+
+---
+
+# This installs the contiv-ksr (Kubernetes State Reflector) on the master node in a Kubernetes cluster.
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contiv-ksr
+  namespace: kube-system
+  labels:
+    k8s-app: contiv-ksr
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: contiv-ksr
+      annotations:
+        # Marks this pod as a critical add-on.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      # We need this to schedule on the master no matter what else is going on, so tolerate everything.
+      - key: ''
+        operator: Exists
+        effect: ''
+      # This likely isn't needed due to the above wildcard, but keep it in for now.
+      - key: CriticalAddonsOnly
+        operator: Exists
+      # Only run this pod on the master.
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      hostNetwork: true
+      # This grants the required permissions to contiv-ksr.
+      serviceAccountName: contiv-ksr
+
+      initContainers:
+        # This init container waits until etcd is started
+        - name: wait-foretcd
+          env:
+          - name: ETCDPORT
+            value: "32379"
+          image: busybox:latest
+          command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
+
+      containers:
+        - name: contiv-ksr
+          image: contivvpp/ksr-arm64:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ETCD_CONFIG
+              value: "/etc/etcd/etcd.conf"
+            - name: HTTP_CONFIG
+              value: "/etc/http/http.conf"
+          volumeMounts:
+            - name: etcd-cfg
+              mountPath: /etc/etcd
+            - name: http-cfg
+              mountPath: /etc/http
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9191
+            periodSeconds: 1
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9191
+            periodSeconds: 1
+            initialDelaySeconds: 30
+
+      volumes:
+        # Used to connect to contiv-etcd.
+        - name: etcd-cfg
+          configMap:
+            name: contiv-etcd-withcompact-cfg
+        - name: http-cfg
+          configMap:
+            name: contiv-ksr-http-cfg
+
+---
+
+# This cluster role defines a set of permissions required for contiv-ksr.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: contiv-ksr
+  namespace: kube-system
+rules:
+  - apiGroups:
+    - ""
+    - extensions
+    resources:
+      - pods
+      - namespaces
+      - networkpolicies
+      - services
+      - endpoints
+      - nodes
+    verbs:
+      - watch
+      - list
+
+---
+
+# This defines a service account for contiv-ksr.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contiv-ksr
+  namespace: kube-system
+
+---
+
+# This binds the contiv-ksr cluster role with contiv-ksr service account.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: contiv-ksr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: contiv-ksr
+subjects:
+- kind: ServiceAccount
+  name: contiv-ksr
+  namespace: kube-system
+


### PR DESCRIPTION
Add a typical contiv-vpp-arm64.yaml file for deployment on arm64 platform.
The deployment way for that on arm64 is the same as the contiv-vpp.yaml
for x86_64 platform for Kubernetes, which is like:
kubectl apply -f ./contiv-vpp-arm64.yaml

Signed-off-by: trevortao <trevor.tao@arm.com>