### PR TITLE
Add yamllint to our travis-ci runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 dist: trusty
 sudo: required
 language: go
@@ -24,6 +25,7 @@ before_install:
   - go get -v github.com/mattn/goveralls
 
 script:
+  - make yamllint
   - make check-links || true
   - make check-format
   - make lint

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 80
+    level: warning

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,17 @@ helm-yaml:
 helm-yaml-arm64:
 	helm template --set vswitch.image.tag=${TAG} --set cni.image.tag=${TAG} --set ksr.image.tag=${TAG} k8s/contiv-vpp -f k8s/contiv-vpp/values-arm64.yaml,k8s/contiv-vpp/values.yaml > k8s/contiv-vpp-arm64.yaml
 
+# Install yamllint
+get-yamllint:
+	pip install --user yamllint
+
+# Lint the yaml files
+yamllint: get-yamllint
+	@echo "=> linting the yaml files"
+	# NOTE: For now we skip the k8s/contiv-vpp directoy as the wackiness going on there with regards
+	# to variable substitution does not make yamllint happy at all.
+	yamllint -c .yamllint.yml $(shell git ls-files '*.yaml' '*.yml' | grep -v 'vendor/' | grep -v 'k8s/contiv-vpp')
+
 .PHONY: build all \
 	install clean test test-race \
 	get-covtools test-cover test-cover-html test-cover-xml \
@@ -270,4 +281,5 @@ helm-yaml-arm64:
 	get-dep dep-install \
 	docker-images docker-dev vagrant-images\
 	describe generate-manifest helm-package helm-yaml \
-	generate-manifest-arm64 helm-yaml-arm64
+	generate-manifest-arm64 helm-yaml-arm64 \
+	get-yamllint yamllint

--- a/k8s/contiv-vpp-arm64.yaml
+++ b/k8s/contiv-vpp-arm64.yaml
@@ -112,13 +112,13 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
-      # We need this to schedule on the master no matter what else is going on, so tolerate everything.
-      - key: ''
-        operator: Exists
-        effect: ''
-      # This likely isn't needed due to the above wildcard, but keep it in for now.
-      - key: CriticalAddonsOnly
-        operator: Exists
+        # We need this to schedule on the master no matter what else is going on, so tolerate everything.
+        - key: ''
+          operator: Exists
+          effect: ''
+        # This likely isn't needed due to the above wildcard, but keep it in for now.
+        - key: CriticalAddonsOnly
+          operator: Exists
       # Only run this pod on the master.
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -149,7 +149,7 @@ spec:
       volumes:
         - name: var-etcd
           hostPath:
-             path: /var/etcd
+            path: /var/etcd
 
 ---
 
@@ -164,8 +164,8 @@ spec:
   selector:
     k8s-app: contiv-etcd
   ports:
-  - port: 12379
-    nodePort: 32379
+    - port: 12379
+      nodePort: 32379
 
 ---
 apiVersion: v1
@@ -236,77 +236,77 @@ spec:
     spec:
       # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: CriticalAddonsOnly
-        operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: CriticalAddonsOnly
+          operator: Exists
       hostNetwork: true
       hostPID: true
 
       # Init containers are executed before regular containers, must finish successfully before regular ones are started.
       initContainers:
-      # This container installs the Contiv CNI binaries
-      # and CNI network config file on each node.
-      - name: contiv-cni
-        image: contivvpp/cni-arm64:latest
-        imagePullPolicy: IfNotPresent
-        env:
-          - name: SLEEP
-            value: "false"
-        volumeMounts:
-          - mountPath: /opt/cni/bin
-            name: cni-bin-dir
-          - mountPath: /etc/cni/net.d
-            name: cni-net-dir
-          - mountPath: /var/run/contiv
-            name: contiv-run
-      # This init container waits until etcd is started
-      - name: wait-foretcd
-        env:
-          - name: ETCDPORT
-            value: "32379"
-        image: arm64v8/busybox:latest
-        command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
-      # This init container extracts/copies VPP LD_PRELOAD libs and default VPP config to the host.
-      - name: vpp-init
-        image: contivvpp/vswitch-arm64:latest
-        imagePullPolicy: IfNotPresent
-        command:
-        - /bin/sh
-        args:
-        - -c
-        - |
-          set -eu
-          chmod 700 /run/vpp
-          rm -rf /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api
-          if [ ! -e /host/etc/vpp/contiv-vswitch.conf ]; then
-              cp /etc/vpp/contiv-vswitch.conf /host/etc/vpp/
-          fi
-          if [ ! -d /var/run/contiv ]; then
-              mkdir /var/run/contiv
-          fi
-          chmod 700 /var/run/contiv
-          rm -f /var/run/contiv/cni.sock
-          if ip link show vpp1 >/dev/null 2>&1; then
-               ip link del vpp1
-          fi
-          cp -f /usr/local/bin/vppctl /host/usr/local/bin/vppctl
-        resources: {}
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - name: usr-local-bin
-            mountPath: /host/usr/local/bin
-          - name: vpp-lib64
-            mountPath: /vpp-lib64/
-          - name: vpp-cfg
-            mountPath: /host/etc/vpp
-          - name: shm
-            mountPath: /dev/shm
-          - name: vpp-run
-            mountPath: /run/vpp
-          - name: contiv-run
-            mountPath: /var/run/contiv
+        # This container installs the Contiv CNI binaries
+        # and CNI network config file on each node.
+        - name: contiv-cni
+          image: contivvpp/cni-arm64:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SLEEP
+              value: "false"
+          volumeMounts:
+            - mountPath: /opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /var/run/contiv
+              name: contiv-run
+        # This init container waits until etcd is started
+        - name: wait-foretcd
+          env:
+            - name: ETCDPORT
+              value: "32379"
+          image: arm64v8/busybox:latest
+          command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
+        # This init container extracts/copies VPP LD_PRELOAD libs and default VPP config to the host.
+        - name: vpp-init
+          image: contivvpp/vswitch-arm64:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - |
+              set -eu
+              chmod 700 /run/vpp
+              rm -rf /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api
+              if [ ! -e /host/etc/vpp/contiv-vswitch.conf ]; then
+                cp /etc/vpp/contiv-vswitch.conf /host/etc/vpp/
+              fi
+              if [ ! -d /var/run/contiv ]; then
+                mkdir /var/run/contiv
+              fi
+              chmod 700 /var/run/contiv
+              rm -f /var/run/contiv/cni.sock
+              if ip link show vpp1 >/dev/null 2>&1; then
+                ip link del vpp1
+              fi
+              cp -f /usr/local/bin/vppctl /host/usr/local/bin/vppctl
+          resources: {}
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: usr-local-bin
+              mountPath: /host/usr/local/bin
+            - name: vpp-lib64
+              mountPath: /vpp-lib64/
+            - name: vpp-cfg
+              mountPath: /host/etc/vpp
+            - name: shm
+              mountPath: /dev/shm
+            - name: vpp-run
+              mountPath: /run/vpp
+            - name: contiv-run
+              mountPath: /var/run/contiv
 
       containers:
         # Runs contiv-vswitch container on each Kubernetes node.
@@ -438,13 +438,13 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
-      # We need this to schedule on the master no matter what else is going on, so tolerate everything.
-      - key: ''
-        operator: Exists
-        effect: ''
-      # This likely isn't needed due to the above wildcard, but keep it in for now.
-      - key: CriticalAddonsOnly
-        operator: Exists
+        # We need this to schedule on the master no matter what else is going on, so tolerate everything.
+        - key: ''
+          operator: Exists
+          effect: ''
+        # This likely isn't needed due to the above wildcard, but keep it in for now.
+        - key: CriticalAddonsOnly
+          operator: Exists
       # Only run this pod on the master.
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -456,8 +456,8 @@ spec:
         # This init container waits until etcd is started
         - name: wait-foretcd
           env:
-          - name: ETCDPORT
-            value: "32379"
+            - name: ETCDPORT
+              value: "32379"
           image: arm64v8/busybox:latest
           command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
 
@@ -507,8 +507,8 @@ metadata:
   namespace: kube-system
 rules:
   - apiGroups:
-    - ""
-    - extensions
+      - ""
+      - extensions
     resources:
       - pods
       - namespaces
@@ -541,7 +541,6 @@ roleRef:
   kind: ClusterRole
   name: contiv-ksr
 subjects:
-- kind: ServiceAccount
-  name: contiv-ksr
-  namespace: kube-system
-
+  - kind: ServiceAccount
+    name: contiv-ksr
+    namespace: kube-system

--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -117,13 +117,13 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
-      # We need this to schedule on the master no matter what else is going on, so tolerate everything.
-      - key: ''
-        operator: Exists
-        effect: ''
-      # This likely isn't needed due to the above wildcard, but keep it in for now.
-      - key: CriticalAddonsOnly
-        operator: Exists
+        # We need this to schedule on the master no matter what else is going on, so tolerate everything.
+        - key: ''
+          operator: Exists
+          effect: ''
+        # This likely isn't needed due to the above wildcard, but keep it in for now.
+        - key: CriticalAddonsOnly
+          operator: Exists
       # Only run this pod on the master.
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -152,7 +152,7 @@ spec:
       volumes:
         - name: var-etcd
           hostPath:
-             path: /var/etcd
+            path: /var/etcd
 
 ---
 
@@ -167,8 +167,8 @@ spec:
   selector:
     k8s-app: contiv-etcd
   ports:
-  - port: 12379
-    nodePort: 32379
+    - port: 12379
+      nodePort: 32379
 
 ---
 apiVersion: v1
@@ -239,77 +239,77 @@ spec:
     spec:
       # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: CriticalAddonsOnly
-        operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: CriticalAddonsOnly
+          operator: Exists
       hostNetwork: true
       hostPID: true
 
       # Init containers are executed before regular containers, must finish successfully before regular ones are started.
       initContainers:
-      # This container installs the Contiv CNI binaries
-      # and CNI network config file on each node.
-      - name: contiv-cni
-        image: contivvpp/cni:latest
-        imagePullPolicy: IfNotPresent
-        env:
-          - name: SLEEP
-            value: "false"
-        volumeMounts:
-          - mountPath: /opt/cni/bin
-            name: cni-bin-dir
-          - mountPath: /etc/cni/net.d
-            name: cni-net-dir
-          - mountPath: /var/run/contiv
-            name: contiv-run
-      # This init container waits until etcd is started
-      - name: wait-foretcd
-        env:
-          - name: ETCDPORT
-            value: "32379"
-        image: busybox:latest
-        command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
-      # This init container extracts/copies VPP LD_PRELOAD libs and default VPP config to the host.
-      - name: vpp-init
-        image: contivvpp/vswitch:latest
-        imagePullPolicy: IfNotPresent
-        command:
-        - /bin/sh
-        args:
-        - -c
-        - |
-          set -eu
-          chmod 700 /run/vpp
-          rm -rf /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api
-          if [ ! -e /host/etc/vpp/contiv-vswitch.conf ]; then
-              cp /etc/vpp/contiv-vswitch.conf /host/etc/vpp/
-          fi
-          if [ ! -d /var/run/contiv ]; then
-              mkdir /var/run/contiv
-          fi
-          chmod 700 /var/run/contiv
-          rm -f /var/run/contiv/cni.sock
-          if ip link show vpp1 >/dev/null 2>&1; then
-               ip link del vpp1
-          fi
-          cp -f /usr/local/bin/vppctl /host/usr/local/bin/vppctl
-        resources: {}
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - name: usr-local-bin
-            mountPath: /host/usr/local/bin
-          - name: vpp-lib64
-            mountPath: /vpp-lib64/
-          - name: vpp-cfg
-            mountPath: /host/etc/vpp
-          - name: shm
-            mountPath: /dev/shm
-          - name: vpp-run
-            mountPath: /run/vpp
-          - name: contiv-run
-            mountPath: /var/run/contiv
+        # This container installs the Contiv CNI binaries
+        # and CNI network config file on each node.
+        - name: contiv-cni
+          image: contivvpp/cni:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SLEEP
+              value: "false"
+          volumeMounts:
+            - mountPath: /opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /var/run/contiv
+              name: contiv-run
+        # This init container waits until etcd is started
+        - name: wait-foretcd
+          env:
+            - name: ETCDPORT
+              value: "32379"
+          image: busybox:latest
+          command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
+        # This init container extracts/copies VPP LD_PRELOAD libs and default VPP config to the host.
+        - name: vpp-init
+          image: contivvpp/vswitch:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - |
+              set -eu
+              chmod 700 /run/vpp
+              rm -rf /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api
+              if [ ! -e /host/etc/vpp/contiv-vswitch.conf ]; then
+                cp /etc/vpp/contiv-vswitch.conf /host/etc/vpp/
+              fi
+              if [ ! -d /var/run/contiv ]; then
+                mkdir /var/run/contiv
+              fi
+              chmod 700 /var/run/contiv
+              rm -f /var/run/contiv/cni.sock
+              if ip link show vpp1 >/dev/null 2>&1; then
+                ip link del vpp1
+              fi
+              cp -f /usr/local/bin/vppctl /host/usr/local/bin/vppctl
+          resources: {}
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: usr-local-bin
+              mountPath: /host/usr/local/bin
+            - name: vpp-lib64
+              mountPath: /vpp-lib64/
+            - name: vpp-cfg
+              mountPath: /host/etc/vpp
+            - name: shm
+              mountPath: /dev/shm
+            - name: vpp-run
+              mountPath: /run/vpp
+            - name: contiv-run
+              mountPath: /var/run/contiv
 
       containers:
         # Runs contiv-vswitch container on each Kubernetes node.
@@ -442,13 +442,13 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
-      # We need this to schedule on the master no matter what else is going on, so tolerate everything.
-      - key: ''
-        operator: Exists
-        effect: ''
-      # This likely isn't needed due to the above wildcard, but keep it in for now.
-      - key: CriticalAddonsOnly
-        operator: Exists
+        # We need this to schedule on the master no matter what else is going on, so tolerate everything.
+        - key: ''
+          operator: Exists
+          effect: ''
+        # This likely isn't needed due to the above wildcard, but keep it in for now.
+        - key: CriticalAddonsOnly
+          operator: Exists
       # Only run this pod on the master.
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -460,8 +460,8 @@ spec:
         # This init container waits until etcd is started
         - name: wait-foretcd
           env:
-          - name: ETCDPORT
-            value: "32379"
+            - name: ETCDPORT
+              value: "32379"
           image: busybox:latest
           command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
 
@@ -511,8 +511,8 @@ metadata:
   namespace: kube-system
 rules:
   - apiGroups:
-    - ""
-    - extensions
+      - ""
+      - extensions
     resources:
       - pods
       - namespaces
@@ -545,7 +545,6 @@ roleRef:
   kind: ClusterRole
   name: contiv-ksr
 subjects:
-- kind: ServiceAccount
-  name: contiv-ksr
-  namespace: kube-system
-
+  - kind: ServiceAccount
+    name: contiv-ksr
+    namespace: kube-system

--- a/k8s/demo/kubecon2017/sce1-nginx/nginx.yaml
+++ b/k8s/demo/kubecon2017/sce1-nginx/nginx.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +7,8 @@ metadata:
     app: nginx
 spec:
   ports:
-  - name: http
-    port: 80
+    - name: http
+      port: 80
   selector:
     app: nginx
 ---
@@ -23,9 +24,8 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nginx
-        imagePullPolicy: IfNotPresent
-        name: nginx
-        ports:
-        - containerPort: 80
-
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
+            - containerPort: 80

--- a/k8s/demo/kubecon2017/sce2-nginx-istio/nginx-inject.yaml
+++ b/k8s/demo/kubecon2017/sce2-nginx-istio/nginx-inject.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +7,8 @@ metadata:
     app: nginx
 spec:
   ports:
-  - name: http
-    port: 80
+    - name: http
+      port: 80
   selector:
     app: nginx
 ---
@@ -30,101 +31,100 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nginx
-        imagePullPolicy: IfNotPresent
-        name: nginx
-        ports:
-        - containerPort: 80
-        resources: {}
-      - args:
-        - proxy
-        - sidecar
-        - -v
-        - "2"
-        - --configPath
-        - /etc/istio/proxy
-        - --binaryPath
-        - /usr/local/bin/envoy
-        - --serviceCluster
-        - nginx
-        - --drainDuration
-        - 45s
-        - --parentShutdownDuration
-        - 1m0s
-        - --discoveryAddress
-        - istio-pilot.istio-system:8080
-        - --discoveryRefreshDelay
-        - 1s
-        - --zipkinAddress
-        - zipkin.istio-system:9411
-        - --connectTimeout
-        - 10s
-        - --statsdUdpAddress
-        - istio-mixer.istio-system:9125
-        - --proxyAdminPort
-        - "15000"
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: docker.io/istio/proxy_debug:0.2.10
-        imagePullPolicy: IfNotPresent
-        name: istio-proxy
-        resources: {}
-        securityContext:
-          privileged: true
-          readOnlyRootFilesystem: false
-          runAsUser: 1337
-        volumeMounts:
-        - mountPath: /etc/istio/proxy
-          name: istio-envoy
-        - mountPath: /etc/certs/
-          name: istio-certs
-          readOnly: true
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
+            - containerPort: 80
+          resources: {}
+        - args:
+            - proxy
+            - sidecar
+            - -v
+            - "2"
+            - --configPath
+            - /etc/istio/proxy
+            - --binaryPath
+            - /usr/local/bin/envoy
+            - --serviceCluster
+            - nginx
+            - --drainDuration
+            - 45s
+            - --parentShutdownDuration
+            - 1m0s
+            - --discoveryAddress
+            - istio-pilot.istio-system:8080
+            - --discoveryRefreshDelay
+            - 1s
+            - --zipkinAddress
+            - zipkin.istio-system:9411
+            - --connectTimeout
+            - 10s
+            - --statsdUdpAddress
+            - istio-mixer.istio-system:9125
+            - --proxyAdminPort
+            - "15000"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          image: docker.io/istio/proxy_debug:0.2.10
+          imagePullPolicy: IfNotPresent
+          name: istio-proxy
+          resources: {}
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: false
+            runAsUser: 1337
+          volumeMounts:
+            - mountPath: /etc/istio/proxy
+              name: istio-envoy
+            - mountPath: /etc/certs/
+              name: istio-certs
+              readOnly: true
       initContainers:
-      - args:
-        - -p
-        - "15001"
-        - -u
-        - "1337"
-        image: docker.io/istio/proxy_init:0.2.10
-        imagePullPolicy: IfNotPresent
-        name: istio-init
-        resources: {}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: true
-      - args:
-        - -c
-        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
-          unlimited
-        command:
-        - /bin/sh
-        image: alpine
-        imagePullPolicy: IfNotPresent
-        name: enable-core-dump
-        resources: {}
-        securityContext:
-          privileged: true
+        - args:
+            - -p
+            - "15001"
+            - -u
+            - "1337"
+          image: docker.io/istio/proxy_init:0.2.10
+          imagePullPolicy: IfNotPresent
+          name: istio-init
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+            privileged: true
+        - args:
+            - -c
+            - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
+          command:
+            - /bin/sh
+          image: alpine
+          imagePullPolicy: IfNotPresent
+          name: enable-core-dump
+          resources: {}
+          securityContext:
+            privileged: true
       volumes:
-      - emptyDir:
-          medium: Memory
-          sizeLimit: "0"
-        name: istio-envoy
-      - name: istio-certs
-        secret:
-          optional: true
-          secretName: istio.default
+        - emptyDir:
+            medium: Memory
+            sizeLimit: "0"
+          name: istio-envoy
+        - name: istio-certs
+          secret:
+            optional: true
+            secretName: istio.default
 status: {}
 ---

--- a/k8s/demo/kubecon2017/sce3-nginx-ldpreload/nginx-ldpreload.yaml
+++ b/k8s/demo/kubecon2017/sce3-nginx-ldpreload/nginx-ldpreload.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/k8s/demo/kubecon2017/sce4-policies/pods.yaml
+++ b/k8s/demo/kubecon2017/sce4-policies/pods.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -7,12 +8,12 @@ metadata:
     role: db
 spec:
   containers:
-  - image: ciscolabs/epapp
-    command:
-      - sleep
-      - "3600"
-    imagePullPolicy: IfNotPresent
-    name: pod1
+    - image: ciscolabs/epapp
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: pod1
   restartPolicy: Always
 
 ---
@@ -25,12 +26,12 @@ metadata:
     role: frontend
 spec:
   containers:
-  - image: ciscolabs/epapp
-    command:
-      - sleep
-      - "3600"
-    imagePullPolicy: IfNotPresent
-    name: pod2
+    - image: ciscolabs/epapp
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: pod2
   restartPolicy: Always
 
 ---
@@ -43,11 +44,10 @@ metadata:
     role: backend
 spec:
   containers:
-  - image: ciscolabs/epapp
-    command:
-      - sleep
-      - "3600"
-    imagePullPolicy: IfNotPresent
-    name: pod3
+    - image: ciscolabs/epapp
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: pod3
   restartPolicy: Always
-

--- a/k8s/demo/kubecon2017/sce4-policies/policy.yaml
+++ b/k8s/demo/kubecon2017/sce4-policies/policy.yaml
@@ -1,3 +1,4 @@
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -9,10 +10,9 @@ spec:
       app: webstore
       role: db
   ingress:
-  - ports:
-    - port: 8080
-    from:
-    - podSelector:
-        matchLabels:
-          role: frontend
-
+    - ports:
+        - port: 8080
+          from:
+        - podSelector:
+            matchLabels:
+              role: frontend

--- a/k8s/examples/envoy/envoy-nginx-ldpreload.yaml
+++ b/k8s/examples/envoy/envoy-nginx-ldpreload.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -10,28 +11,28 @@ spec:
   restartPolicy: Never
 
   containers:
-  - name: envoy
-    image: envoy-pod:v1
-    imagePullPolicy: IfNotPresent
-    env:
-      # ldpreload-related env vars
-      - name: VCL_APP_SCOPE_GLOBAL
-        value: ""
-      - name: VCL_APP_SCOPE_LOCAL
-        value: ""
-      - name: VCL_APP_PROXY_TRANSPORT_TCP
-        value: ""
-      # enable verbose VCL debugs, do not use for production
-      - name: VCL_DEBUG
-        value: "3"
+    - name: envoy
+      image: envoy-pod:v1
+      imagePullPolicy: IfNotPresent
+      env:
+        # ldpreload-related env vars
+        - name: VCL_APP_SCOPE_GLOBAL
+          value: ""
+        - name: VCL_APP_SCOPE_LOCAL
+          value: ""
+        - name: VCL_APP_PROXY_TRANSPORT_TCP
+          value: ""
+        # enable verbose VCL debugs, do not use for production
+        - name: VCL_DEBUG
+          value: "3"
 
-  - name: nginx
-    image: nginx
-    imagePullPolicy: IfNotPresent
-    env:
-      # ldpreload-related env vars
-      - name: VCL_APP_SCOPE_LOCAL
-        value: ""
-      # enable verbose VCL debugs, do not use for production
-      - name: VCL_DEBUG
-        value: "3"
+    - name: nginx
+      image: nginx
+      imagePullPolicy: IfNotPresent
+      env:
+        # ldpreload-related env vars
+        - name: VCL_APP_SCOPE_LOCAL
+          value: ""
+        # enable verbose VCL debugs, do not use for production
+        - name: VCL_DEBUG
+          value: "3"

--- a/k8s/examples/envoy/envoy-nginx.yaml
+++ b/k8s/examples/envoy/envoy-nginx.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -7,11 +8,10 @@ spec:
   restartPolicy: Never
 
   containers:
-  - name: envoy
-    image: envoy-pod:v1
-    imagePullPolicy: IfNotPresent
+    - name: envoy
+      image: envoy-pod:v1
+      imagePullPolicy: IfNotPresent
 
-  - name: nginx
-    image: nginx
-    imagePullPolicy: IfNotPresent
-
+    - name: nginx
+      image: nginx
+      imagePullPolicy: IfNotPresent

--- a/k8s/examples/nginx-proxy/nginx-proxy.yaml
+++ b/k8s/examples/nginx-proxy/nginx-proxy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -10,29 +11,28 @@ spec:
   restartPolicy: Never
 
   containers:
-  - name: nginx-proxy
-    image: nginx-proxy
-    imagePullPolicy: IfNotPresent
-    env:
-      # ldpreload-related env vars
-      - name: VCL_APP_SCOPE_GLOBAL
-        value: ""
-      - name: VCL_APP_SCOPE_LOCAL
-        value: ""
-      - name: VCL_APP_PROXY_TRANSPORT_TCP
-        value: ""
-      # enable verbose VCL debugs, do not use for production
-      - name: VCL_DEBUG
-        value: "3"
+    - name: nginx-proxy
+      image: nginx-proxy
+      imagePullPolicy: IfNotPresent
+      env:
+        # ldpreload-related env vars
+        - name: VCL_APP_SCOPE_GLOBAL
+          value: ""
+        - name: VCL_APP_SCOPE_LOCAL
+          value: ""
+        - name: VCL_APP_PROXY_TRANSPORT_TCP
+          value: ""
+        # enable verbose VCL debugs, do not use for production
+        - name: VCL_DEBUG
+          value: "3"
 
-  - name: nginx-server
-    image: nginx
-    imagePullPolicy: IfNotPresent
-    env:
-      # ldpreload-related env vars
-      - name: VCL_APP_SCOPE_LOCAL
-        value: ""
-      # enable verbose VCL debugs, do not use for production
-      - name: VCL_DEBUG
-        value: "3"
-
+    - name: nginx-server
+      image: nginx
+      imagePullPolicy: IfNotPresent
+      env:
+        # ldpreload-related env vars
+        - name: VCL_APP_SCOPE_LOCAL
+          value: ""
+        # enable verbose VCL debugs, do not use for production
+        - name: VCL_DEBUG
+          value: "3"

--- a/tests/nginx-istio/nginx-envoy.yaml
+++ b/tests/nginx-istio/nginx-envoy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +7,8 @@ metadata:
     app: nginx
 spec:
   ports:
-  - name: http
-    port: 80
+    - name: http
+      port: 80
   selector:
     app: nginx
 ---
@@ -31,118 +32,106 @@ spec:
         ldpreload: "true"
     spec:
       containers:
-      - image: nginx
-        imagePullPolicy: IfNotPresent
-        name: nginx
-        ports:
-        - containerPort: 80
-        resources: {}
-        env:
-          # ldpreload-related env vars
-          - name: VCL_APP_SCOPE_LOCAL
-            value: ""
-          # enable verbose VCL debugs, do not use for production
-          - name: VCL_DEBUG
-            value: "3"
-      - args:
-        - proxy
-        - sidecar
-        - -v
-        - "2"
-        - --configPath
-        - /etc/istio/proxy
-        - --binaryPath
-        - /usr/local/bin/envoy
-        - --serviceCluster
-        - nginx
-        - --drainDuration
-        - 45s
-        - --parentShutdownDuration
-        - 1m0s
-        - --discoveryAddress
-        - istio-pilot.istio-system:8080
-        - --discoveryRefreshDelay
-        - 1s
-        - --zipkinAddress
-        - zipkin.istio-system:9411
-        - --connectTimeout
-        - 10s
-        - --statsdUdpAddress
-        - istio-mixer.istio-system:9125
-        - --proxyAdminPort
-        - "15000"
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        # ldpreload-related env vars
-        - name: VCL_APP_SCOPE_GLOBAL
-          value: ""
-        - name: VCL_APP_SCOPE_LOCAL
-          value: ""
-        - name: VCL_APP_PROXY_TRANSPORT_TCP
-          value: ""
-        # enable verbose VCL debugs, do not use for production
-        - name: VCL_DEBUG
-          value: "3"
-        image: docker.io/istio/proxy_debug:0.2.10
-        imagePullPolicy: IfNotPresent
-        name: istio-proxy
-        resources: {}
-        securityContext:
-          privileged: true
-          readOnlyRootFilesystem: false
-          runAsUser: 1337
-        volumeMounts:
-        - mountPath: /etc/istio/proxy
-          name: istio-envoy
-        - mountPath: /etc/certs/
-          name: istio-certs
-          readOnly: true
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
+            - containerPort: 80
+          resources: {}
+          env:
+            # ldpreload-related env vars
+            - name: VCL_APP_SCOPE_LOCAL
+              value: ""
+            # enable verbose VCL debugs, do not use for production
+            - name: VCL_DEBUG
+              value: "3"
+        - args:
+            - proxy
+            - sidecar
+            - -v
+            - "2"
+            - --configPath
+            - /etc/istio/proxy
+            - --binaryPath
+            - /usr/local/bin/envoy
+            - --serviceCluster
+            - nginx
+            - --drainDuration
+            - 45s
+            - --parentShutdownDuration
+            - 1m0s
+            - --discoveryAddress
+            - istio-pilot.istio-system:8080
+            - --discoveryRefreshDelay
+            - 1s
+            - --zipkinAddress
+            - zipkin.istio-system:9411
+            - --connectTimeout
+            - 10s
+            - --statsdUdpAddress
+            - istio-mixer.istio-system:9125
+            - --proxyAdminPort
+            - "15000"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # ldpreload-related env vars
+            - name: VCL_APP_SCOPE_GLOBAL
+              value: ""
+            - name: VCL_APP_SCOPE_LOCAL
+              value: ""
+            - name: VCL_APP_PROXY_TRANSPORT_TCP
+              value: ""
+            # enable verbose VCL debugs, do not use for production
+            - name: VCL_DEBUG
+              value: "3"
+          image: docker.io/istio/proxy_debug:0.2.10
+          imagePullPolicy: IfNotPresent
+          name: istio-proxy
+          resources: {}
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: false
+            runAsUser: 1337
+          volumeMounts:
+            - mountPath: /etc/istio/proxy
+              name: istio-envoy
+            - mountPath: /etc/certs/
+              name: istio-certs
+              readOnly: true
       initContainers:
-      - args:
-        - -p
-        - "15001"
-        - -u
-        - "1337"
-        image: docker.io/istio/proxy_init:0.2.10
-        imagePullPolicy: IfNotPresent
-        name: istio-init
-        resources: {}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: true
-#      - args:
-#        - -c
-#        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
-#          unlimited
-#        command:
-#        - /bin/sh
-#        image: alpine
-#        imagePullPolicy: IfNotPresent
-#        name: enable-core-dump
-#        resources: {}
-#        securityContext:
-#          privileged: true
+        - args:
+            - -p
+            - "15001"
+            - -u
+            - "1337"
+          image: docker.io/istio/proxy_init:0.2.10
+          imagePullPolicy: IfNotPresent
+          name: istio-init
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+            privileged: true
       volumes:
-      - emptyDir:
-          medium: Memory
-          sizeLimit: "0"
-        name: istio-envoy
-      - name: istio-certs
-        secret:
-          optional: true
-          secretName: istio.default
+        - emptyDir:
+            medium: Memory
+            sizeLimit: "0"
+          name: istio-envoy
+        - name: istio-certs
+          secret:
+            optional: true
+            secretName: istio.default
 status: {}
 ---

--- a/tests/policy/perf/deployment-client-ab.yaml
+++ b/tests/policy/perf/deployment-client-ab.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -15,8 +16,8 @@ spec:
         role: frontend
     spec:
       containers:
-      - image: ab
-        imagePullPolicy: IfNotPresent
-        name: ab
-        command: ["/bin/sh"]
-        args: ["-c", "while true; do sleep 30; done;"]
+        - image: ab
+          imagePullPolicy: IfNotPresent
+          name: ab
+          command: ["/bin/sh"]
+          args: ["-c", "while true; do sleep 30; done;"]

--- a/tests/policy/perf/deployment-client-trex.yaml
+++ b/tests/policy/perf/deployment-client-trex.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -15,8 +16,8 @@ spec:
         role: frontend
     spec:
       containers:
-      - image: trex
-        imagePullPolicy: IfNotPresent
-        name: trex
-        command: ["bash"]
-        args: ["-c", "while true; do sleep 30; done;"]
+        - image: trex
+          imagePullPolicy: IfNotPresent
+          name: trex
+          command: ["bash"]
+          args: ["-c", "while true; do sleep 30; done;"]

--- a/tests/policy/perf/deployment-client-wrk.yaml
+++ b/tests/policy/perf/deployment-client-wrk.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -15,8 +16,8 @@ spec:
         role: frontend
     spec:
       containers:
-      - image: wrk
-        imagePullPolicy: IfNotPresent
-        name: wrk
-        command: ["bash"]
-        args: ["-c", "while true; do sleep 30; done;"]
+        - image: wrk
+          imagePullPolicy: IfNotPresent
+          name: wrk
+          command: ["bash"]
+          args: ["-c", "while true; do sleep 30; done;"]

--- a/tests/policy/perf/deployment-nopolicy-pods.yaml
+++ b/tests/policy/perf/deployment-nopolicy-pods.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -15,8 +16,8 @@ spec:
         role: backend
     spec:
       containers:
-      - name: busybox
-        image: busybox
-        command:
-          - sleep
-          - "3600"
+        - name: busybox
+          image: busybox
+          command:
+            - sleep
+            - "3600"

--- a/tests/policy/perf/deployment-policy-pods.yaml
+++ b/tests/policy/perf/deployment-policy-pods.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -17,8 +18,8 @@ spec:
         app: webapp
     spec:
       containers:
-      - image: nginx
-        imagePullPolicy: IfNotPresent
-        name: nginx-server
-        ports:
-        - containerPort: 80
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx-server
+          ports:
+            - containerPort: 80

--- a/tests/policy/perf/policy-large.yaml
+++ b/tests/policy/perf/policy-large.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -6,20 +7,20 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-        app: webapp
-        role: db
+      app: webapp
+      role: db
   policyTypes:
-  - Ingress
-  - Egress
+    - Ingress
+    - Egress
   ingress:
     - from:
-      - ipBlock:
-          cidr: 172.17.0.0/16
-          except:
-          - 172.17.1.0/24
-      - podSelector:
-          matchLabels:
-            role: frontend
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - podSelector:
+            matchLabels:
+              role: frontend
       ports:
         - protocol: TCP
           port: 8000
@@ -34,13 +35,13 @@ spec:
         - protocol: TCP
           port: 8085
     - from:
-      - ipBlock:
-          cidr: 11.1.1.0/16
-          except:
-          - 11.1.1.0/24
-      - podSelector:
-          matchLabels:
-            role: backend
+        - ipBlock:
+            cidr: 11.1.1.0/16
+            except:
+              - 11.1.1.0/24
+        - podSelector:
+            matchLabels:
+              role: backend
       ports:
         - protocol: TCP
           port: 8086
@@ -48,12 +49,11 @@ spec:
           port: 8087
   egress:
     - to:
-      - ipBlock:
-          cidr: 11.0.0.0/24
-      - podSelector:
-          matchLabels:
-            app: datastore
+        - ipBlock:
+            cidr: 11.0.0.0/24
+        - podSelector:
+            matchLabels:
+              app: datastore
       ports:
-      - protocol: TCP
-        port: 5978
-
+        - protocol: TCP
+          port: 5978

--- a/tests/policy/perf/policy-small.yaml
+++ b/tests/policy/perf/policy-small.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -6,13 +7,13 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-        app: webapp
-        role: db
+      app: webapp
+      role: db
   ingress:
-  - from:
-    - podSelector:
-        matchLabels:
-          role: frontend
-    ports:
-    - protocol: TCP
-      port: 80
+    - from:
+        - podSelector:
+          matchLabels:
+            role: frontend
+      ports:
+        - protocol: TCP
+          port: 80

--- a/tests/robot/resources/istio029.yaml
+++ b/tests/robot/resources/istio029.yaml
@@ -21,39 +21,39 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-pilot-istio-system
 rules:
-- apiGroups: ["config.istio.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["*"]
-- apiGroups: ["istio.io"]
-  resources: ["istioconfigs", "istioconfigs.istio.io"]
-  verbs: ["*"]
-- apiGroups: ["extensions"]
-  resources: ["thirdpartyresources", "thirdpartyresources.extensions", "ingresses", "ingresses/status"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["configmaps", "endpoints", "pods", "services"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["namespaces", "nodes", "secrets"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["externaladmissionhookconfigurations"]
-  verbs: ["create", "update", "delete"]
+  - apiGroups: ["config.istio.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["*"]
+  - apiGroups: ["istio.io"]
+    resources: ["istioconfigs", "istioconfigs.istio.io"]
+    verbs: ["*"]
+  - apiGroups: ["extensions"]
+    resources: ["thirdpartyresources", "thirdpartyresources.extensions", "ingresses", "ingresses/status"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["configmaps", "endpoints", "pods", "services"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["namespaces", "nodes", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["externaladmissionhookconfigurations"]
+    verbs: ["create", "update", "delete"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-initializer-istio-system
 rules:
-- apiGroups: ["*"]
-  resources: ["deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers"]
-  verbs: ["initialize", "patch", "watch", "list"]
-- apiGroups: ["*"]
-  resources: ["configmaps"]
-  verbs: ["get", "list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers"]
+    verbs: ["initialize", "patch", "watch", "list"]
+  - apiGroups: ["*"]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
 ---
 # Mixer CRD needs to watch and list CRDs
 # It also uses discovery API to discover Kinds of config.istio.io
@@ -63,27 +63,27 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-mixer-istio-system
 rules:
-- apiGroups: ["config.istio.io"] # Istio CRD watcher
-  resources: ["*"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets"]
-  verbs: ["get", "list", "watch"]
+  - apiGroups: ["config.istio.io"] # Istio CRD watcher
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-ca-istio-system
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create", "get", "watch", "list", "update"]
-- apiGroups: [""]
-  resources: ["serviceaccounts"]
-  verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "watch", "list", "update"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "watch", "list"]
 ---
 # Permissions for the sidecar proxy.
 kind: ClusterRole
@@ -91,15 +91,15 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-sidecar-istio-system
 rules:
-- apiGroups: ["istio.io"]
-  resources: ["istioconfigs"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["extensions"]
-  resources: ["thirdpartyresources", "ingresses"]
-  verbs: ["get", "watch", "list", "update"]
-- apiGroups: [""]
-  resources: ["configmaps", "pods", "endpoints", "services"]
-  verbs: ["get", "watch", "list"]
+  - apiGroups: ["istio.io"]
+    resources: ["istioconfigs"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["extensions"]
+    resources: ["thirdpartyresources", "ingresses"]
+    verbs: ["get", "watch", "list", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps", "pods", "endpoints", "services"]
+    verbs: ["get", "watch", "list"]
 ---
 # Grant permissions to the Pilot/discovery.
 kind: ClusterRoleBinding
@@ -107,9 +107,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-pilot-admin-role-binding-istio-system
 subjects:
-- kind: ServiceAccount
-  name: istio-pilot-service-account
-  namespace: istio-system
+  - kind: ServiceAccount
+    name: istio-pilot-service-account
+    namespace: istio-system
 roleRef:
   kind: ClusterRole
   name: istio-pilot-istio-system
@@ -121,9 +121,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-initializer-admin-role-binding-istio-system
 subjects:
-- kind: ServiceAccount
-  name: istio-initializer-service-account
-  namespace: istio-system
+  - kind: ServiceAccount
+    name: istio-initializer-service-account
+    namespace: istio-system
 roleRef:
   kind: ClusterRole
   name: istio-initializer-istio-system
@@ -135,9 +135,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-ca-role-binding-istio-system
 subjects:
-- kind: ServiceAccount
-  name: istio-ca-service-account
-  namespace: istio-system
+  - kind: ServiceAccount
+    name: istio-ca-service-account
+    namespace: istio-system
 roleRef:
   kind: ClusterRole
   name: istio-ca-istio-system
@@ -149,9 +149,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-ingress-admin-role-binding-istio-system
 subjects:
-- kind: ServiceAccount
-  name: istio-ingress-service-account
-  namespace: istio-system
+  - kind: ServiceAccount
+    name: istio-ingress-service-account
+    namespace: istio-system
 roleRef:
   kind: ClusterRole
   name: istio-pilot-istio-system
@@ -163,9 +163,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-egress-admin-role-binding-istio-system
 subjects:
-- kind: ServiceAccount
-  name: istio-egress-service-account
-  namespace: istio-system
+  - kind: ServiceAccount
+    name: istio-egress-service-account
+    namespace: istio-system
 roleRef:
   kind: ClusterRole
   name: istio-pilot-istio-system
@@ -179,9 +179,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-sidecar-role-binding-istio-system
 subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: istio-system
+  - kind: ServiceAccount
+    name: default
+    namespace: istio-system
 roleRef:
   kind: ClusterRole
   name: istio-sidecar-istio-system
@@ -193,9 +193,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: istio-mixer-admin-role-binding-istio-system
 subjects:
-- kind: ServiceAccount
-  name: istio-mixer-service-account
-  namespace: istio-system
+  - kind: ServiceAccount
+    name: istio-mixer-service-account
+    namespace: istio-system
 roleRef:
   kind: ClusterRole
   name: istio-mixer-istio-system
@@ -219,19 +219,19 @@ metadata:
     istio: mixer
 spec:
   ports:
-  - name: tcp
-    port: 9091
-  - name: http-health
-    port: 9093
-  - name: configapi
-    port: 9094
-  - name: statsd-prom
-    port: 9102
-  - name: statsd-udp
-    port: 9125
-    protocol: UDP
-  - name: prometheus
-    port: 42422
+    - name: tcp
+      port: 9091
+    - name: http-health
+      port: 9093
+    - name: configapi
+      port: 9094
+    - name: statsd-prom
+      port: 9102
+    - name: statsd-udp
+      port: 9125
+      protocol: UDP
+    - name: prometheus
+      port: 42422
   selector:
     istio: mixer
 ---
@@ -257,37 +257,37 @@ spec:
     spec:
       serviceAccountName: istio-mixer-service-account
       containers:
-      - name: statsd-to-prometheus
-        image: prom/statsd-exporter
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 9102
-        - containerPort: 9125
+        - name: statsd-to-prometheus
+          image: prom/statsd-exporter
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9102
+            - containerPort: 9125
           protocol: UDP
-        args:
-        - '-statsd.mapping-config=/etc/statsd/mapping.conf'
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/statsd
-      - name: mixer
-        image: docker.io/istio/mixer:0.2.9
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 9091
-        - containerPort: 9094
-        - containerPort: 42422
-        args:
-          - --configStoreURL=fs:///etc/opt/mixer/configroot
-          - --configStore2URL=k8s://
-          - --configDefaultNamespace=istio-system
-          - --traceOutput=http://zipkin:9411/api/v1/spans
-          - --logtostderr
-          - -v
-          - "2"
+          args:
+            - '-statsd.mapping-config=/etc/statsd/mapping.conf'
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/statsd
+        - name: mixer
+          image: docker.io/istio/mixer:0.2.9
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9091
+            - containerPort: 9094
+            - containerPort: 42422
+          args:
+            - --configStoreURL=fs:///etc/opt/mixer/configroot
+            - --configStore2URL=k8s://
+            - --configDefaultNamespace=istio-system
+            - --traceOutput=http://zipkin:9411/api/v1/spans
+            - --logtostderr
+            - -v
+            - "2"
       volumes:
-      - name: config-volume
-        configMap:
-          name: istio-mixer
+        - name: config-volume
+          configMap:
+            name: istio-mixer
 ---
 # Mixer CRD definitions are generated using
 # mixs crd all
@@ -720,9 +720,9 @@ metadata:
 spec:
   match: "true" # If omitted match is true.
   actions:
-  - handler: handler.stdio
-    instances:
-    - accesslog.logentry
+    - handler: handler.stdio
+      instances:
+        - accesslog.logentry
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -823,71 +823,71 @@ metadata:
   namespace: istio-system
 spec:
   metrics:
-  - name: request_count
-    instance_name: requestcount.metric.istio-system
-    kind: COUNTER
-    label_names:
-    - source_service
-    - source_version
-    - destination_service
-    - destination_version
-    - response_code
-  - name: request_duration
-    instance_name: requestduration.metric.istio-system
-    kind: DISTRIBUTION
-    label_names:
-    - source_service
-    - source_version
-    - destination_service
-    - destination_version
-    - response_code
-    buckets:
-      explicit_buckets:
-        bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-  - name: request_size
-    instance_name: requestsize.metric.istio-system
-    kind: DISTRIBUTION
-    label_names:
-    - source_service
-    - source_version
-    - destination_service
-    - destination_version
-    - response_code
-    buckets:
-      exponentialBuckets:
-        numFiniteBuckets: 8
-        scale: 1
-        growthFactor: 10
-  - name: response_size
-    instance_name: responsesize.metric.istio-system
-    kind: DISTRIBUTION
-    label_names:
-    - source_service
-    - source_version
-    - destination_service
-    - destination_version
-    - response_code
-    buckets:
-      exponentialBuckets:
-        numFiniteBuckets: 8
-        scale: 1
-        growthFactor: 10
-  - name: tcp_bytes_sent
-    instance_name: tcpbytesent.metric.istio-system
-    kind: COUNTER
-    label_names:
-    - source_service
-    - source_version
-    - destination_service
-    - destination_version
-  - name: tcp_bytes_received
-    instance_name: tcpbytereceived.metric.istio-system
-    kind: COUNTER
-    label_names:
-    - source_service
-    - source_version
-    - destination_service
-    - destination_version
+    - name: request_count
+      instance_name: requestcount.metric.istio-system
+      kind: COUNTER
+      label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - response_code
+    - name: request_duration
+      instance_name: requestduration.metric.istio-system
+      kind: DISTRIBUTION
+      label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - response_code
+      buckets:
+        explicit_buckets:
+          bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+    - name: request_size
+      instance_name: requestsize.metric.istio-system
+      kind: DISTRIBUTION
+      label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - response_code
+      buckets:
+        exponentialBuckets:
+          numFiniteBuckets: 8
+          scale: 1
+          growthFactor: 10
+    - name: response_size
+      instance_name: responsesize.metric.istio-system
+      kind: DISTRIBUTION
+      label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - response_code
+      buckets:
+        exponentialBuckets:
+          numFiniteBuckets: 8
+          scale: 1
+          growthFactor: 10
+    - name: tcp_bytes_sent
+      instance_name: tcpbytesent.metric.istio-system
+      kind: COUNTER
+      label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+    - name: tcp_bytes_received
+      instance_name: tcpbytereceived.metric.istio-system
+      kind: COUNTER
+      label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -898,12 +898,12 @@ metadata:
     istio-protocol: http
 spec:
   actions:
-  - handler: handler.prometheus
-    instances:
-    - requestcount.metric
-    - requestduration.metric
-    - requestsize.metric
-    - responsesize.metric
+    - handler: handler.prometheus
+      instances:
+        - requestcount.metric
+        - requestduration.metric
+        - requestsize.metric
+        - responsesize.metric
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -914,10 +914,10 @@ metadata:
     istio-protocol: tcp # needed so that mixer will only execute when context.protocol == TCP
 spec:
   actions:
-  - handler: handler.prometheus
-    instances:
-    - tcpbytesent.metric
-    - tcpbytereceived.metric
+    - handler: handler.prometheus
+      instances:
+        - tcpbytesent.metric
+        - tcpbytereceived.metric
 ---
 ################################
 # Istio configMap cluster-wide
@@ -1044,10 +1044,10 @@ metadata:
     istio: pilot
 spec:
   ports:
-  - port: 8080
-    name: http-discovery
-  - port: 443
-    name: http-admission-webhook
+    - port: 8080
+      name: http-discovery
+    - port: 443
+      name: http-admission-webhook
   selector:
     istio: pilot
 ---
@@ -1073,31 +1073,31 @@ spec:
     spec:
       serviceAccountName: istio-pilot-service-account
       containers:
-      - name: discovery
-        image: docker.io/istio/pilot:0.2.9
-        imagePullPolicy: IfNotPresent
-        args: ["discovery", "-v", "2", "--admission-service", "istio-pilot-external"]
-        ports:
-        - containerPort: 8080
-        - containerPort: 443
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/istio/config
+        - name: discovery
+          image: docker.io/istio/pilot:0.2.9
+          imagePullPolicy: IfNotPresent
+          args: ["discovery", "-v", "2", "--admission-service", "istio-pilot-external"]
+          ports:
+            - containerPort: 8080
+            - containerPort: 443
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/istio/config
       volumes:
-      - name: config-volume
-        configMap:
-          name: istio
+        - name: config-volume
+          configMap:
+            name: istio
 ---
 ################################
 # Istio ingress
@@ -1112,11 +1112,10 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 80
-#   nodePort: 32000
-    name: http
-  - port: 443
-    name: https
+    - port: 80
+      name: http
+    - port: 443
+      name: https
   selector:
     istio: ingress
 ---
@@ -1142,46 +1141,46 @@ spec:
     spec:
       serviceAccountName: istio-ingress-service-account
       containers:
-      - name: istio-ingress
-        image: docker.io/istio/proxy_debug:0.2.9
-        args:
-        - proxy
-        - ingress
-        - -v
-        - "2"
-        - --discoveryAddress
-        - istio-pilot:8080
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 80
-        - containerPort: 443
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
+        - name: istio-ingress
+          image: docker.io/istio/proxy_debug:0.2.9
+          args:
+            - proxy
+            - ingress
+            - -v
+            - "2"
+            - --discoveryAddress
+            - istio-pilot:8080
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        volumeMounts:
-        - name: istio-certs
-          mountPath: /etc/certs
-          readOnly: true
-        - name: ingress-certs
-          mountPath: /etc/istio/ingress-certs
-          readOnly: true
+          volumeMounts:
+            - name: istio-certs
+              mountPath: /etc/certs
+              readOnly: true
+            - name: ingress-certs
+              mountPath: /etc/istio/ingress-certs
+              readOnly: true
       volumes:
-      - name: istio-certs
-        secret:
-          secretName: istio.default
-          optional: true
-      - name: ingress-certs
-        secret:
-          secretName: istio-ingress-certs
-          optional: true
+        - name: istio-certs
+          secret:
+            secretName: istio.default
+            optional: true
+        - name: ingress-certs
+          secret:
+            secretName: istio-ingress-certs
+            optional: true
 ---
 ################################
 # Istio egress
@@ -1193,7 +1192,7 @@ metadata:
   namespace: istio-system
 spec:
   ports:
-  - port: 80
+    - port: 80
   selector:
     istio: egress
 ---
@@ -1219,36 +1218,36 @@ spec:
     spec:
       serviceAccountName: istio-egress-service-account
       containers:
-      - name: proxy
-        image: docker.io/istio/proxy_debug:0.2.9
-        imagePullPolicy: IfNotPresent
-        args:
-        - proxy
-        - egress
-        - -v
-        - "2"
-        - --discoveryAddress
-        - istio-pilot:8080
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        volumeMounts:
-        - name: istio-certs
-          mountPath: /etc/certs
-          readOnly: true
+        - name: proxy
+          image: docker.io/istio/proxy_debug:0.2.9
+          imagePullPolicy: IfNotPresent
+          args:
+            - proxy
+            - egress
+            - -v
+            - "2"
+            - --discoveryAddress
+            - istio-pilot:8080
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: istio-certs
+              mountPath: /etc/certs
+              readOnly: true
       volumes:
-      - name: istio-certs
-        secret:
-          secretName: istio.default
-          optional: true
+        - name: istio-certs
+          secret:
+            secretName: istio.default
+            optional: true
 ---
 ################################
 # Istio-CA cluster-wide
@@ -1261,7 +1260,6 @@ metadata:
   namespace: istio-system
 ---
 # Istio CA watching all namespaces
-apiVersion: v1
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
@@ -1278,12 +1276,12 @@ spec:
     spec:
       serviceAccountName: istio-ca-service-account
       containers:
-      - name: istio-ca
-        image: docker.io/istio/istio-ca:0.2.9
-        imagePullPolicy: IfNotPresent
-        command: ["/usr/local/bin/istio_ca"]
-        args:
-          - --grpc-port=8060
-          - --grpc-hostname=istio-ca
-          - --self-signed-ca=true
+        - name: istio-ca
+          image: docker.io/istio/istio-ca:0.2.9
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/local/bin/istio_ca"]
+          args:
+            - --grpc-port=8060
+            - --grpc-hostname=istio-ca
+            - --self-signed-ca=true
 ---

--- a/tests/robot/resources/nginx-istio.yaml
+++ b/tests/robot/resources/nginx-istio.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +7,8 @@ metadata:
     app: nginx
 spec:
   ports:
-  - name: http
-    port: 80
+    - name: http
+      port: 80
   selector:
     app: nginx
 ---
@@ -30,101 +31,101 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nginx
-        imagePullPolicy: IfNotPresent
-        name: nginx
-        ports:
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
         - containerPort: 80
-        resources: {}
-      - args:
-        - proxy
-        - sidecar
-        - -v
-        - "2"
-        - --configPath
-        - /etc/istio/proxy
-        - --binaryPath
-        - /usr/local/bin/envoy
-        - --serviceCluster
-        - nginx
-        - --drainDuration
-        - 45s
-        - --parentShutdownDuration
-        - 1m0s
-        - --discoveryAddress
-        - istio-pilot.istio-system:8080
-        - --discoveryRefreshDelay
-        - 1s
-        - --zipkinAddress
-        - zipkin.istio-system:9411
-        - --connectTimeout
-        - 10s
-        - --statsdUdpAddress
-        - istio-mixer.istio-system:9125
-        - --proxyAdminPort
-        - "15000"
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: docker.io/istio/proxy_debug:0.2.9
-        imagePullPolicy: IfNotPresent
-        name: istio-proxy
-        resources: {}
-        securityContext:
-          privileged: true
-          readOnlyRootFilesystem: false
-          runAsUser: 1337
-        volumeMounts:
-        - mountPath: /etc/istio/proxy
-          name: istio-envoy
-        - mountPath: /etc/certs/
-          name: istio-certs
-          readOnly: true
+          resources: {}
+        - args:
+            - proxy
+            - sidecar
+            - -v
+            - "2"
+            - --configPath
+            - /etc/istio/proxy
+            - --binaryPath
+            - /usr/local/bin/envoy
+            - --serviceCluster
+            - nginx
+            - --drainDuration
+            - 45s
+            - --parentShutdownDuration
+            - 1m0s
+            - --discoveryAddress
+            - istio-pilot.istio-system:8080
+            - --discoveryRefreshDelay
+            - 1s
+            - --zipkinAddress
+            - zipkin.istio-system:9411
+            - --connectTimeout
+            - 10s
+            - --statsdUdpAddress
+            - istio-mixer.istio-system:9125
+            - --proxyAdminPort
+            - "15000"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          image: docker.io/istio/proxy_debug:0.2.9
+          imagePullPolicy: IfNotPresent
+          name: istio-proxy
+          resources: {}
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: false
+            runAsUser: 1337
+          volumeMounts:
+            - mountPath: /etc/istio/proxy
+              name: istio-envoy
+            - mountPath: /etc/certs/
+              name: istio-certs
+              readOnly: true
       initContainers:
-      - args:
-        - -p
-        - "15001"
-        - -u
-        - "1337"
-        image: docker.io/istio/proxy_init:0.2.9
-        imagePullPolicy: IfNotPresent
-        name: istio-init
-        resources: {}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: true
-      - args:
-        - -c
-        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
-          unlimited
-        command:
-        - /bin/sh
-        image: alpine
-        imagePullPolicy: IfNotPresent
-        name: enable-core-dump
-        resources: {}
-        securityContext:
-          privileged: true
-      volumes:
-      - emptyDir:
-          medium: Memory
-          sizeLimit: "0"
-        name: istio-envoy
-      - name: istio-certs
-        secret:
-          optional: true
-          secretName: istio.default
+        - args:
+            - -p
+            - "15001"
+            - -u
+            - "1337"
+          image: docker.io/istio/proxy_init:0.2.9
+          imagePullPolicy: IfNotPresent
+          name: istio-init
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+            privileged: true
+        - args:
+            - -c
+            - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
+              unlimited
+          command:
+            - /bin/sh
+          image: alpine
+          imagePullPolicy: IfNotPresent
+          name: enable-core-dump
+          resources: {}
+          securityContext:
+            privileged: true
+          volumes:
+            - emptyDir:
+              medium: Memory
+              sizeLimit: "0"
+              name: istio-envoy
+        - name: istio-certs
+          secret:
+            optional: true
+            secretName: istio.default
 status: {}
 ---

--- a/tests/robot/resources/nginx-ldpreload-node2.yaml
+++ b/tests/robot/resources/nginx-ldpreload-node2.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +7,8 @@ metadata:
     app: nginx
 spec:
   ports:
-  - name: http
-    port: 80
+    - name: http
+      port: 80
   selector:
     app: nginx
 ---
@@ -25,19 +26,19 @@ spec:
       nodeSelector:
         location: server_node
       containers:
-      - image: nginx
-        imagePullPolicy: IfNotPresent
-        name: nginx
-        ports:
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
         - containerPort: 80
-        securityContext:
-          privileged: true
-        env:
-          # ldpreload-related env vars
-          - name: VCL_APP_SCOPE_GLOBAL
-            value: ""
-          - name: VCL_APP_SCOPE_LOCAL
-            value: ""
-          # enable verbose VCL debugs, do not use for production
-          - name: VCL_DEBUG
-            value: "3"
+          securityContext:
+            privileged: true
+          env:
+            # ldpreload-related env vars
+            - name: VCL_APP_SCOPE_GLOBAL
+              value: ""
+            - name: VCL_APP_SCOPE_LOCAL
+              value: ""
+            # enable verbose VCL debugs, do not use for production
+            - name: VCL_DEBUG
+              value: "3"

--- a/tests/robot/resources/nginx-node2.yaml
+++ b/tests/robot/resources/nginx-node2.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +7,8 @@ metadata:
     app: nginx
 spec:
   ports:
-  - name: http
-    port: 80
+    - name: http
+      port: 80
   selector:
     app: nginx
 ---
@@ -23,10 +24,10 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nginx
-        imagePullPolicy: IfNotPresent
-        name: nginx
-        ports:
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
         - containerPort: 80
       nodeSelector:
         location: server_node

--- a/tests/robot/resources/nginx.yaml
+++ b/tests/robot/resources/nginx.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +7,8 @@ metadata:
     app: nginx
 spec:
   ports:
-  - name: http
-    port: 80
+    - name: http
+      port: 80
   selector:
     app: nginx
 ---
@@ -23,8 +24,8 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nginx
-        imagePullPolicy: IfNotPresent
-        name: nginx
-        ports:
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
         - containerPort: 80

--- a/tests/robot/resources/nginx10.yaml
+++ b/tests/robot/resources/nginx10.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,10 +7,10 @@ metadata:
     app: nginx
 spec:
   ports:
-  - name: http
-    port: 80
-  selector:
-    app: nginx
+    - name: http
+      port: 80
+      selector:
+        app: nginx
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -23,8 +24,8 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nginx
-        imagePullPolicy: IfNotPresent
-        name: nginx
-        ports:
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
         - containerPort: 80

--- a/tests/robot/resources/one-ldpreload-client-iperf.yaml
+++ b/tests/robot/resources/one-ldpreload-client-iperf.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -11,19 +12,19 @@ spec:
         ldpreload: "true"
     spec:
       containers:
-      - image: networkstatic/iperf3
-        imagePullPolicy: IfNotPresent
-        name: client
-        command: ["bash"]
-        args: ["-c", "while true; do sleep 30; done;"]
-        securityContext:
-          privileged: true
-        env:
-          # ldpreload-related env vars
-          - name: VCL_APP_SCOPE_GLOBAL
-            value: ""
-          - name: VCL_APP_SCOPE_LOCAL
-            value: ""
-          # enable verbose VCL debugs, do not use for production
-          - name: VCL_DEBUG
-            value: "3"
+        - image: networkstatic/iperf3
+          imagePullPolicy: IfNotPresent
+          name: client
+          command: ["bash"]
+          args: ["-c", "while true; do sleep 30; done;"]
+          securityContext:
+            privileged: true
+          env:
+            # ldpreload-related env vars
+            - name: VCL_APP_SCOPE_GLOBAL
+              value: ""
+            - name: VCL_APP_SCOPE_LOCAL
+              value: ""
+            # enable verbose VCL debugs, do not use for production
+            - name: VCL_DEBUG
+              value: "3"

--- a/tests/robot/resources/one-ldpreload-server-iperf.yaml
+++ b/tests/robot/resources/one-ldpreload-server-iperf.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +7,8 @@ metadata:
     app: test-server-iperf
 spec:
   ports:
-  - name: test-server-iperf
-    port: 5201
+    - name: test-server-iperf
+      port: 5201
   selector:
     app: test-server-iperf
 ---
@@ -24,21 +25,21 @@ spec:
         ldpreload: "true"
     spec:
       containers:
-      - image: networkstatic/iperf3
-        imagePullPolicy: IfNotPresent
-        name: server-iperf
-        ports:
+        - image: networkstatic/iperf3
+          imagePullPolicy: IfNotPresent
+          name: server-iperf
+          ports:
         - containerPort: 5201
-        command: ["iperf3"]
-        args: ["-V4d", "-s"]
-        securityContext:
-          privileged: true
-        env:
-          # ldpreload-related env vars
-          - name: VCL_APP_SCOPE_GLOBAL
-            value: ""
-          - name: VCL_APP_SCOPE_LOCAL
-            value: ""
-          # enable verbose VCL debugs, do not use for production
-          - name: VCL_DEBUG
-            value: "3"
+          command: ["iperf3"]
+          args: ["-V4d", "-s"]
+          securityContext:
+            privileged: true
+          env:
+            # ldpreload-related env vars
+            - name: VCL_APP_SCOPE_GLOBAL
+              value: ""
+            - name: VCL_APP_SCOPE_LOCAL
+              value: ""
+            # enable verbose VCL debugs, do not use for production
+            - name: VCL_DEBUG
+              value: "3"

--- a/tests/robot/resources/one-ldpreload-server2-iperf.yaml
+++ b/tests/robot/resources/one-ldpreload-server2-iperf.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +7,8 @@ metadata:
     app: test-server2-iperf
 spec:
   ports:
-  - name: test-server2-iperf
-    port: 5201
+    - name: test-server2-iperf
+      port: 5201
   selector:
     app: test-server2-iperf
 ---
@@ -24,17 +25,16 @@ spec:
         ldpreload: "true"
     spec:
       containers:
-      - image: networkstatic/iperf3
-        imagePullPolicy: IfNotPresent
-        name: server2-iperf
-        ports:
+        - image: networkstatic/iperf3
+          imagePullPolicy: IfNotPresent
+          name: server2-iperf
+          ports:
         - containerPort: 5201
-        command: ["iperf3"]
-        args: ["-V4d", "-s"]
-        securityContext:
-          privileged: true
-        env:
-          # ldpreload-related env vars
-          - name: VCL_APP_SCOPE_GLOBAL
-            value: ""
-
+          command: ["iperf3"]
+          args: ["-V4d", "-s"]
+          securityContext:
+            privileged: true
+          env:
+            # ldpreload-related env vars
+            - name: VCL_APP_SCOPE_GLOBAL
+              value: ""

--- a/tests/robot/resources/one-ubuntu-istio.yaml
+++ b/tests/robot/resources/one-ubuntu-istio.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -17,105 +18,105 @@ spec:
         app: ubuntu-client
     spec:
       containers:
-      - args:
-        - while true; do sleep 30; done;
-        command:
-        - /bin/bash
-        - -c
-        - --
-        image: rastislavszabo/ubuntu
-        imagePullPolicy: IfNotPresent
-        name: ubuntu-client
-        resources: {}
-      - args:
-        - proxy
-        - sidecar
-        - -v
-        - "2"
-        - --configPath
-        - /etc/istio/proxy
-        - --binaryPath
-        - /usr/local/bin/envoy
-        - --serviceCluster
-        - ubuntu-client
-        - --drainDuration
-        - 45s
-        - --parentShutdownDuration
-        - 1m0s
-        - --discoveryAddress
-        - istio-pilot.istio-system:8080
-        - --discoveryRefreshDelay
-        - 1s
-        - --zipkinAddress
-        - zipkin.istio-system:9411
-        - --connectTimeout
-        - 10s
-        - --statsdUdpAddress
-        - istio-mixer.istio-system:9125
-        - --proxyAdminPort
-        - "15000"
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: docker.io/istio/proxy_debug:0.2.9
-        imagePullPolicy: IfNotPresent
-        name: istio-proxy
-        resources: {}
-        securityContext:
-          privileged: true
-          readOnlyRootFilesystem: false
-          runAsUser: 1337
-        volumeMounts:
-        - mountPath: /etc/istio/proxy
-          name: istio-envoy
-        - mountPath: /etc/certs/
-          name: istio-certs
-          readOnly: true
+        - args:
+            - while true; do sleep 30; done;
+          command:
+            - /bin/bash
+            - -c
+            - --
+          image: rastislavszabo/ubuntu
+          imagePullPolicy: IfNotPresent
+          name: ubuntu-client
+          resources: {}
+        - args:
+            - proxy
+            - sidecar
+            - -v
+            - "2"
+            - --configPath
+            - /etc/istio/proxy
+            - --binaryPath
+            - /usr/local/bin/envoy
+            - --serviceCluster
+            - ubuntu-client
+            - --drainDuration
+            - 45s
+            - --parentShutdownDuration
+            - 1m0s
+            - --discoveryAddress
+            - istio-pilot.istio-system:8080
+            - --discoveryRefreshDelay
+            - 1s
+            - --zipkinAddress
+            - zipkin.istio-system:9411
+            - --connectTimeout
+            - 10s
+            - --statsdUdpAddress
+            - istio-mixer.istio-system:9125
+            - --proxyAdminPort
+            - "15000"
+          env:
+            - name: POD_NAME
+              valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          image: docker.io/istio/proxy_debug:0.2.9
+          imagePullPolicy: IfNotPresent
+          name: istio-proxy
+          resources: {}
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: false
+            runAsUser: 1337
+          volumeMounts:
+            - mountPath: /etc/istio/proxy
+              name: istio-envoy
+            - mountPath: /etc/certs/
+              name: istio-certs
+              readOnly: true
       initContainers:
-      - args:
-        - -p
-        - "15001"
-        - -u
-        - "1337"
-        image: docker.io/istio/proxy_init:0.2.9
-        imagePullPolicy: IfNotPresent
-        name: istio-init
-        resources: {}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: true
-      - args:
-        - -c
-        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
-          unlimited
-        command:
-        - /bin/sh
-        image: alpine
-        imagePullPolicy: IfNotPresent
-        name: enable-core-dump
-        resources: {}
-        securityContext:
-          privileged: true
+        - args:
+            - -p
+            - "15001"
+            - -u
+            - "1337"
+          image: docker.io/istio/proxy_init:0.2.9
+          imagePullPolicy: IfNotPresent
+          name: istio-init
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+            privileged: true
+        - args:
+            - -c
+            - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
+              unlimited
+          command:
+            - /bin/sh
+          image: alpine
+          imagePullPolicy: IfNotPresent
+          name: enable-core-dump
+          resources: {}
+          securityContext:
+            privileged: true
       volumes:
-      - emptyDir:
-          medium: Memory
-          sizeLimit: "0"
-        name: istio-envoy
-      - name: istio-certs
-        secret:
-          optional: true
-          secretName: istio.default
+        - emptyDir:
+            medium: Memory
+            sizeLimit: "0"
+          name: istio-envoy
+        - name: istio-certs
+          secret:
+            optional: true
+            secretName: istio.default
 status: {}
 ---

--- a/tests/robot/resources/ubuntu-client-ldpreload-node1.yaml
+++ b/tests/robot/resources/ubuntu-client-ldpreload-node1.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -12,19 +13,19 @@ spec:
       nodeSelector:
         location: client_node
       containers:
-      - image: rastislavszabo/ubuntu
-        imagePullPolicy: IfNotPresent
-        name: ubuntu-client
-        command: [ "/bin/bash", "-c", "--" ]
-        args: [ "while true; do sleep 30; done;" ]
-        securityContext:
-          privileged: true
-        env:
-          # ldpreload-related env vars
-          - name: VCL_APP_SCOPE_GLOBAL
-            value: ""
-          - name: VCL_APP_SCOPE_LOCAL
-            value: ""
-          # enable verbose VCL debugs, do not use for production
-          - name: VCL_DEBUG
-            value: "3"
+        - image: rastislavszabo/ubuntu
+          imagePullPolicy: IfNotPresent
+          name: ubuntu-client
+          command: ["/bin/bash", "-c", "--"]
+          args: ["while true; do sleep 30; done;"]
+          securityContext:
+            privileged: true
+          env:
+            # ldpreload-related env vars
+            - name: VCL_APP_SCOPE_GLOBAL
+              value: ""
+            - name: VCL_APP_SCOPE_LOCAL
+              value: ""
+            # enable verbose VCL debugs, do not use for production
+            - name: VCL_DEBUG
+              value: "3"

--- a/tests/robot/resources/ubuntu-client-node1.yaml
+++ b/tests/robot/resources/ubuntu-client-node1.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -10,11 +11,11 @@ spec:
         app: ubuntu-client
     spec:
       containers:
-      - image: rastislavszabo/ubuntu
-        imagePullPolicy: IfNotPresent
-        name: ubuntu-client
-        # Just spin & wait forever
-        command: [ "/bin/bash", "-c", "--" ]
-        args: [ "while true; do sleep 30; done;" ]
+        - image: rastislavszabo/ubuntu
+          imagePullPolicy: IfNotPresent
+          name: ubuntu-client
+          # Just spin & wait forever
+          command: ["/bin/bash", "-c", "--"]
+          args: ["while true; do sleep 30; done;"]
       nodeSelector:
         location: client_node

--- a/tests/robot/resources/ubuntu-client.yaml
+++ b/tests/robot/resources/ubuntu-client.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -10,9 +11,9 @@ spec:
         app: ubuntu-client
     spec:
       containers:
-      - image: rastislavszabo/ubuntu
-        imagePullPolicy: IfNotPresent
-        name: ubuntu-client
-        # Just spin & wait forever
-        command: [ "/bin/bash", "-c", "--" ]
-        args: [ "while true; do sleep 30; done;" ]
+        - image: rastislavszabo/ubuntu
+          imagePullPolicy: IfNotPresent
+          name: ubuntu-client
+          # Just spin & wait forever
+          command: ["/bin/bash", "-c", "--"]
+          args: ["while true; do sleep 30; done;"]

--- a/tests/robot/resources/ubuntu-server-node2.yaml
+++ b/tests/robot/resources/ubuntu-server-node2.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -10,11 +11,11 @@ spec:
         app: ubuntu-server
     spec:
       containers:
-      - image: rastislavszabo/ubuntu
-        imagePullPolicy: IfNotPresent
-        name: ubuntu-server
-        # Just spin & wait forever
-        command: [ "/bin/bash", "-c", "--" ]
-        args: [ "while true; do sleep 30; done;" ]
+        - image: rastislavszabo/ubuntu
+          imagePullPolicy: IfNotPresent
+          name: ubuntu-server
+          # Just spin & wait forever
+          command: ["/bin/bash", "-c", "--"]
+          args: ["while true; do sleep 30; done;"]
       nodeSelector:
         location: server_node

--- a/tests/robot/resources/ubuntu-server.yaml
+++ b/tests/robot/resources/ubuntu-server.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -10,9 +11,9 @@ spec:
         app: ubuntu-server
     spec:
       containers:
-      - image: rastislavszabo/ubuntu
-        imagePullPolicy: IfNotPresent
-        name: ubuntu-server
-        # Just spin & wait forever
-        command: [ "/bin/bash", "-c", "--" ]
-        args: [ "while true; do sleep 30; done;" ]
+        - image: rastislavszabo/ubuntu
+          imagePullPolicy: IfNotPresent
+          name: ubuntu-server
+          # Just spin & wait forever
+          command: ["/bin/bash", "-c", "--"]
+          args: ["while true; do sleep 30; done;"]

--- a/tests/robot/suites/policy/test_data/allow_port_5000_server_from_client.yaml
+++ b/tests/robot/suites/policy/test_data/allow_port_5000_server_from_client.yaml
@@ -1,3 +1,4 @@
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -9,8 +10,8 @@ spec:
       app: ubuntu-server
   ingress:
     - ports:
-      - port: 5000
-      from:
-      - podSelector:
-          matchLabels:
-            app: ubuntu-client
+        - port: 5000
+          from:
+        - podSelector:
+            matchLabels:
+              app: ubuntu-client

--- a/tests/robot/suites/policy/test_data/allow_port_5000_server_from_nginx.yaml
+++ b/tests/robot/suites/policy/test_data/allow_port_5000_server_from_nginx.yaml
@@ -1,3 +1,4 @@
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -9,8 +10,8 @@ spec:
       app: ubuntu-server
   ingress:
     - ports:
-      - port: 5000
+        - port: 5000
       from:
-      - podSelector:
-          matchLabels:
-            app: nginx
+        - podSelector:
+            matchLabels:
+              app: nginx

--- a/tests/robot/suites/policy/test_data/allow_tcp_4444_server_from_client.yaml
+++ b/tests/robot/suites/policy/test_data/allow_tcp_4444_server_from_client.yaml
@@ -1,3 +1,4 @@
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -9,10 +10,9 @@ spec:
       app: ubuntu-server
   ingress:
     - ports:
-      - protocol: TCP
-        port: 4444
+        - protocol: TCP
+          port: 4444
       from:
-      - podSelector:
-          matchLabels:
-            app: ubuntu-client
-
+        - podSelector:
+            matchLabels:
+              app: ubuntu-client

--- a/tests/robot/suites/policy/test_data/allow_tcp_4444_server_from_nginx.yaml
+++ b/tests/robot/suites/policy/test_data/allow_tcp_4444_server_from_nginx.yaml
@@ -1,3 +1,4 @@
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -9,10 +10,9 @@ spec:
       app: ubuntu-server
   ingress:
     - ports:
-      - protocol: TCP
-        port: 4444
+        - protocol: TCP
+          port: 4444
       from:
-      - podSelector:
-          matchLabels:
-            app: nginx
-
+        - podSelector:
+            matchLabels:
+              app: nginx

--- a/tests/robot/suites/policy/test_data/allow_udp_7000_server_from_client.yaml
+++ b/tests/robot/suites/policy/test_data/allow_udp_7000_server_from_client.yaml
@@ -1,3 +1,4 @@
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -9,10 +10,9 @@ spec:
       app: ubuntu-server
   ingress:
     - ports:
-      - protocol: UDP
-        port: 7000
+        - protocol: UDP
+          port: 7000
       from:
-      - podSelector:
-          matchLabels:
-            app: ubuntu-client
-
+        - podSelector:
+            matchLabels:
+              app: ubuntu-client

--- a/tests/robot/suites/policy/test_data/allow_udp_7000_server_from_nginx.yaml
+++ b/tests/robot/suites/policy/test_data/allow_udp_7000_server_from_nginx.yaml
@@ -1,3 +1,4 @@
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -9,10 +10,9 @@ spec:
       app: ubuntu-server
   ingress:
     - ports:
-      - protocol: UDP
-        port: 7000
+        - protocol: UDP
+          port: 7000
       from:
-      - podSelector:
-          matchLabels:
-            app: nginx
-
+        - podSelector:
+            matchLabels:
+              app: nginx


### PR DESCRIPTION
This commit is inspired by a similar commit to Network Service Mesh [1], this
commit [2] from cn-infra, and this commit [3] to vpp-agent.

Since we are making heavy use of yaml files for Network Service Mesh, we should
ensure these are syntactically correct. We'll use yamllint [4] for this.

This commit adds running of yamllint into our travis-ci runs. It also adds a
custom configuration file which turns the yamllint line length check into a
warning. And finally, it fixes a large amount of yamllint errors in our
existing yaml files.

[1] https://github.com/ligato/networkservicemesh/pull/263
[2] https://github.com/ligato/cn-infra/pull/333
[3] https://github.com/ligato/vpp-agent/pull/820
[4] https://github.com/adrienverge/yamllint

Signed-off-by: Kyle Mestery <mestery@mestery.com>