### PR TITLE
Add Multi-Arch Support to Contiv/VPP Docker Images

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -42,5 +42,20 @@ To tag and push the devel vswitch image, execute:
 ./push-all.sh --dev-upload true
 ```
 
+To enable the multi-arch feature of the images tagged 'latest' in contiv/vpp official repo
+for x86_64(amd64) and arm64, install the manifest-tool first by:
+```
+./install-manifest-tool.sh
+```
+and push multi-arch manifest after docker login with approriate user:
+```
+./push-manifest.sh
+```
+To enable the multi-arch of dev-vswitch image, execute:
+```
+./push-manifest.sh --dev-upload true
+```
+
+
 To use the development image for testing with specific version of VPP, see
 [DEVIMAGE.md](DEVIMAGE.md).

--- a/docker/install-manifest-tool.sh
+++ b/docker/install-manifest-tool.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# fail in case of error
+set -e
+
+#manifest-tool - inspect and push manifest list images to a registry
+
+MANIFEST_TOOL_VERSION=v0.7.0
+BUILDARCH=`uname -m`
+
+if [ ${BUILDARCH} = "aarch64" ] ; then
+  BUILDARCH="arm64"
+fi
+
+if [ ${BUILDARCH} = "x86_64" ] ; then
+  BUILDARCH="amd64"
+fi
+
+curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-${BUILDARCH} > manifest-tool
+chmod +x manifest-tool
+mv manifest-tool /usr/bin/
+

--- a/docker/push-manifest.sh
+++ b/docker/push-manifest.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# fail in case of error
+set -e
+
+# default values for "skip dev-upload"
+DEV_UPLOAD="false"
+
+# list of images we are tagging & pushing
+IMAGES=()
+IMAGES_VPP=("cni" "ksr" "stn" "crd" "vswitch")
+IMAGES_BIN=("vpp-binaries")
+
+# override defaults from arguments
+while [ "$1" != "" ]; do
+    case $1 in
+        -d | --dev-upload )
+            DEV_UPLOAD="true"
+            echo "Using dev upload: ${DEV_UPLOAD}"
+            ;;
+        * )
+            echo "Invalid parameter: "$1
+            exit 1
+    esac
+    shift
+done
+
+
+ARCHES="amd64 arm64"
+platforms="linux/amd64,linux/arm64"
+
+# Please install manifest-tool first by the script 'install-manifest-tool.sh'
+# Do 'docker login' first to get the correct $(HOME)/.docker/config.json
+
+# Just multi-arch the latest image now
+
+for IMAGE in "${IMAGES[@]}"
+do
+    /usr/bin/manifest-tool push from-args --platforms ${platforms} --template contivvpp/${IMAGE}-ARCH:latest --target contivvpp/${IMAGE}:latest
+done
+
+for IMAGE in "${IMAGES_VPP[@]}"
+do
+    /usr/bin/manifest-tool push from-args --platforms ${platforms} --template contivvpp/${IMAGE}-ARCH:latest --target contivvpp/${IMAGE}:latest
+done
+
+for IMAGE in "${IMAGES_BIN[@]}"
+do
+    /usr/bin/manifest-tool push from-args --platforms ${platforms} --template contivvpp/${IMAGE}-ARCH:latest --target contivvpp/${IMAGE}:latest
+done
+
+if [ "${DEV_UPLOAD}" == "true" ]
+then
+    /usr/bin/manifest-tool push from-args --platforms ${platforms} --template contivvpp/dev-vswitch-ARCH:latest --target contivvpp/dev-vswitch:latest
+fi
+


### PR DESCRIPTION
Add multi-arch support to Contiv/VPP docker images
tagged 'latest' with the 'manifest-tool', please refer:
https://docs.docker.com/registry/spec/manifest-v2-2/
for fat-manifest information.

Add the user guide for these tools/scripts in
docker/README.md.

Signed-off-by: trevortao <trevor.tao@arm.com>