### PR TITLE
Fix Helm template error for arm64 and Update Yaml File

### DIFF
--- a/k8s/contiv-vpp-arm64.yaml
+++ b/k8s/contiv-vpp-arm64.yaml
@@ -45,12 +45,19 @@ data:
       VxlanCIDR: 192.168.30.0/24
       NodeInterconnectDHCP: False
   logs.conf: |
-    defaultlevel: debug
+    default-level: debug
   grpc.conf: |
     network: unix
     endpoint: /var/run/contiv/cni.sock
   http.conf: |
-      endpoint: 0.0.0.0:9999
+    endpoint: 0.0.0.0:9999
+  bolt.conf: |
+    db-path: /var/bolt/bolt.db
+    file-mode: 432
+    lock-timeout: 0
+  telemetry.conf: |
+    polling-interval: 30000000000
+    disabled: true
 
 ---
 
@@ -251,6 +258,8 @@ spec:
             name: cni-bin-dir
           - mountPath: /etc/cni/net.d
             name: cni-net-dir
+          - mountPath: /var/run/contiv
+            name: contiv-run
       # This init container waits until etcd is started
       - name: wait-foretcd
         env:
@@ -333,7 +342,13 @@ spec:
                   fieldPath: spec.nodeName
             - name: ETCD_CONFIG
               value: "/etc/etcd/etcd.conf"
+            - name: BOLT_CONFIG
+              value: "/etc/agent/bolt.conf"
+            - name: TELEMETRY_CONFIG
+              value: "/etc/agent/telemetry.conf"
           volumeMounts:
+            - name: var-bolt
+              mountPath: /var/bolt
             - name: etcd-cfg
               mountPath: /etc/etcd
             - name: vpp-cfg
@@ -398,6 +413,9 @@ spec:
         - name: govpp-plugin-cfg
           configMap:
             name: govpp-cfg
+        - name: var-bolt
+          hostPath:
+            path: /var/bolt
 
 ---
 
@@ -446,7 +464,7 @@ spec:
 
       containers:
         - name: contiv-ksr
-          image: contivvpp/ksr:latest
+          image: contivvpp/ksr-arm64:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ETCD_CONFIG

--- a/k8s/contiv-vpp/templates/vpp.yaml
+++ b/k8s/contiv-vpp/templates/vpp.yaml
@@ -83,20 +83,27 @@ data:
     {{- end }}
     {{- end }}
   logs.conf: |
-    defaultlevel: {{ .Values.logs.defaultLevel }}
+    default-level: {{ .Values.logs.defaultLevel }}
   grpc.conf: |
     network: unix
     endpoint: /var/run/contiv/cni.sock
   http.conf: |
-      endpoint: 0.0.0.0:9999
-      {{- if .Values.http.enableServerCert }}
-      server-cert-file: /var/http/{{ .Values.http.serverCert }}
-      server-key-file: /var/http/{{ .Values.http.serverKey }}
-      {{- end }}
-      {{- if .Values.http.enableBasicAuth }}
-      client-basic-auth:
-        - {{ .Values.http.basicAuth | quote }}
-      {{- end }}
+    endpoint: 0.0.0.0:9999
+    {{- if .Values.http.enableServerCert }}
+    server-cert-file: /var/http/{{ .Values.http.serverCert }}
+    server-key-file: /var/http/{{ .Values.http.serverKey }}
+    {{- end }}
+    {{- if .Values.http.enableBasicAuth }}
+    client-basic-auth:
+      - {{ .Values.http.basicAuth | quote }}
+    {{- end }}
+  bolt.conf: |
+    db-path: /var/bolt/bolt.db
+    file-mode: 432
+    lock-timeout: 0
+  telemetry.conf: |
+    polling-interval: {{ .Values.telemetry.pollingInterval | int64 }}
+    disabled: {{ .Values.telemetry.disabled }}
 
 ---
 
@@ -428,6 +435,8 @@ spec:
             name: cni-bin-dir
           - mountPath: /etc/cni/net.d
             name: cni-net-dir
+          - mountPath: /var/run/contiv
+            name: contiv-run
       # This init container waits until etcd is started
       - name: wait-foretcd
         env:
@@ -550,7 +559,17 @@ spec:
                   fieldPath: spec.nodeName
             - name: ETCD_CONFIG
               value: "/etc/etcd/etcd.conf"
+            - name: BOLT_CONFIG
+              value: "/etc/agent/bolt.conf"
+            {{- if .Values.bolt.debug }}
+            - name: DEBUG_BOLT_CLIENT
+              value: "true"
+            {{- end}}
+            - name: TELEMETRY_CONFIG
+              value: "/etc/agent/telemetry.conf"
           volumeMounts:
+            - name: var-bolt
+              mountPath: /var/bolt
             - name: etcd-cfg
               mountPath: /etc/etcd
               {{- if .Values.etcd.secureTransport }}
@@ -680,6 +699,28 @@ spec:
           hostPath:
             path: {{ .Values.vswitch.coreDumpsDir }}
         {{- end }}
+{{- if not .Values.bolt.usePersistentVolume }}
+        - name: var-bolt
+          hostPath:
+            path: {{ .Values.bolt.dataDir }}
+        {{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: var-bolt
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.bolt.persistentVolumeSize }}
+    {{- if .Values.bolt.persistentVolumeStorageClass }}
+    {{- if (eq "-" .Values.bolt.persistentVolumeStorageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.bolt.persistentVolumeStorageClass }}"
+    {{- end }}
+    {{- end }}
+{{- end }}
 
 ---
 
@@ -732,7 +773,11 @@ spec:
 
       containers:
         - name: contiv-ksr
+          {{- if .Values.Arm64Platform }}
+          image: {{ .Values.ksr_arm64.image.repository }}:{{ default .Chart.Version .Values.ksr.image.tag }}
+          {{- else }}
           image: {{ .Values.ksr.image.repository }}:{{ default .Chart.Version .Values.ksr.image.tag }}
+          {{- end }}
           imagePullPolicy: {{ .Values.ksr.image.pullPolicy }}
           env:
             - name: ETCD_CONFIG


### PR DESCRIPTION
1. Fix the Helm template error of using x86 docker image
for arm64
2. Update the contiv-vpp-arm64.yaml to latest version

Signed-off-by: trevortao <trevor.tao@arm.com>