### PR TITLE
Fix Vagrant restart - do not generate incorrect netplan config file

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -238,9 +238,6 @@ else
   if [ "#{dep_scenario}" = 'nostn' ]; then
     #shutdown interface
     ip link set enp0s8 down
-    cat <<EOL >> /etc/netplan/50-vagrant.yaml
-    enp0s8: {}
-EOL
   fi
 fi
 SCRIPT


### PR DESCRIPTION
Incorrect netplan config file caused VM end up without IP connectivity after node restart. No need to put there anything for interfaces that should be disabled.