### PR TITLE
STN: Fix Proxy Arp for /31 Subnets

### DIFF
--- a/cmd/contiv-init/vppcfg.go
+++ b/cmd/contiv-init/vppcfg.go
@@ -285,7 +285,14 @@ func configureVpp(contivCfg *contiv.Config, stnData *stn.STNReply, useDHCP bool)
 
 	// TODO: do this using linuxcalls once supported in vpp-agent
 	firstIP, lastIP := cidr.AddressRange(cfg.mainIPNet)
-	err = enableArpProxy(ch, cidr.Inc(firstIP), cidr.Dec(lastIP), tapIdx)
+
+	// If larger than a /31, remove network and broadcast addresses
+	// from address range.
+	if cidr.AddressCount(cfg.mainIPNet) > 2 {
+		firstIP = cidr.Inc(firstIP)
+		lastIP = cidr.Dec(lastIP)
+	}
+	err = enableArpProxy(ch, firstIP, lastIP, tapIdx)
 	if err != nil {
 		logger.Errorf("Error by configuring proxy ARP: %v", err)
 		return nil, err


### PR DESCRIPTION
When using STN mode on /31 subnets, like those on Packet.net, proxy arp was incorrectly set, for example 10.0.0.95 - 10.0.0.94. 

This patch only removes the host/broadcast addresses for subnets larger than a /31, so that the arp range is correctly set to 10.0.0.94 - 10.0.0.95.