### PR TITLE
contiv-crd: added missing GenerateCRDReport call

### DIFF
--- a/plugins/crd/cache/telemetry_cache.go
+++ b/plugins/crd/cache/telemetry_cache.go
@@ -224,6 +224,7 @@ func (ctc *ContivTelemetryCache) validateCluster() {
 	fmt.Printf("validations: %d, resyncs: %d, updates: %d, responses: %d\n",
 		ctc.nValidations, ctc.nResyncs, ctc.nUpdates, ctc.nnResponses)
 	ctc.Report.Print()
+	ctc.ControllerReport.GenerateCRDReport()
 }
 
 // Collect real-time node state (mainly VPP, but some Linux too) from the


### PR DESCRIPTION
This PR adds a call in telemetry_cache, to generates the report into CRD after all the checks and validations have finished. 