### PR TITLE
Expose IPAM config via REST handler

### DIFF
--- a/plugins/contiv/ipam/ipam.go
+++ b/plugins/contiv/ipam/ipam.go
@@ -64,6 +64,8 @@ type IPAM struct {
 	excludededIPfromNodeIPrange []uint32 // IPs from the NodeInterconnect CIDR that should not be assigned
 
 	lastAssigned int // counter denoting last assigned IP address
+
+	config *Config // ipam configuration
 }
 
 type uintIP = uint32
@@ -91,6 +93,7 @@ func New(logger logging.Logger, nodeID uint32, nodeName string, config *Config, 
 		lastAssigned: 1,
 		broker:       broker,
 		nodeName:     nodeName,
+		config:       config,
 	}
 
 	// computing IPAM struct variables from IPAM config

--- a/plugins/contiv/ipam/rest_handlers.go
+++ b/plugins/contiv/ipam/rest_handlers.go
@@ -27,12 +27,25 @@ const (
 	PluginURL = Prefix + "ipam"
 )
 
+type config struct {
+	PodIfIPCIDR             string `json:"podIfIPCIDR"`
+	PodSubnetCIDR           string `json:"podSubnetCIRDR"`
+	PodNetworkPrefixLen     uint8  `json:"podNetworkPrefixLen"`
+	VPPHostSubnetCIDR       string `json:"vppHostSubnetCIDR"`
+	VPPHostNetworkPrefixLen uint8  `json:"vppHostNetworkPrefixLen"`
+	NodeInterconnectCIDR    string `json:"nodeInterconnectCIDR"`
+	NodeInterconnectDHCP    bool   `json:"nodeInterconnectDHCP"`
+	VxlanCIDR               string `json:"vxlanCIDR"`
+	ServiceCIDR             string `json:"serviceCIDR"`
+}
+
 type ipamData struct {
-	NodeID         uint32 `json:"nodeId"`
-	NodeName       string `json:"nodeName"`
-	NodeIP         string `json:"nodeIP"`
-	PodNetwork     string `json:"podNetwork"`
-	VppHostNetwork string `json:"vppHostNetwork"`
+	NodeID         uint32  `json:"nodeId"`
+	NodeName       string  `json:"nodeName"`
+	NodeIP         string  `json:"nodeIP"`
+	PodNetwork     string  `json:"podNetwork"`
+	VppHostNetwork string  `json:"vppHostNetwork"`
+	Config         *config `json:"config"`
 }
 
 func (i *IPAM) registerHandlers(http rest.HTTPHandlers) {
@@ -61,6 +74,17 @@ func (i *IPAM) ipamGetHandler(formatter *render.Render) http.HandlerFunc {
 			NodeIP:         nodeIP.String(),
 			PodNetwork:     i.PodNetwork().String(),
 			VppHostNetwork: i.VPPHostNetwork().String(),
+			Config: &config{
+				PodIfIPCIDR:             i.config.PodIfIPCIDR,
+				PodSubnetCIDR:           i.config.PodSubnetCIDR,
+				PodNetworkPrefixLen:     i.config.PodNetworkPrefixLen,
+				VPPHostSubnetCIDR:       i.config.VPPHostSubnetCIDR,
+				VPPHostNetworkPrefixLen: i.config.VPPHostNetworkPrefixLen,
+				NodeInterconnectCIDR:    i.config.NodeInterconnectCIDR,
+				NodeInterconnectDHCP:    i.config.NodeInterconnectDHCP,
+				VxlanCIDR:               i.config.VxlanCIDR,
+				ServiceCIDR:             i.config.ServiceCIDR,
+			},
 		})
 	}
 }


### PR DESCRIPTION
Example output:

```json
$ curl localhost:9999/contiv/v1/ipam
{
  "nodeId": 1,
  "nodeName": "vagrant-arch.vagrantup.com",
  "nodeIP": "192.168.16.1",
  "podNetwork": "10.1.1.0/24",
  "vppHostNetwork": "172.30.1.0/24",
  "config": {
    "podIfIPCIDR": "10.2.1.0/24",
    "podSubnetCIRDR": "10.1.0.0/16",
    "podNetworkPrefixLen": 24,
    "vppHostSubnetCIDR": "172.30.0.0/16",
    "vppHostNetworkPrefixLen": 24,
    "nodeInterconnectCIDR": "192.168.16.0/24",
    "nodeInterconnectDHCP": false,
    "vxlanCIDR": "192.168.30.0/24",
    "serviceCIDR": "10.96.0.0/12"
  }
}
```

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>