### PR TITLE
IPAM enhancements

### DIFF
--- a/plugins/contiv/config.go
+++ b/plugins/contiv/config.go
@@ -124,6 +124,9 @@ func (cfg *Config) ApplyIPAMConfig() error {
 		VPPHostSubnetCIDR:       vppHostSubnetCIDR.String(),
 		VPPHostNetworkPrefixLen: vppHostNetworkPrefixLen,
 		VxlanCIDR:               vxlanCIDR.String(),
+		NodeInterconnectCIDR:    cfg.IPAMConfig.NodeInterconnectCIDR,
+		NodeInterconnectDHCP:    cfg.IPAMConfig.NodeInterconnectDHCP,
+		ContivCIDR:              cfg.IPAMConfig.ContivCIDR,
 	}
 
 	if cfg.IPAMConfig.NodeInterconnectCIDR == "" && cfg.IPAMConfig.NodeInterconnectDHCP == false {

--- a/plugins/contiv/config_test.go
+++ b/plugins/contiv/config_test.go
@@ -60,6 +60,22 @@ func testApplyIPAM(t *testing.T) {
 		},
 	}
 
+	// Try with overridden NodeInterconnectCIDR
+	configData5 := &Config{
+		IPAMConfig: ipam.Config{
+			ContivCIDR:           "10.128.0.0/14",
+			NodeInterconnectCIDR: "192.168.16.0/24",
+		},
+	}
+
+	// Try with NodeInterconnectDHCP enabled
+	configData6 := &Config{
+		IPAMConfig: ipam.Config{
+			ContivCIDR:           "10.128.0.0/14",
+			NodeInterconnectDHCP: true,
+		},
+	}
+
 	err := configData1.ApplyIPAMConfig()
 	gomega.Expect(err).To(gomega.BeNil())
 
@@ -89,4 +105,23 @@ func testApplyIPAM(t *testing.T) {
 	gomega.Expect(configData4.IPAMConfig.NodeInterconnectCIDR).To(gomega.Equal("192.168.16.0/24"))
 	gomega.Expect(configData4.IPAMConfig.VxlanCIDR).To(gomega.Equal("192.168.30.0/24"))
 	gomega.Expect(configData4.IPAMConfig.PodIfIPCIDR).To(gomega.Equal("10.2.1.0/24"))
+
+	err = configData5.ApplyIPAMConfig()
+	gomega.Expect(err).To(gomega.BeNil())
+
+	gomega.Expect(configData5.IPAMConfig.PodSubnetCIDR).To(gomega.Equal("10.128.0.0/16"))
+	gomega.Expect(configData5.IPAMConfig.VPPHostSubnetCIDR).To(gomega.Equal("10.129.0.0/16"))
+	gomega.Expect(configData5.IPAMConfig.NodeInterconnectCIDR).To(gomega.Equal("192.168.16.0/24"))
+	gomega.Expect(configData5.IPAMConfig.VxlanCIDR).To(gomega.Equal("10.130.2.0/23"))
+	gomega.Expect(configData5.IPAMConfig.PodIfIPCIDR).To(gomega.Equal("10.130.4.0/25"))
+
+	err = configData6.ApplyIPAMConfig()
+	gomega.Expect(err).To(gomega.BeNil())
+
+	gomega.Expect(configData6.IPAMConfig.PodSubnetCIDR).To(gomega.Equal("10.128.0.0/16"))
+	gomega.Expect(configData6.IPAMConfig.VPPHostSubnetCIDR).To(gomega.Equal("10.129.0.0/16"))
+	gomega.Expect(configData6.IPAMConfig.NodeInterconnectCIDR).To(gomega.Equal(""))
+	gomega.Expect(configData6.IPAMConfig.NodeInterconnectDHCP).To(gomega.BeTrue())
+	gomega.Expect(configData6.IPAMConfig.VxlanCIDR).To(gomega.Equal("10.130.2.0/23"))
+	gomega.Expect(configData6.IPAMConfig.PodIfIPCIDR).To(gomega.Equal("10.130.4.0/25"))
 }

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -469,7 +469,7 @@ applyVPPnetwork() {
 
   if [ "#{crd_disabled}" = "false" ]; then
     # Deploy contiv-vpp networking with CRD
-    helm template --name vagrant $stn_config --set contiv.crdNodeConfigurationDisabled=false --set contiv.ipamConfig.contivCIDR=10.128.0.0/14 "#{contiv_dir}"/k8s/contiv-vpp > "#{contiv_dir}"/k8s/contiv-vpp/manifest.yaml
+    helm template --name vagrant $stn_config --set contiv.crdNodeConfigurationDisabled=false --set contiv.ipamConfig.contivCIDR=10.128.0.0/14 --set contiv.ipamConfig.NodeInterConnectCIDR=null "#{contiv_dir}"/k8s/contiv-vpp > "#{contiv_dir}"/k8s/contiv-vpp/manifest.yaml
     kubectl apply -f #{contiv_dir}/k8s/contiv-vpp/manifest.yaml
 
     # Wait until crd agent is ready


### PR DESCRIPTION
Added support for the following scenarios:
* ContivCIDR + NodeInterconnectDHCP
* ContivCIDR + NodeInreconnectCIDR(override)

After this change NodeInterconnectCIDR in contiv.yaml must be empty
in order to use the subnet computed from ContivCIDR.