### PR TITLE
Make the IPAM endpoint versioned (/contiv/v1/) + add documentation

### DIFF
--- a/plugins/contiv/ipam/doc.go
+++ b/plugins/contiv/ipam/doc.go
@@ -24,4 +24,18 @@
 //		Calculated POD IPs: 10.1.5.2 - 10.1.5.254 (/24)
 //		Calculated VPP-host interconnect IPs: 172.30.5.1, 172.30.5.2 (/24)
 //  	Calculated Node Interconnect IP:  192.168.16.5 (/24)
+//
+// Additionally the package provides REST endpoint for getting some of IPAM informations from node on URL
+// GET /contiv/v1/ipam.
+//
+// Example:
+//
+//      $ curl localhost:9999/contiv/v1/ipam
+//      {
+//        "nodeId": 1,
+//        "nodeName": "vagrant-arch.vagrantup.com",
+//        "nodeIP": "192.168.16.1",
+//        "podNetwork": "10.1.1.0/24",
+//        "vppHostNetwork": "172.30.1.0/24"
+//      }
 package ipam

--- a/plugins/contiv/ipam/rest_handlers.go
+++ b/plugins/contiv/ipam/rest_handlers.go
@@ -20,6 +20,13 @@ import (
 	"net/http"
 )
 
+const (
+	// Prefix is versioned prefix for REST urls
+	Prefix = "/contiv/v1/"
+	// PluginURL is versioned URL (using prefix) for IPAM REST endpoint
+	PluginURL = Prefix + "ipam"
+)
+
 type ipamData struct {
 	NodeID         uint32 `json:"nodeId"`
 	NodeName       string `json:"nodeName"`
@@ -33,8 +40,8 @@ func (i *IPAM) registerHandlers(http rest.HTTPHandlers) {
 		i.logger.Warnf("No http handler provided, skipping registration of IPAM REST handlers")
 		return
 	}
-	http.RegisterHTTPHandler("/ipam", i.ipamGetHandler, "GET")
-	i.logger.Infof("IPAM REST handler registered: GET /ipam")
+	http.RegisterHTTPHandler(PluginURL, i.ipamGetHandler, "GET")
+	i.logger.Infof("IPAM REST handler registered: GET %v", PluginURL)
 }
 
 func (i *IPAM) ipamGetHandler(formatter *render.Render) http.HandlerFunc {


### PR DESCRIPTION
- Add new prefix const to rest_handlers that contains versioned prefix
for the REST endpoints
- Make /ipam endpoint use new versioned prefix (so now it is
/contiv/v1/ipam)
- Update documentation for IPAM plugin to include informations about REST
endpoints it exposes with curl example.

See https://github.com/contiv/vpp/pull/1039#issuecomment-413912333 for context.

Example curl output:

```
$ curl localhost:9999/contiv/v1/ipam
{
  "nodeId": 1,
  "nodeName": "vagrant-arch.vagrantup.com",
  "nodeIP": "192.168.16.1",
  "podNetwork": "10.1.1.0/24",
  "vppHostNetwork": "172.30.1.0/24"
}
```