### PR TITLE
ipam: introducing contivCIDR to calculate pod/node/vxlan address spaces

### DIFF
--- a/k8s/contiv-vpp-arm64.yaml
+++ b/k8s/contiv-vpp-arm64.yaml
@@ -36,7 +36,7 @@ data:
     ServiceLocalEndpointWeight: 1
     DisableNATVirtualReassembly: true
     IPAMConfig:
-      ContivCIDR: 10.1.0.0/16
+      ContivCIDR: 10.1.0.0/15
       NodeInterconnectDHCP: False
   logs.conf: |
     default-level: debug

--- a/k8s/contiv-vpp-arm64.yaml
+++ b/k8s/contiv-vpp-arm64.yaml
@@ -36,7 +36,7 @@ data:
     ServiceLocalEndpointWeight: 1
     DisableNATVirtualReassembly: true
     IPAMConfig:
-      ContivCIDR: 10.1.0.0/15
+      ContivCIDR: 10.0.0.0/14
       NodeInterconnectDHCP: False
   logs.conf: |
     default-level: debug

--- a/k8s/contiv-vpp-arm64.yaml
+++ b/k8s/contiv-vpp-arm64.yaml
@@ -36,13 +36,7 @@ data:
     ServiceLocalEndpointWeight: 1
     DisableNATVirtualReassembly: true
     IPAMConfig:
-      PodSubnetCIDR: 10.1.0.0/16
-      PodNetworkPrefixLen: 24
-      PodIfIPCIDR: 10.2.1.0/24
-      VPPHostSubnetCIDR: 172.30.0.0/16
-      VPPHostNetworkPrefixLen: 24
-      NodeInterconnectCIDR: 192.168.16.0/24
-      VxlanCIDR: 192.168.30.0/24
+      ContivCIDR: 10.1.0.0/16
       NodeInterconnectDHCP: False
   logs.conf: |
     default-level: debug
@@ -125,31 +119,31 @@ spec:
       hostNetwork: true
 
       containers:
-        - name: contiv-etcd
-          image: quay.io/coreos/etcd:v3.3.5-arm64
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: CONTIV_ETCD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: ETCDCTL_API
-              value: "3"
-            - name: ETCD_UNSUPPORTED_ARCH
-              value: "arm64"
-          command:
-            - /bin/sh
-          args:
-            - -c
-            - /usr/local/bin/etcd --name=contiv-etcd --data-dir=/var/etcd/contiv-data
-              --advertise-client-urls=http://0.0.0.0:12379 --listen-client-urls=http://0.0.0.0:12379 --listen-peer-urls=http://0.0.0.0:12380
-          volumeMounts:
-            - name: var-etcd
-              mountPath: /var/etcd/
-      volumes:
+      - name: contiv-etcd
+        image: quay.io/coreos/etcd:v3.3.5-arm64
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: CONTIV_ETCD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ETCDCTL_API
+          value: "3"
+        - name: ETCD_UNSUPPORTED_ARCH
+          value: "arm64"
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - /usr/local/bin/etcd --name=contiv-etcd --data-dir=/var/etcd/contiv-data
+          --advertise-client-urls=http://0.0.0.0:12379 --listen-client-urls=http://0.0.0.0:12379 --listen-peer-urls=http://0.0.0.0:12380
+        volumeMounts:
         - name: var-etcd
-          hostPath:
-             path: /var/etcd
+          mountPath: /var/etcd/
+      volumes:
+      - name: var-etcd
+        hostPath:
+          path: /var/etcd
 
 ---
 
@@ -251,20 +245,20 @@ spec:
         image: contivvpp/cni-arm64:latest
         imagePullPolicy: IfNotPresent
         env:
-          - name: SLEEP
-            value: "false"
+        - name: SLEEP
+          value: "false"
         volumeMounts:
-          - mountPath: /opt/cni/bin
-            name: cni-bin-dir
-          - mountPath: /etc/cni/net.d
-            name: cni-net-dir
-          - mountPath: /var/run/contiv
-            name: contiv-run
+        - mountPath: /opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /etc/cni/net.d
+          name: cni-net-dir
+        - mountPath: /var/run/contiv
+          name: contiv-run
       # This init container waits until etcd is started
       - name: wait-foretcd
         env:
-          - name: ETCDPORT
-            value: "32379"
+        - name: ETCDPORT
+          value: "32379"
         image: arm64v8/busybox:latest
         command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
       # This init container extracts/copies VPP LD_PRELOAD libs and default VPP config to the host.
@@ -295,126 +289,126 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-          - name: usr-local-bin
-            mountPath: /host/usr/local/bin
-          - name: vpp-lib64
-            mountPath: /vpp-lib64/
-          - name: vpp-cfg
-            mountPath: /host/etc/vpp
-          - name: shm
-            mountPath: /dev/shm
-          - name: vpp-run
-            mountPath: /run/vpp
-          - name: contiv-run
-            mountPath: /var/run/contiv
+        - name: usr-local-bin
+          mountPath: /host/usr/local/bin
+        - name: vpp-lib64
+          mountPath: /vpp-lib64/
+        - name: vpp-cfg
+          mountPath: /host/etc/vpp
+        - name: shm
+          mountPath: /dev/shm
+        - name: vpp-run
+          mountPath: /run/vpp
+        - name: contiv-run
+          mountPath: /var/run/contiv
 
       containers:
-        # Runs contiv-vswitch container on each Kubernetes node.
-        # It contains the vSwitch VPP and its management agent.
-        - name: contiv-vswitch
-          image: contivvpp/vswitch-arm64:latest
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            privileged: true
-          ports:
-            # readiness + liveness probe
-            - containerPort: 9999
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9999
-            periodSeconds: 3
-            timeoutSeconds: 2
-            failureThreshold: 3
-            initialDelaySeconds: 15
-          livenessProbe:
-            httpGet:
-              path: /liveness
-              port: 9999
-            periodSeconds: 3
-            timeoutSeconds: 2
-            failureThreshold: 3
-            initialDelaySeconds: 60
-          env:
-            - name: MICROSERVICE_LABEL
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: ETCD_CONFIG
-              value: "/etc/etcd/etcd.conf"
-            - name: BOLT_CONFIG
-              value: "/etc/agent/bolt.conf"
-            - name: TELEMETRY_CONFIG
-              value: "/etc/agent/telemetry.conf"
-          volumeMounts:
-            - name: var-bolt
-              mountPath: /var/bolt
-            - name: etcd-cfg
-              mountPath: /etc/etcd
-            - name: vpp-cfg
-              mountPath: /etc/vpp
-            - name: shm
-              mountPath: /dev/shm
-            - name: dev
-              mountPath: /dev
-            - name: vpp-run
-              mountPath: /run/vpp
-            - name: contiv-run
-              mountPath: /var/run/contiv
-            - name: contiv-plugin-cfg
-              mountPath: /etc/agent
-            - name: govpp-plugin-cfg
-              mountPath: /etc/govpp
-      volumes:
-        # Used to connect to contiv-etcd.
-        - name: etcd-cfg
-          configMap:
-            name: contiv-etcd-cfg
-        # Used to install CNI.
-        - name: cni-bin-dir
-          hostPath:
-            path: /opt/cni/bin
-        - name: cni-net-dir
-          hostPath:
-            path: /etc/cni/net.d
-        # VPP startup config folder.
-        - name: vpp-cfg
-          hostPath:
-            path: /etc/vpp
-        # To install vppctl.
-        - name: usr-local-bin
-          hostPath:
-            path: /usr/local/bin
-        # LD_PRELOAD library.
-        - name: vpp-lib64
-          hostPath:
-            path: /tmp/ldpreload/vpp-lib64
-        # /dev mount is required for DPDK-managed NICs on VPP (/dev/uio0) and for shared memory communication with VPP (/dev/shm)
-        - name: dev
-          hostPath:
-            path: /dev
-        - name: shm
-          hostPath:
-            path: /dev/shm
-        # For CLI unix socket.
-        - name: vpp-run
-          hostPath:
-            path: /run/vpp
-        # For CNI / STN unix domain socket
-        - name: contiv-run
-          hostPath:
-            path: /var/run/contiv
-        # Used to configure contiv plugin.
-        - name: contiv-plugin-cfg
-          configMap:
-            name: contiv-agent-cfg
-        # Used to configure govpp plugin.
-        - name: govpp-plugin-cfg
-          configMap:
-            name: govpp-cfg
+      # Runs contiv-vswitch container on each Kubernetes node.
+      # It contains the vSwitch VPP and its management agent.
+      - name: contiv-vswitch
+        image: contivvpp/vswitch-arm64:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        ports:
+        # readiness + liveness probe
+        - containerPort: 9999
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9999
+          periodSeconds: 3
+          timeoutSeconds: 2
+          failureThreshold: 3
+          initialDelaySeconds: 15
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 9999
+          periodSeconds: 3
+          timeoutSeconds: 2
+          failureThreshold: 3
+          initialDelaySeconds: 60
+        env:
+        - name: MICROSERVICE_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ETCD_CONFIG
+          value: "/etc/etcd/etcd.conf"
+        - name: BOLT_CONFIG
+          value: "/etc/agent/bolt.conf"
+        - name: TELEMETRY_CONFIG
+          value: "/etc/agent/telemetry.conf"
+        volumeMounts:
         - name: var-bolt
-          hostPath:
-            path: /var/bolt
+          mountPath: /var/bolt
+        - name: etcd-cfg
+          mountPath: /etc/etcd
+        - name: vpp-cfg
+          mountPath: /etc/vpp
+        - name: shm
+          mountPath: /dev/shm
+        - name: dev
+          mountPath: /dev
+        - name: vpp-run
+          mountPath: /run/vpp
+        - name: contiv-run
+          mountPath: /var/run/contiv
+        - name: contiv-plugin-cfg
+          mountPath: /etc/agent
+        - name: govpp-plugin-cfg
+          mountPath: /etc/govpp
+      volumes:
+      # Used to connect to contiv-etcd.
+      - name: etcd-cfg
+        configMap:
+          name: contiv-etcd-cfg
+      # Used to install CNI.
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+      # VPP startup config folder.
+      - name: vpp-cfg
+        hostPath:
+          path: /etc/vpp
+      # To install vppctl.
+      - name: usr-local-bin
+        hostPath:
+          path: /usr/local/bin
+      # LD_PRELOAD library.
+      - name: vpp-lib64
+        hostPath:
+          path: /tmp/ldpreload/vpp-lib64
+      # /dev mount is required for DPDK-managed NICs on VPP (/dev/uio0) and for shared memory communication with VPP (/dev/shm)
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      # For CLI unix socket.
+      - name: vpp-run
+        hostPath:
+          path: /run/vpp
+      # For CNI / STN unix domain socket
+      - name: contiv-run
+        hostPath:
+          path: /var/run/contiv
+      # Used to configure contiv plugin.
+      - name: contiv-plugin-cfg
+        configMap:
+          name: contiv-agent-cfg
+      # Used to configure govpp plugin.
+      - name: govpp-plugin-cfg
+        configMap:
+          name: govpp-cfg
+      - name: var-bolt
+        hostPath:
+          path: /var/bolt
 
 ---
 
@@ -453,49 +447,49 @@ spec:
       serviceAccountName: contiv-ksr
 
       initContainers:
-        # This init container waits until etcd is started
-        - name: wait-foretcd
-          env:
-          - name: ETCDPORT
-            value: "32379"
-          image: arm64v8/busybox:latest
-          command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
+      # This init container waits until etcd is started
+      - name: wait-foretcd
+        env:
+        - name: ETCDPORT
+          value: "32379"
+        image: arm64v8/busybox:latest
+        command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
 
       containers:
-        - name: contiv-ksr
-          image: contivvpp/ksr-arm64:latest
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: ETCD_CONFIG
-              value: "/etc/etcd/etcd.conf"
-            - name: HTTP_CONFIG
-              value: "/etc/http/http.conf"
-          volumeMounts:
-            - name: etcd-cfg
-              mountPath: /etc/etcd
-            - name: http-cfg
-              mountPath: /etc/http
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9191
-            periodSeconds: 1
-            initialDelaySeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /liveness
-              port: 9191
-            periodSeconds: 1
-            initialDelaySeconds: 30
+      - name: contiv-ksr
+        image: contivvpp/ksr-arm64:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: ETCD_CONFIG
+          value: "/etc/etcd/etcd.conf"
+        - name: HTTP_CONFIG
+          value: "/etc/http/http.conf"
+        volumeMounts:
+        - name: etcd-cfg
+          mountPath: /etc/etcd
+        - name: http-cfg
+          mountPath: /etc/http
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9191
+          periodSeconds: 1
+          initialDelaySeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 9191
+          periodSeconds: 1
+          initialDelaySeconds: 30
 
       volumes:
-        # Used to connect to contiv-etcd.
-        - name: etcd-cfg
-          configMap:
-            name: contiv-etcd-withcompact-cfg
-        - name: http-cfg
-          configMap:
-            name: contiv-ksr-http-cfg
+      # Used to connect to contiv-etcd.
+      - name: etcd-cfg
+        configMap:
+          name: contiv-etcd-withcompact-cfg
+      - name: http-cfg
+        configMap:
+          name: contiv-ksr-http-cfg
 
 ---
 
@@ -506,19 +500,19 @@ metadata:
   name: contiv-ksr
   namespace: kube-system
 rules:
-  - apiGroups:
-    - ""
-    - extensions
-    resources:
-      - pods
-      - namespaces
-      - networkpolicies
-      - services
-      - endpoints
-      - nodes
-    verbs:
-      - watch
-      - list
+- apiGroups:
+  - ""
+  - extensions
+  resources:
+  - pods
+  - namespaces
+  - networkpolicies
+  - services
+  - endpoints
+  - nodes
+  verbs:
+  - watch
+  - list
 
 ---
 
@@ -544,4 +538,3 @@ subjects:
 - kind: ServiceAccount
   name: contiv-ksr
   namespace: kube-system
-

--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -36,7 +36,7 @@ data:
     ServiceLocalEndpointWeight: 1
     DisableNATVirtualReassembly: true
     IPAMConfig:
-      ContivCIDR: 10.1.0.0/16
+      ContivCIDR: 10.1.0.0/15
       NodeInterconnectDHCP: False
   logs.conf: |
     default-level: debug

--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -36,13 +36,7 @@ data:
     ServiceLocalEndpointWeight: 1
     DisableNATVirtualReassembly: true
     IPAMConfig:
-      PodSubnetCIDR: 10.1.0.0/16
-      PodNetworkPrefixLen: 24
-      PodIfIPCIDR: 10.2.1.0/24
-      VPPHostSubnetCIDR: 172.30.0.0/16
-      VPPHostNetworkPrefixLen: 24
-      NodeInterconnectCIDR: 192.168.16.0/24
-      VxlanCIDR: 192.168.30.0/24
+      ContivCIDR: 10.1.0.0/16
       NodeInterconnectDHCP: False
   logs.conf: |
     default-level: debug
@@ -130,29 +124,29 @@ spec:
       hostNetwork: true
 
       containers:
-        - name: contiv-etcd
-          image: quay.io/coreos/etcd:v3.1.10
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: CONTIV_ETCD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: ETCDCTL_API
-              value: "3"
-          command:
-            - /bin/sh
-          args:
-            - -c
-            - /usr/local/bin/etcd --name=contiv-etcd --data-dir=/var/etcd/contiv-data
-              --advertise-client-urls=http://0.0.0.0:12379 --listen-client-urls=http://0.0.0.0:12379 --listen-peer-urls=http://0.0.0.0:12380
-          volumeMounts:
-            - name: var-etcd
-              mountPath: /var/etcd/
-      volumes:
+      - name: contiv-etcd
+        image: quay.io/coreos/etcd:v3.1.10
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: CONTIV_ETCD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ETCDCTL_API
+          value: "3"
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - /usr/local/bin/etcd --name=contiv-etcd --data-dir=/var/etcd/contiv-data
+          --advertise-client-urls=http://0.0.0.0:12379 --listen-client-urls=http://0.0.0.0:12379 --listen-peer-urls=http://0.0.0.0:12380
+        volumeMounts:
         - name: var-etcd
-          hostPath:
-             path: /var/etcd
+          mountPath: /var/etcd/
+      volumes:
+      - name: var-etcd
+        hostPath:
+          path: /var/etcd
 
 ---
 
@@ -254,20 +248,20 @@ spec:
         image: contivvpp/cni:latest
         imagePullPolicy: IfNotPresent
         env:
-          - name: SLEEP
-            value: "false"
+        - name: SLEEP
+          value: "false"
         volumeMounts:
-          - mountPath: /opt/cni/bin
-            name: cni-bin-dir
-          - mountPath: /etc/cni/net.d
-            name: cni-net-dir
-          - mountPath: /var/run/contiv
-            name: contiv-run
+        - mountPath: /opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /etc/cni/net.d
+          name: cni-net-dir
+        - mountPath: /var/run/contiv
+          name: contiv-run
       # This init container waits until etcd is started
       - name: wait-foretcd
         env:
-          - name: ETCDPORT
-            value: "32379"
+        - name: ETCDPORT
+          value: "32379"
         image: busybox:latest
         command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
       # This init container extracts/copies VPP LD_PRELOAD libs and default VPP config to the host.
@@ -298,127 +292,127 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-          - name: usr-local-bin
-            mountPath: /host/usr/local/bin
-          - name: vpp-lib64
-            mountPath: /vpp-lib64/
-          - name: vpp-cfg
-            mountPath: /host/etc/vpp
-          - name: shm
-            mountPath: /dev/shm
-          - name: vpp-run
-            mountPath: /run/vpp
-          - name: contiv-run
-            mountPath: /var/run/contiv
+        - name: usr-local-bin
+          mountPath: /host/usr/local/bin
+        - name: vpp-lib64
+          mountPath: /vpp-lib64/
+        - name: vpp-cfg
+          mountPath: /host/etc/vpp
+        - name: shm
+          mountPath: /dev/shm
+        - name: vpp-run
+          mountPath: /run/vpp
+        - name: contiv-run
+          mountPath: /var/run/contiv
 
       containers:
-        # Runs contiv-vswitch container on each Kubernetes node.
-        # It contains the vSwitch VPP and its management agent.
-        - name: contiv-vswitch
-          image: contivvpp/vswitch:latest
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            privileged: true
-          ports:
-            # readiness + liveness probe
-            - containerPort: 9999
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9999
-            periodSeconds: 3
-            timeoutSeconds: 2
-            failureThreshold: 3
-            initialDelaySeconds: 15
-          livenessProbe:
-            httpGet:
-              path: /liveness
-              port: 9999
-            periodSeconds: 3
-            timeoutSeconds: 2
-            failureThreshold: 3
-            initialDelaySeconds: 60
-          env:
-            - name: MICROSERVICE_LABEL
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: ETCD_CONFIG
-              value: "/etc/etcd/etcd.conf"
-            - name: BOLT_CONFIG
-              value: "/etc/agent/bolt.conf"
-            - name: TELEMETRY_CONFIG
-              value: "/etc/agent/telemetry.conf"
-          volumeMounts:
-            - name: var-bolt
-              mountPath: /var/bolt
-            - name: etcd-cfg
-              mountPath: /etc/etcd
-            - name: vpp-cfg
-              mountPath: /etc/vpp
-            - name: shm
-              mountPath: /dev/shm
-            - name: dev
-              mountPath: /dev
-            - name: vpp-run
-              mountPath: /run/vpp
-            - name: contiv-run
-              mountPath: /var/run/contiv
-            - name: contiv-plugin-cfg
-              mountPath: /etc/agent
-            - name: govpp-plugin-cfg
-              mountPath: /etc/govpp
+      # Runs contiv-vswitch container on each Kubernetes node.
+      # It contains the vSwitch VPP and its management agent.
+      - name: contiv-vswitch
+        image: contivvpp/vswitch:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        ports:
+        # readiness + liveness probe
+        - containerPort: 9999
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9999
+          periodSeconds: 3
+          timeoutSeconds: 2
+          failureThreshold: 3
+          initialDelaySeconds: 15
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 9999
+          periodSeconds: 3
+          timeoutSeconds: 2
+          failureThreshold: 3
+          initialDelaySeconds: 60
+        env:
+        - name: MICROSERVICE_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ETCD_CONFIG
+          value: "/etc/etcd/etcd.conf"
+        - name: BOLT_CONFIG
+          value: "/etc/agent/bolt.conf"
+        - name: TELEMETRY_CONFIG
+          value: "/etc/agent/telemetry.conf"
+        volumeMounts:
+        - name: var-bolt
+          mountPath: /var/bolt
+        - name: etcd-cfg
+          mountPath: /etc/etcd
+        - name: vpp-cfg
+          mountPath: /etc/vpp
+        - name: shm
+          mountPath: /dev/shm
+        - name: dev
+          mountPath: /dev
+        - name: vpp-run
+          mountPath: /run/vpp
+        - name: contiv-run
+          mountPath: /var/run/contiv
+        - name: contiv-plugin-cfg
+          mountPath: /etc/agent
+        - name: govpp-plugin-cfg
+          mountPath: /etc/govpp
 
       volumes:
-        # Used to connect to contiv-etcd.
-        - name: etcd-cfg
-          configMap:
-            name: contiv-etcd-cfg
-        # Used to install CNI.
-        - name: cni-bin-dir
-          hostPath:
-            path: /opt/cni/bin
-        - name: cni-net-dir
-          hostPath:
-            path: /etc/cni/net.d
-        # VPP startup config folder.
-        - name: vpp-cfg
-          hostPath:
-            path: /etc/vpp
-        # To install vppctl.
-        - name: usr-local-bin
-          hostPath:
-            path: /usr/local/bin
-        # LD_PRELOAD library.
-        - name: vpp-lib64
-          hostPath:
-            path: /tmp/ldpreload/vpp-lib64
-        # /dev mount is required for DPDK-managed NICs on VPP (/dev/uio0) and for shared memory communication with VPP (/dev/shm)
-        - name: dev
-          hostPath:
-            path: /dev
-        - name: shm
-          hostPath:
-            path: /dev/shm
-        # For CLI unix socket.
-        - name: vpp-run
-          hostPath:
-            path: /run/vpp
-        # For CNI / STN unix domain socket
-        - name: contiv-run
-          hostPath:
-            path: /var/run/contiv
-        # Used to configure contiv plugin.
-        - name: contiv-plugin-cfg
-          configMap:
-            name: contiv-agent-cfg
-        # Used to configure govpp plugin.
-        - name: govpp-plugin-cfg
-          configMap:
-            name: govpp-cfg
-        - name: var-bolt
-          hostPath:
-            path: /var/bolt
+      # Used to connect to contiv-etcd.
+      - name: etcd-cfg
+        configMap:
+          name: contiv-etcd-cfg
+      # Used to install CNI.
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+      # VPP startup config folder.
+      - name: vpp-cfg
+        hostPath:
+          path: /etc/vpp
+      # To install vppctl.
+      - name: usr-local-bin
+        hostPath:
+          path: /usr/local/bin
+      # LD_PRELOAD library.
+      - name: vpp-lib64
+        hostPath:
+          path: /tmp/ldpreload/vpp-lib64
+      # /dev mount is required for DPDK-managed NICs on VPP (/dev/uio0) and for shared memory communication with VPP (/dev/shm)
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      # For CLI unix socket.
+      - name: vpp-run
+        hostPath:
+          path: /run/vpp
+      # For CNI / STN unix domain socket
+      - name: contiv-run
+        hostPath:
+          path: /var/run/contiv
+      # Used to configure contiv plugin.
+      - name: contiv-plugin-cfg
+        configMap:
+          name: contiv-agent-cfg
+      # Used to configure govpp plugin.
+      - name: govpp-plugin-cfg
+        configMap:
+          name: govpp-cfg
+      - name: var-bolt
+        hostPath:
+          path: /var/bolt
 
 ---
 
@@ -457,49 +451,49 @@ spec:
       serviceAccountName: contiv-ksr
 
       initContainers:
-        # This init container waits until etcd is started
-        - name: wait-foretcd
-          env:
-          - name: ETCDPORT
-            value: "32379"
-          image: busybox:latest
-          command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
+      # This init container waits until etcd is started
+      - name: wait-foretcd
+        env:
+        - name: ETCDPORT
+          value: "32379"
+        image: busybox:latest
+        command: ['sh', '-c', 'until nc -w 2 127.0.0.1:$ETCDPORT; do echo waiting for etcd; sleep 2; done;']
 
       containers:
-        - name: contiv-ksr
-          image: contivvpp/ksr:latest
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: ETCD_CONFIG
-              value: "/etc/etcd/etcd.conf"
-            - name: HTTP_CONFIG
-              value: "/etc/http/http.conf"
-          volumeMounts:
-            - name: etcd-cfg
-              mountPath: /etc/etcd
-            - name: http-cfg
-              mountPath: /etc/http
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9191
-            periodSeconds: 1
-            initialDelaySeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /liveness
-              port: 9191
-            periodSeconds: 1
-            initialDelaySeconds: 30
+      - name: contiv-ksr
+        image: contivvpp/ksr:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: ETCD_CONFIG
+          value: "/etc/etcd/etcd.conf"
+        - name: HTTP_CONFIG
+          value: "/etc/http/http.conf"
+        volumeMounts:
+        - name: etcd-cfg
+          mountPath: /etc/etcd
+        - name: http-cfg
+          mountPath: /etc/http
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9191
+          periodSeconds: 1
+          initialDelaySeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 9191
+          periodSeconds: 1
+          initialDelaySeconds: 30
 
       volumes:
-        # Used to connect to contiv-etcd.
-        - name: etcd-cfg
-          configMap:
-            name: contiv-etcd-withcompact-cfg
-        - name: http-cfg
-          configMap:
-            name: contiv-ksr-http-cfg
+      # Used to connect to contiv-etcd.
+      - name: etcd-cfg
+        configMap:
+          name: contiv-etcd-withcompact-cfg
+      - name: http-cfg
+        configMap:
+          name: contiv-ksr-http-cfg
 
 ---
 
@@ -510,19 +504,19 @@ metadata:
   name: contiv-ksr
   namespace: kube-system
 rules:
-  - apiGroups:
-    - ""
-    - extensions
-    resources:
-      - pods
-      - namespaces
-      - networkpolicies
-      - services
-      - endpoints
-      - nodes
-    verbs:
-      - watch
-      - list
+- apiGroups:
+  - ""
+  - extensions
+  resources:
+  - pods
+  - namespaces
+  - networkpolicies
+  - services
+  - endpoints
+  - nodes
+  verbs:
+  - watch
+  - list
 
 ---
 
@@ -548,4 +542,3 @@ subjects:
 - kind: ServiceAccount
   name: contiv-ksr
   namespace: kube-system
-

--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -36,7 +36,7 @@ data:
     ServiceLocalEndpointWeight: 1
     DisableNATVirtualReassembly: true
     IPAMConfig:
-      ContivCIDR: 10.1.0.0/15
+      ContivCIDR: 10.0.0.0/14
       NodeInterconnectDHCP: False
   logs.conf: |
     default-level: debug

--- a/k8s/contiv-vpp/templates/vpp.yaml
+++ b/k8s/contiv-vpp/templates/vpp.yaml
@@ -44,15 +44,7 @@ data:
     {{- end }}
     DisableNATVirtualReassembly: {{ .Values.contiv.disableNATVirtualReassembly }}
     IPAMConfig:
-      PodSubnetCIDR: {{ .Values.contiv.ipamConfig.podSubnetCIDR }}
-      PodNetworkPrefixLen: {{ .Values.contiv.ipamConfig.podNetworkPrefixLen }}
-      PodIfIPCIDR: {{ .Values.contiv.ipamConfig.podIfIPCIDR }}
-      VPPHostSubnetCIDR: {{ .Values.contiv.ipamConfig.vppHostSubnetCIDR }}
-      VPPHostNetworkPrefixLen: {{ .Values.contiv.ipamConfig.vppHostNetworkPrefixLen }}
-      {{- if .Values.contiv.ipamConfig.nodeInterconnectCIDR }}
-      NodeInterconnectCIDR: {{ .Values.contiv.ipamConfig.nodeInterconnectCIDR }}
-      {{- end }}
-      VxlanCIDR: {{ .Values.contiv.ipamConfig.vxlanCIDR }}
+      ContivCIDR: {{ .Values.contiv.ipamConfig.contivCIDR }}
       NodeInterconnectDHCP: {{ if .Values.contiv.ipamConfig.nodeInterconnectCIDR }}False{{ else }}True{{ end }}
       {{- if .Values.contiv.ipamConfig.serviceCIDR }}
       ServiceCIDR: {{ .Values.contiv.ipamConfig.serviceCIDR }}

--- a/k8s/contiv-vpp/values.yaml
+++ b/k8s/contiv-vpp/values.yaml
@@ -14,7 +14,7 @@ contiv:
   serviceLocalEndpointWeight: 1
   disableNATVirtualReassembly: True
   ipamConfig:
-    contivCIDR: "10.1.0.0/15"
+    contivCIDR: "10.0.0.0/14"
     #serviceCIDR: "10.96.0.0/12"
   # example of node configuration for VPP interfaces
   #nodeConfig:

--- a/k8s/contiv-vpp/values.yaml
+++ b/k8s/contiv-vpp/values.yaml
@@ -14,7 +14,7 @@ contiv:
   serviceLocalEndpointWeight: 1
   disableNATVirtualReassembly: True
   ipamConfig:
-    contivCIDR: "10.1.0.0/16"
+    contivCIDR: "10.1.0.0/15"
     #serviceCIDR: "10.96.0.0/12"
   # example of node configuration for VPP interfaces
   #nodeConfig:

--- a/k8s/contiv-vpp/values.yaml
+++ b/k8s/contiv-vpp/values.yaml
@@ -14,13 +14,7 @@ contiv:
   serviceLocalEndpointWeight: 1
   disableNATVirtualReassembly: True
   ipamConfig:
-    podSubnetCIDR: "10.1.0.0/16"
-    podNetworkPrefixLen: 24
-    podIfIPCIDR: 10.2.1.0/24
-    vppHostSubnetCIDR: "172.30.0.0/16"
-    vppHostNetworkPrefixLen: 24
-    vxlanCIDR: "192.168.30.0/24"
-    nodeInterconnectCIDR: "192.168.16.0/24"
+    contivCIDR: "10.1.0.0/16"
     #serviceCIDR: "10.96.0.0/12"
   # example of node configuration for VPP interfaces
   #nodeConfig:

--- a/plugins/contiv/ipam/ipam.go
+++ b/plugins/contiv/ipam/ipam.go
@@ -82,6 +82,7 @@ type Config struct {
 	NodeInterconnectDHCP    bool   // if set to true DHCP is used to acquire IP for the main VPP interface (NodeInterconnectCIDR can be omitted in config)
 	VxlanCIDR               string // subnet used for for inter-node VXLAN
 	ServiceCIDR             string // subnet used by services
+	ContivCIDR              string // subnet from which all subnets (pod/node/vxlan) will be created
 }
 
 // New returns new IPAM module to be used on the node specified by the nodeID.

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -628,15 +628,15 @@ func appendIfMissing(slice []string, s string) []string {
 func getIPAMConfig(config *Config) *Config {
 	_, contivNetwork, _ := net.ParseCIDR(config.IPAMConfig.ContivCIDR)
 	maskSize, _ := contivNetwork.Mask.Size()
-	subnetPrefixLength := 24 - maskSize
+	subnetPrefixLength := 23 - maskSize
 
 	podSubnetCIDR, _ := subnet(contivNetwork, 1, 0)
 	podNetworkPrefixLen := uint8(24)
 	vppHostSubnetCIDR, _ := subnet(contivNetwork, 1, 1)
 	vppHostNetworkPrefixLen := uint8(24)
-	nodeInterconnectCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 253)
-	podIfIPCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 254)
-	vxlanCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 255)
+	nodeInterconnectCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 125)
+	podIfIPCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 126)
+	vxlanCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 127)
 
 	config.IPAMConfig = ipam.Config{
 		PodIfIPCIDR:             podIfIPCIDR.String(),

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -626,7 +626,7 @@ func appendIfMissing(slice []string, s string) []string {
 
 // getIPAMConfig populates the Config struct with the calculated subnets
 func getIPAMConfig(config *Config) *Config {
-	_, contivNetwork, _ := net.ParseCIDR("10.1.0.0/14")
+	_, contivNetwork, _ := net.ParseCIDR(config.IPAMConfig.ContivCIDR)
 	maskSize, _ := contivNetwork.Mask.Size()
 	subnetPrefixLength := 23 - maskSize
 
@@ -660,7 +660,7 @@ func getIPAMConfig(config *Config) *Config {
 // num: given network number.
 //
 // Example: 10.1.0.0/16, with additional 8 bits and a network number of 5
-// result = 10.3.5.0/24
+// result = 10.1.5.0/24
 func subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
 	ip := base.IP
 	mask := base.Mask

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -626,17 +626,17 @@ func appendIfMissing(slice []string, s string) []string {
 
 // getIPAMConfig populates the Config struct with the calculated subnets
 func getIPAMConfig(config *Config) *Config {
-	_, contivNetwork, _ := net.ParseCIDR(config.IPAMConfig.ContivCIDR)
+	_, contivNetwork, _ := net.ParseCIDR("10.1.0.0/14")
 	maskSize, _ := contivNetwork.Mask.Size()
 	subnetPrefixLength := 23 - maskSize
 
-	podSubnetCIDR, _ := subnet(contivNetwork, 1, 0)
-	podNetworkPrefixLen := uint8(24)
-	vppHostSubnetCIDR, _ := subnet(contivNetwork, 1, 1)
-	vppHostNetworkPrefixLen := uint8(24)
-	nodeInterconnectCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 125)
-	podIfIPCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 126)
-	vxlanCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 127)
+	podSubnetCIDR, _ := subnet(contivNetwork, 2, 0)
+	podNetworkPrefixLen := uint8(25)
+	vppHostSubnetCIDR, _ := subnet(contivNetwork, 2, 1)
+	vppHostNetworkPrefixLen := uint8(25)
+	nodeInterconnectCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 128)
+	podIfIPCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 129)
+	vxlanCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 130)
 
 	config.IPAMConfig = ipam.Config{
 		PodIfIPCIDR:             podIfIPCIDR.String(),

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -20,6 +20,7 @@ package contiv
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"net"
 
 	"strings"
@@ -452,6 +453,8 @@ func (plugin *Plugin) loadExternalConfig() error {
 	}
 	plugin.Config = externalCfg
 
+	externalCfg = getIPAMConfig(externalCfg)
+
 	// use tap version 2 as default in case that TAPs are enabled
 	if plugin.Config.TAPInterfaceVersion == 0 {
 		plugin.Config.TAPInterfaceVersion = 2
@@ -619,4 +622,101 @@ func appendIfMissing(slice []string, s string) []string {
 		}
 	}
 	return append(slice, s)
+}
+
+// getIPAMConfig populates the Config struct with the calculated subnets
+func getIPAMConfig(config *Config) *Config {
+	_, contivNetwork, _ := net.ParseCIDR(config.IPAMConfig.ContivCIDR)
+	maskSize, _ := contivNetwork.Mask.Size()
+	subnetPrefixLength := 24 - maskSize
+
+	podSubnetCIDR, _ := subnet(contivNetwork, 1, 0)
+	podNetworkPrefixLen := uint8(24)
+	vppHostSubnetCIDR, _ := subnet(contivNetwork, 1, 1)
+	vppHostNetworkPrefixLen := uint8(24)
+	nodeInterconnectCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 253)
+	podIfIPCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 254)
+	vxlanCIDR, _ := subnet(contivNetwork, subnetPrefixLength, 255)
+
+	config.IPAMConfig = ipam.Config{
+		PodIfIPCIDR:             podIfIPCIDR.String(),
+		PodSubnetCIDR:           podSubnetCIDR.String(),
+		PodNetworkPrefixLen:     podNetworkPrefixLen,
+		VPPHostSubnetCIDR:       vppHostSubnetCIDR.String(),
+		VPPHostNetworkPrefixLen: vppHostNetworkPrefixLen,
+		VxlanCIDR:               vxlanCIDR.String(),
+	}
+
+	if config.IPAMConfig.NodeInterconnectDHCP != true {
+		config.IPAMConfig.NodeInterconnectCIDR = nodeInterconnectCIDR.String()
+	}
+
+	return config
+}
+
+// subnet takes a CIDR range and creates a subnet from it
+// base: parent CIDR range
+// newBits: number of additional prefix bits
+// num: given network number.
+//
+// Example: 10.1.0.0/16, with additional 8 bits and a network number of 5
+// result = 10.3.5.0/24
+func subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	baseLength, addressLength := mask.Size()
+	newPrefixLen := baseLength + newBits
+
+	// check if there is sufficient address space to extend the network prefix
+	if newPrefixLen > addressLength {
+		return nil, fmt.Errorf("not enought space to extend prefix of %d by %d", baseLength, newBits)
+	}
+
+	// calculate the maximum network number
+	maxNetNum := uint64(1<<uint64(newBits)) - 1
+	if uint64(num) > maxNetNum {
+		return nil, fmt.Errorf("prefix extension of %d does not accommodate a subnet numbered %d", newBits, num)
+	}
+
+	return &net.IPNet{
+		IP:   insertNetworkNumIntoIP(ip, num, newPrefixLen),
+		Mask: net.CIDRMask(newPrefixLen, addressLength),
+	}, nil
+}
+
+// ipToInt is simple utility function for conversion between IPv4/IPv6 and int.
+func ipToInt(ip net.IP) (*big.Int, int) {
+	val := &big.Int{}
+	val.SetBytes([]byte(ip))
+	if len(ip) == net.IPv4len {
+		return val, 32
+	} else if len(ip) == net.IPv6len {
+		return val, 128
+	} else {
+		return nil, 0
+	}
+}
+
+// intToIP is simple utility function for conversion between int and IPv4/IPv6.
+func intToIP(ipInt *big.Int, bits int) net.IP {
+	ipBytes := ipInt.Bytes()
+	val := make([]byte, bits/8)
+
+	// big.Int.Bytes() removes front zero padding.
+	// IP bytes packed at the end of the return array,
+	for i := 1; i <= len(ipBytes); i++ {
+		val[len(val)-i] = ipBytes[len(ipBytes)-i]
+	}
+
+	return net.IP(val)
+}
+
+func insertNetworkNumIntoIP(ip net.IP, num int, prefixLen int) net.IP {
+	ipInt, totalBits := ipToInt(ip)
+	bigNum := big.NewInt(int64(num))
+	bigNum.Lsh(bigNum, uint(totalBits-prefixLen))
+	ipInt.Or(ipInt, bigNum)
+
+	return intToIP(ipInt, totalBits)
 }

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -423,7 +423,7 @@ VAGRANTFILE_API_VERSION = "2"
     config.vm.define "k8s-gateway" do |gw|
       gw.vm.hostname = "k8s-gateway"
       # Interface for K8s Cluster
-      gw.vm.network :private_network, ip: "10.0.251.254",  netmask: "255.255.254.0" virtualbox__intnet: "vpp"
+      gw.vm.network :private_network, ip: "10.1.1.254",  netmask: "255.255.254.0" virtualbox__intnet: "vpp"
       gw.vm.provider "virtualbox" do |v|
         v.customize ["modifyvm", :id, "--ioapic", "on"]
         v.memory = 256
@@ -446,7 +446,7 @@ VAGRANTFILE_API_VERSION = "2"
         # default router
         k8smaster.vm.provision "shell",
           run: "always",
-          inline: "route add default gw 10.0.251.254"
+          inline: "route add default gw 10.1.1.254"
         # delete default gw on eth0
         k8smaster.vm.provision "shell",
           run: "always",
@@ -489,7 +489,7 @@ VAGRANTFILE_API_VERSION = "2"
           # default router
           node.vm.provision "shell",
             run: "always",
-            inline: "route add default gw 10.0.251.254"
+            inline: "route add default gw 10.1.1.254"
           # delete default gw on eth0
           node.vm.provision "shell",
             run: "always",

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -423,7 +423,7 @@ VAGRANTFILE_API_VERSION = "2"
     config.vm.define "k8s-gateway" do |gw|
       gw.vm.hostname = "k8s-gateway"
       # Interface for K8s Cluster
-      gw.vm.network :private_network, ip: "10.1.253.254", virtualbox__intnet: "vpp"
+      gw.vm.network :private_network, ip: "10.0.251.254",  netmask: "255.255.254.0" virtualbox__intnet: "vpp"
       gw.vm.provider "virtualbox" do |v|
         v.customize ["modifyvm", :id, "--ioapic", "on"]
         v.memory = 256
@@ -446,7 +446,7 @@ VAGRANTFILE_API_VERSION = "2"
         # default router
         k8smaster.vm.provision "shell",
           run: "always",
-          inline: "route add default gw 10.1.253.254"
+          inline: "route add default gw 10.0.251.254"
         # delete default gw on eth0
         k8smaster.vm.provision "shell",
           run: "always",
@@ -489,7 +489,7 @@ VAGRANTFILE_API_VERSION = "2"
           # default router
           node.vm.provision "shell",
             run: "always",
-            inline: "route add default gw 10.1.253.254"
+            inline: "route add default gw 10.0.251.254"
           # delete default gw on eth0
           node.vm.provision "shell",
             run: "always",

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -423,7 +423,7 @@ VAGRANTFILE_API_VERSION = "2"
     config.vm.define "k8s-gateway" do |gw|
       gw.vm.hostname = "k8s-gateway"
       # Interface for K8s Cluster
-      gw.vm.network :private_network, ip: "192.168.16.100", virtualbox__intnet: "vpp"
+      gw.vm.network :private_network, ip: "10.1.253.254", virtualbox__intnet: "vpp"
       gw.vm.provider "virtualbox" do |v|
         v.customize ["modifyvm", :id, "--ioapic", "on"]
         v.memory = 256
@@ -446,7 +446,7 @@ VAGRANTFILE_API_VERSION = "2"
         # default router
         k8smaster.vm.provision "shell",
           run: "always",
-          inline: "route add default gw 192.168.16.100"
+          inline: "route add default gw 10.1.253.254"
         # delete default gw on eth0
         k8smaster.vm.provision "shell",
           run: "always",
@@ -489,7 +489,7 @@ VAGRANTFILE_API_VERSION = "2"
           # default router
           node.vm.provision "shell",
             run: "always",
-            inline: "route add default gw 192.168.16.100"
+            inline: "route add default gw 10.1.253.254"
           # delete default gw on eth0
           node.vm.provision "shell",
             run: "always",

--- a/vagrant/config/vagrant-yaml
+++ b/vagrant/config/vagrant-yaml
@@ -7,7 +7,7 @@ if [ $DEP_SCENARIO = "nostn" ]; then
     - NodeName: \"k8s-master\"\
       MainVppInterface:\
         InterfaceName: \"GigabitEthernet0/8/0\"\
-      Gateway: \"10.1.253.254\"'
+      Gateway: \"10.0.251.254\"'
 
   worker_gw_config=''
 for i in `seq 1 $NUM_K8S_NODES`; do
@@ -15,7 +15,7 @@ worker_gw_config=$worker_gw_config'\
     - NodeName: \"k8s-worker'$i'\"\
       MainVppInterface:\
         InterfaceName: \"GigabitEthernet0/8/0\"\
-      Gateway: \"10.1.253.254\"'
+      Gateway: \"10.0.251.254\"'
 done
 
   sed -i "/logs.conf/i \

--- a/vagrant/config/vagrant-yaml
+++ b/vagrant/config/vagrant-yaml
@@ -7,7 +7,7 @@ if [ $DEP_SCENARIO = "nostn" ]; then
     - NodeName: \"k8s-master\"\
       MainVppInterface:\
         InterfaceName: \"GigabitEthernet0/8/0\"\
-      Gateway: \"192.168.16.100\"'
+      Gateway: \"10.1.253.254\"'
 
   worker_gw_config=''
 for i in `seq 1 $NUM_K8S_NODES`; do
@@ -15,7 +15,7 @@ worker_gw_config=$worker_gw_config'\
     - NodeName: \"k8s-worker'$i'\"\
       MainVppInterface:\
         InterfaceName: \"GigabitEthernet0/8/0\"\
-      Gateway: \"192.168.16.100\"'
+      Gateway: \"10.1.253.254\"'
 done
 
   sed -i "/logs.conf/i \

--- a/vagrant/config/vagrant-yaml
+++ b/vagrant/config/vagrant-yaml
@@ -7,7 +7,7 @@ if [ $DEP_SCENARIO = "nostn" ]; then
     - NodeName: \"k8s-master\"\
       MainVppInterface:\
         InterfaceName: \"GigabitEthernet0/8/0\"\
-      Gateway: \"10.0.251.254\"'
+      Gateway: \"10.1.1.254\"'
 
   worker_gw_config=''
 for i in `seq 1 $NUM_K8S_NODES`; do
@@ -15,7 +15,7 @@ worker_gw_config=$worker_gw_config'\
     - NodeName: \"k8s-worker'$i'\"\
       MainVppInterface:\
         InterfaceName: \"GigabitEthernet0/8/0\"\
-      Gateway: \"10.0.251.254\"'
+      Gateway: \"10.1.1.254\"'
 done
 
   sed -i "/logs.conf/i \


### PR DESCRIPTION
This PR removes the ability from the user to define pod/node/vxlan address space.

  * Introducing ContivCIDR in the contiv-vpp.yaml from which, all the subnets are being calculated
    A /14 prefix (or less, i.e /13, /12) is needed. 
  * From the given CIDR we get two subnets of 32768 (or more) addresses each assigned for 
    PodSubnetCIDR and VPPHostSubnetCIDR
  * Three /23 subnets are reserved for NodeInterconnectCIDR, VxlanCIDR and podIfIPCIDR
  * Modified Vagrant to reflect changes 
  * Modified Helm charts
  * Modified yaml (k8s/contiv-vpp + arm)