### PR TITLE
Expose IPAM state via REST

### DIFF
--- a/plugins/contiv/ipam/ipam.go
+++ b/plugins/contiv/ipam/ipam.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ligato/cn-infra/db/keyval"
 	"github.com/ligato/cn-infra/logging"
+	"github.com/ligato/cn-infra/rpc/rest"
 	"sort"
 )
 
@@ -37,8 +38,9 @@ type IPAM struct {
 	logger logging.Logger
 	mutex  sync.RWMutex
 
-	nodeID uint32             // identifier of the node for which this IPAM is created for
-	broker keyval.ProtoBroker // broker that is used for persisting
+	nodeID   uint32             // identifier of the node for which this IPAM is created for
+	nodeName string             // node name for which this IPAM is created for
+	broker   keyval.ProtoBroker // broker that is used for persisting
 
 	// POD related variables
 	podSubnetIPPrefix   net.IPNet        // IPv4 subnet from which individual POD networks are allocated, this is subnet for all PODs across all nodes
@@ -81,13 +83,14 @@ type Config struct {
 }
 
 // New returns new IPAM module to be used on the node specified by the nodeID.
-func New(logger logging.Logger, nodeID uint32, config *Config, nodeInterconnectExcludedIPs []net.IP, broker keyval.ProtoBroker) (*IPAM, error) {
+func New(logger logging.Logger, nodeID uint32, nodeName string, config *Config, nodeInterconnectExcludedIPs []net.IP, broker keyval.ProtoBroker, http rest.HTTPHandlers) (*IPAM, error) {
 	// create basic IPAM
 	ipam := &IPAM{
 		logger:       logger,
 		nodeID:       nodeID,
 		lastAssigned: 1,
 		broker:       broker,
+		nodeName:     nodeName,
 	}
 
 	// computing IPAM struct variables from IPAM config
@@ -113,6 +116,7 @@ func New(logger logging.Logger, nodeID uint32, config *Config, nodeInterconnectE
 	}
 	logger.Infof("IPAM values loaded: %+v", ipam)
 
+	ipam.registerHandlers(http)
 	return ipam, nil
 }
 

--- a/plugins/contiv/ipam/ipam_test.go
+++ b/plugins/contiv/ipam/ipam_test.go
@@ -66,7 +66,7 @@ func newDefaultConfig() *ipam.Config {
 func setup(t *testing.T, cfg *ipam.Config) *ipam.IPAM {
 	RegisterTestingT(t)
 
-	i, err := ipam.New(logrus.DefaultLogger(), hostID1, cfg, nil, nil)
+	i, err := ipam.New(logrus.DefaultLogger(), hostID1, "", cfg, nil, nil, nil)
 	Expect(err).To(BeNil())
 	return i
 }
@@ -247,7 +247,7 @@ func TestPodNetworkSubnets(t *testing.T) {
 	var lastID uint32 = 16
 	var outOfRangeId uint32 = 17
 
-	first, err := ipam.New(logrus.DefaultLogger(), firstID, customConfig, nil, nil)
+	first, err := ipam.New(logrus.DefaultLogger(), firstID, "", customConfig, nil, nil, nil)
 	Expect(err).To(BeNil())
 	Expect(first).NotTo(BeNil())
 	Expect(first.PodNetwork().String()).To(BeEquivalentTo("1.4.1.16/28"))
@@ -256,7 +256,7 @@ func TestPodNetworkSubnets(t *testing.T) {
 	Expect(firstNodeIP.String()).To(BeEquivalentTo("3.4.5.193"))
 
 	// the biggest NodeID uses the podNetwork zero-ending
-	last, err := ipam.New(logrus.DefaultLogger(), 16, customConfig, nil, nil)
+	last, err := ipam.New(logrus.DefaultLogger(), 16, "", customConfig, nil, nil, nil)
 	Expect(err).To(BeNil())
 	Expect(last).NotTo(BeNil())
 	Expect(last.PodNetwork().String()).To(BeEquivalentTo("1.4.1.0/28"))
@@ -264,7 +264,7 @@ func TestPodNetworkSubnets(t *testing.T) {
 	Expect(err).To(BeNil())
 	Expect(lastNodeIP.String()).To(BeEquivalentTo("3.4.5.208"))
 
-	outOfRange, err := ipam.New(logrus.DefaultLogger(), outOfRangeId, customConfig, nil, nil)
+	outOfRange, err := ipam.New(logrus.DefaultLogger(), outOfRangeId, "", customConfig, nil, nil, nil)
 	Expect(err).NotTo(BeNil())
 	Expect(outOfRange).To(BeNil())
 }
@@ -279,7 +279,7 @@ func TestMoreThan256Node(t *testing.T) {
 	customConfig.VxlanCIDR = "2.2.128.0/17"
 	customConfig.NodeInterconnectCIDR = "1.1.128.0/17"
 
-	last, err := ipam.New(logrus.DefaultLogger(), 257, customConfig, nil, nil)
+	last, err := ipam.New(logrus.DefaultLogger(), 257, "", customConfig, nil, nil, nil)
 	Expect(err).To(BeNil())
 	Expect(last).NotTo(BeNil())
 
@@ -305,7 +305,7 @@ func TestExceededVxlanRange(t *testing.T) {
 	customConfig.VxlanCIDR = "2.2.2.128/28"
 
 	// valid nodID from pod subnet perspective, however it doesn't fit into vxlan range
-	last, err := ipam.New(logrus.DefaultLogger(), 17, customConfig, nil, nil)
+	last, err := ipam.New(logrus.DefaultLogger(), 17, "", customConfig, nil, nil, nil)
 	Expect(err).To(BeNil())
 	Expect(last).NotTo(BeNil())
 
@@ -330,7 +330,7 @@ func TestExceededNodeIPRange(t *testing.T) {
 	customConfig.NodeInterconnectCIDR = "3.3.3.0/28"
 
 	// valid nodID from pod subnet perspective, however it doesn't fit into nodeIP range
-	last, err := ipam.New(logrus.DefaultLogger(), 17, customConfig, nil, nil)
+	last, err := ipam.New(logrus.DefaultLogger(), 17, "", customConfig, nil, nil, nil)
 	Expect(err).To(BeNil())
 	Expect(last).NotTo(BeNil())
 
@@ -350,17 +350,17 @@ func TestConfigWithBadCIDR(t *testing.T) {
 
 	customConfig := newDefaultConfig()
 	customConfig.PodSubnetCIDR = "1.2.3./19"
-	_, err := ipam.New(logrus.DefaultLogger(), hostID1, customConfig, nil, nil)
+	_, err := ipam.New(logrus.DefaultLogger(), hostID1, "", customConfig, nil, nil, nil)
 	Expect(err).NotTo(BeNil(), "Pod subnet CIDR is unparsable, but IPAM initialization didn't fail")
 
 	customConfig = newDefaultConfig()
 	customConfig.VPPHostSubnetCIDR = "1.2.3./19"
-	_, err = ipam.New(logrus.DefaultLogger(), hostID1, customConfig, nil, nil)
+	_, err = ipam.New(logrus.DefaultLogger(), hostID1, "", customConfig, nil, nil, nil)
 	Expect(err).NotTo(BeNil(), "VSwitch subnet CIDR is unparsable, but IPAM initialization didn't fail")
 
 	customConfig = newDefaultConfig()
 	customConfig.NodeInterconnectCIDR = "1.2.3./19"
-	_, err = ipam.New(logrus.DefaultLogger(), hostID1, customConfig, nil, nil)
+	_, err = ipam.New(logrus.DefaultLogger(), hostID1, "", customConfig, nil, nil, nil)
 	Expect(err).NotTo(BeNil(), "Host subnet CIDR is unparsable, but IPAM initialization didn't fail")
 }
 
@@ -371,13 +371,13 @@ func TestConfigWithBadPrefixSizes(t *testing.T) {
 	customConfig := newDefaultConfig()
 	customConfig.PodSubnetCIDR = "1.2.3.4/19"
 	customConfig.PodNetworkPrefixLen = 18
-	_, err := ipam.New(logrus.DefaultLogger(), hostID1, customConfig, nil, nil)
+	_, err := ipam.New(logrus.DefaultLogger(), hostID1, "", customConfig, nil, nil, nil)
 	Expect(err).NotTo(BeNil())
 
 	customConfig = newDefaultConfig()
 	customConfig.VPPHostSubnetCIDR = "1.2.3.4/19"
 	customConfig.VPPHostNetworkPrefixLen = 18
-	_, err = ipam.New(logrus.DefaultLogger(), hostID1, customConfig, nil, nil)
+	_, err = ipam.New(logrus.DefaultLogger(), hostID1, "", customConfig, nil, nil, nil)
 	Expect(err).NotTo(BeNil())
 }
 
@@ -391,7 +391,7 @@ func TestExcludeGateway(t *testing.T) {
 
 	excluded := []net.IP{anotherUsed, gw}
 	customConfig := newDefaultConfig()
-	ipam, err := ipam.New(logrus.DefaultLogger(), hostID1, customConfig, excluded, nil)
+	ipam, err := ipam.New(logrus.DefaultLogger(), hostID1, "", customConfig, excluded, nil, nil)
 	Expect(err).To(BeNil())
 
 	first, err := ipam.NodeIPAddress(1)

--- a/plugins/contiv/ipam/persist_test.go
+++ b/plugins/contiv/ipam/persist_test.go
@@ -26,7 +26,7 @@ import (
 func TestPersistingAllocatedIPs(t *testing.T) {
 	gomega.RegisterTestingT(t)
 	broker := &broker.MockBroker{}
-	myIpam, err := ipam.New(logrus.DefaultLogger(), 1, newDefaultConfig(), nil, broker)
+	myIpam, err := ipam.New(logrus.DefaultLogger(), 1, "", newDefaultConfig(), nil, broker, nil)
 	gomega.Expect(err).To(gomega.BeNil())
 	gomega.Expect(myIpam).NotTo(gomega.BeNil())
 
@@ -55,7 +55,7 @@ func TestPersistingAllocatedIPs(t *testing.T) {
 	gomega.Expect(broker.Keys()).To(gomega.ContainElement(model.Key("third")))
 
 	// load data by another IPAM instance
-	anotherIPAM, err := ipam.New(logrus.DefaultLogger(), 1, newDefaultConfig(), nil, broker)
+	anotherIPAM, err := ipam.New(logrus.DefaultLogger(), 1, "", newDefaultConfig(), nil, broker, nil)
 	gomega.Expect(err).To(gomega.BeNil())
 	gomega.Expect(anotherIPAM).NotTo(gomega.BeNil())
 

--- a/plugins/contiv/ipam/rest_handlers.go
+++ b/plugins/contiv/ipam/rest_handlers.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"github.com/ligato/cn-infra/rpc/rest"
+	"github.com/unrolled/render"
+	"net/http"
+)
+
+type ipamData struct {
+	NodeID         uint32 `json:"nodeId"`
+	NodeName       string `json:"nodeName"`
+	NodeIP         string `json:"nodeIP"`
+	PodNetwork     string `json:"podNetwork"`
+	VppHostNetwork string `json:"vppHostNetwork"`
+}
+
+func (i *IPAM) registerHandlers(http rest.HTTPHandlers) {
+	if http == nil {
+		i.logger.Warnf("No http handler provided, skipping registration of IPAM REST handlers")
+		return
+	}
+	http.RegisterHTTPHandler("/ipam", i.ipamGetHandler, "GET")
+	i.logger.Infof("IPAM REST handler registered: GET /ipam")
+}
+
+func (i *IPAM) ipamGetHandler(formatter *render.Render) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		i.logger.Debug("Getting IPAM data")
+		nodeID := i.NodeID()
+		nodeIP, err := i.NodeIPAddress(nodeID)
+		if err != nil {
+			i.logger.Errorf("Error getting node IP: %v", err)
+			formatter.JSON(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		formatter.JSON(w, http.StatusOK, ipamData{
+			NodeID:         nodeID,
+			NodeName:       i.nodeName,
+			NodeIP:         nodeIP.String(),
+			PodNetwork:     i.PodNetwork().String(),
+			VppHostNetwork: i.VPPHostNetwork().String(),
+		})
+	}
+}

--- a/plugins/contiv/options.go
+++ b/plugins/contiv/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ligato/cn-infra/db/keyval/etcd"
 	"github.com/ligato/cn-infra/logging"
 	"github.com/ligato/cn-infra/rpc/grpc"
+	"github.com/ligato/cn-infra/rpc/rest"
 	"github.com/ligato/cn-infra/servicelabel"
 	"github.com/ligato/vpp-agent/plugins/govppmux"
 )
@@ -49,6 +50,7 @@ func NewPlugin(opts ...Option) *Plugin {
 	p.Proxy = &kvdbproxy.DefaultPlugin
 	p.ETCD = &etcd.DefaultPlugin
 	p.Bolt = &bolt.DefaultPlugin
+	p.HTTPHandlers = &rest.DefaultPlugin
 
 	for _, o := range opts {
 		o(p)

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ligato/cn-infra/infra"
 	"github.com/ligato/cn-infra/logging"
 	"github.com/ligato/cn-infra/rpc/grpc"
+	"github.com/ligato/cn-infra/rpc/rest"
 	"github.com/ligato/cn-infra/servicelabel"
 	"github.com/ligato/cn-infra/utils/safeclose"
 	"github.com/ligato/vpp-agent/clientv1/linux"
@@ -85,6 +86,7 @@ type Deps struct {
 	ETCD         *etcd.Plugin
 	Bolt         keyval.KvProtoPlugin
 	Watcher      datasync.KeyValProtoWatcher
+	HTTPHandlers rest.HTTPHandlers
 }
 
 // Config represents configuration for the Contiv plugin.
@@ -197,7 +199,8 @@ func (plugin *Plugin) Init() error {
 		plugin.myNodeConfig,
 		nodeID,
 		plugin.excludedIPsFromNodeCIDR(),
-		plugin.Bolt.NewBroker(plugin.ServiceLabel.GetAgentPrefix()))
+		plugin.Bolt.NewBroker(plugin.ServiceLabel.GetAgentPrefix()),
+		plugin.HTTPHandlers)
 	if err != nil {
 		return fmt.Errorf("Can't create new remote CNI server due to error: %v ", err)
 	}

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ligato/cn-infra/datasync"
 	"github.com/ligato/cn-infra/db/keyval"
 	"github.com/ligato/cn-infra/logging"
+	"github.com/ligato/cn-infra/rpc/rest"
 	"github.com/ligato/vpp-agent/clientv1/linux"
 	linux_intf "github.com/ligato/vpp-agent/plugins/linux/model/interfaces"
 	linux_l3 "github.com/ligato/vpp-agent/plugins/linux/model/l3"
@@ -222,8 +223,8 @@ type vswitchConfig struct {
 // newRemoteCNIServer initializes a new remote CNI server instance.
 func newRemoteCNIServer(logger logging.Logger, vppTxnFactory func() linuxclient.DataChangeDSL, proxy kvdbproxy.Proxy,
 	configuredContainers *containeridx.ConfigIndex, govppChan api.Channel, index ifaceidx.SwIfIndex, dhcpIndex ifaceidx.DhcpIndex, agentLabel string,
-	config *Config, nodeConfig *OneNodeConfig, nodeID uint32, nodeExcludeIPs []net.IP, broker keyval.ProtoBroker) (*remoteCNIserver, error) {
-	ipam, err := ipam.New(logger, nodeID, &config.IPAMConfig, nodeExcludeIPs, broker)
+	config *Config, nodeConfig *OneNodeConfig, nodeID uint32, nodeExcludeIPs []net.IP, broker keyval.ProtoBroker, http rest.HTTPHandlers) (*remoteCNIserver, error) {
+	ipam, err := ipam.New(logger, nodeID, agentLabel, &config.IPAMConfig, nodeExcludeIPs, broker, http)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/contiv/remote_cni_server_test.go
+++ b/plugins/contiv/remote_cni_server_test.go
@@ -157,6 +157,7 @@ func setupTestCNIServer(config *Config, nodeConfig *OneNodeConfig, existingInter
 		nodeConfig,
 		1,
 		nil,
+		nil,
 		nil)
 	server.test = true
 	gomega.Expect(err).To(gomega.BeNil())
@@ -407,7 +408,7 @@ func TestVeth1NameFromRequest(t *testing.T) {
 		"testlabel",
 		&configVethL2NoTCP,
 		nil,
-		1, nil, nil)
+		1, nil, nil, nil)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	hostIfName := server.veth1HostIfNameFromRequest(&req)


### PR DESCRIPTION
Expose IPAM state:
```
{
  nodeId,
  nodeIP,
  nodeName,
  podNetwork,
  vppHostNetwork
}
```

via HTPP REST interface (endpoint is `GET /ipam`).

Example output:

```json
$ http 10.0.2.15:9999/ipam
HTTP/1.1 200 OK
Content-Length: 158
Content-Type: application/json; charset=UTF-8
Date: Fri, 17 Aug 2018 11:07:53 GMT

{
    "nodeIP": "192.168.16.1",
    "nodeId": 1,
    "nodeName": "vagrant-arch.vagrantup.com",
    "podNetwork": "10.1.1.0/24",
    "vppHostNetwork": "172.30.1.0/24"
}
```

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>