### PR TITLE
[TESTING] Fix nodePort + mgmtIP issues

### DIFF
--- a/plugins/contiv/node_events.go
+++ b/plugins/contiv/node_events.go
@@ -162,6 +162,9 @@ func (s *remoteCNIserver) processChangeEvent(dataChngEv datasync.ChangeEvent) er
 			// Note: the case where IP address is changed during runtime is not handled
 			if nodeInfo.IpAddress != "" && nodeInfo.ManagementIpAddress != "" {
 				s.Logger.Info("New node discovered: ", nodeInfo.Id)
+				//TODO: if there is a change in mgmt IPs and routes are already configured
+				// delte outdated routes
+
 				// add routes to the node
 				err = s.addRoutesToNode(nodeInfo)
 			} else {

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -564,14 +564,15 @@ func (plugin *Plugin) handleKsrNodeResync(it datasync.KeyValIterator) error {
 		}
 
 		if value.Name == plugin.ServiceLabel.GetAgentLabel() {
-			var internalIPs []string
+			var k8sIPs []string
 			for i := range value.Addresses {
-				if value.Addresses[i].Type == protoNode.NodeAddress_NodeInternalIP {
-					internalIPs = append(internalIPs, value.Addresses[i].Address)
+				if value.Addresses[i].Type == protoNode.NodeAddress_NodeInternalIP ||
+					value.Addresses[i].Type == protoNode.NodeAddress_NodeExternalIP {
+					k8sIPs = appendIfMissing(k8sIPs, value.Addresses[i].Address)
 				}
 			}
-			if len(internalIPs) > 0 {
-				ips := strings.Join(internalIPs, MgmtIPSeparator)
+			if len(k8sIPs) > 0 {
+				ips := strings.Join(k8sIPs, MgmtIPSeparator)
 				plugin.Log.Info("Internal IP of the node is ", ips)
 				return plugin.nodeIDAllocator.updateManagementIP(ips)
 			}

--- a/plugins/contiv/plugin_impl_contiv.go
+++ b/plugins/contiv/plugin_impl_contiv.go
@@ -528,15 +528,16 @@ func (plugin *Plugin) handleKsrNodeChange(change datasync.ChangeEvent) error {
 		plugin.Log.Error(err)
 		return err
 	}
-	var internalIPs []string
+	var k8sIPs []string
 	for i := range value.Addresses {
-		if value.Addresses[i].Type == protoNode.NodeAddress_NodeInternalIP {
-			internalIPs = append(internalIPs, value.Addresses[i].Address)
+		if value.Addresses[i].Type == protoNode.NodeAddress_NodeInternalIP ||
+			value.Addresses[i].Type == protoNode.NodeAddress_NodeExternalIP {
+			k8sIPs = appendIfMissing(k8sIPs, value.Addresses[i].Address)
 		}
 	}
-	if len(internalIPs) > 0 {
-		ips := strings.Join(internalIPs, MgmtIPSeparator)
-		plugin.Log.Info("Internal IP of the node is ", ips)
+	if len(k8sIPs) > 0 {
+		ips := strings.Join(k8sIPs, MgmtIPSeparator)
+		plugin.Log.Info("Management IP of the node is ", ips)
 		return plugin.nodeIDAllocator.updateManagementIP(ips)
 	}
 

--- a/plugins/contiv/remote_cni_server.go
+++ b/plugins/contiv/remote_cni_server.go
@@ -728,6 +728,8 @@ func (s *remoteCNIserver) configureOtherVPPInterfaces(config *vswitchConfig, nod
 func (s *remoteCNIserver) configureVswitchHostConnectivity(config *vswitchConfig) error {
 	var err error
 	txn := s.vppTxnFactory().Put()
+	// txnNotPersisted applies the config of items that are not persisted
+	txnNotPersisted := s.vppTxnFactory().Put()
 
 	if s.stnIP == "" {
 		// execute only if STN has not already configured this
@@ -771,8 +773,10 @@ func (s *remoteCNIserver) configureVswitchHostConnectivity(config *vswitchConfig
 	}
 	for _, r := range config.routesToHost {
 		s.Logger.Debug("Adding route to host IP: ", r)
-		txn.StaticRoute(r)
+		txnNotPersisted.StaticRoute(r)
 	}
+	// do not persist routesToHost
+	config.routesToHost = nil
 
 	// configure the route from the host to PODs
 	if s.stnGw == "" {
@@ -816,7 +820,11 @@ func (s *remoteCNIserver) configureVswitchHostConnectivity(config *vswitchConfig
 
 	}
 
-	return nil
+	err = txnNotPersisted.Send().ReceiveReply()
+	if err != nil {
+		s.Logger.Error(err)
+	}
+	return err
 }
 
 // configureVswitchVxlanBridgeDomain configures bridge domain for the VXLAN tunnels.

--- a/plugins/contiv/remote_cni_server_test.go
+++ b/plugins/contiv/remote_cni_server_test.go
@@ -256,7 +256,7 @@ func TestConfigureVswitchDHCP(t *testing.T) {
 	err := server.resync()
 	gomega.Expect(err).To(gomega.BeNil())
 
-	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(4))
+	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(5))
 	// TODO add asserts for txns(one linux plugin txn and one default plugins txn) / currently applied config
 
 	// node IP is empty since DHCP reply have not been received
@@ -265,7 +265,7 @@ func TestConfigureVswitchDHCP(t *testing.T) {
 	gomega.Expect(server.GetHostInterconnectIfName()).ToNot(gomega.BeEmpty())
 
 	server.close()
-	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(5))
+	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(6))
 }
 
 func TestAddDelTap(t *testing.T) {
@@ -309,7 +309,7 @@ func TestConfigureVswitchVeth(t *testing.T) {
 	err := server.resync()
 	gomega.Expect(err).To(gomega.BeNil())
 
-	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(5))
+	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(6))
 	// TODO add asserts for txns(one linux plugin txn and one default plugins txn) / currently applied config
 
 	// check physical interface name
@@ -331,7 +331,7 @@ func TestConfigureVswitchVeth(t *testing.T) {
 	gomega.Expect(server.GetOtherPhysicalIfNames()).To(gomega.Equal([]string{"GigabitEthernet0/0/0/10"}))
 
 	server.close()
-	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(6))
+	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(7))
 }
 
 func TestConfigureVswitchTap(t *testing.T) {
@@ -344,7 +344,7 @@ func TestConfigureVswitchTap(t *testing.T) {
 	err := server.resync()
 	gomega.Expect(err).To(gomega.BeNil())
 
-	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(4))
+	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(5))
 	// TODO add asserts for txns(one linux plugin txn and one default plugins txn) / currently applied config
 
 	// node IP must not be empty
@@ -357,7 +357,7 @@ func TestConfigureVswitchTap(t *testing.T) {
 	gomega.Expect(server.GetVxlanBVIIfName()).ToNot(gomega.BeEmpty())
 
 	server.close()
-	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(5))
+	gomega.Expect(len(txns.CommittedTxns)).To(gomega.BeEquivalentTo(6))
 }
 
 func TestNodeAddDelL2(t *testing.T) {

--- a/plugins/service/processor/processor_impl.go
+++ b/plugins/service/processor/processor_impl.go
@@ -481,15 +481,19 @@ func (sp *ServiceProcessor) getNodeIPs() *renderer.IPAddresses {
 		}
 		addedNodeIPs[ipAddr] = struct{}{}
 		// Node management IP (K8s, host)
-		ipAddr = sp.trimIPAddrPrefix(node.ManagementIpAddress)
-		sp.Log.WithField("IPAddr", ipAddr).Debug("Node mgmt IP")
-		if _, duplicate := addedNodeIPs[ipAddr]; !duplicate {
-			nodeMgmtIP := net.ParseIP(ipAddr)
-			if nodeMgmtIP != nil {
-				nodeIPs.Add(nodeMgmtIP)
+		mgmtIPs := strings.Split(node.ManagementIpAddress, contiv.MgmtIPSeparator)
+		for _, mIP := range mgmtIPs {
+			ipAddr = sp.trimIPAddrPrefix(mIP)
+			sp.Log.WithField("IPAddr", ipAddr).Debug("Node mgmt IP")
+			if _, duplicate := addedNodeIPs[ipAddr]; !duplicate {
+				nodeMgmtIP := net.ParseIP(ipAddr)
+				if nodeMgmtIP != nil {
+					nodeIPs.Add(nodeMgmtIP)
+				}
 			}
+			addedNodeIPs[ipAddr] = struct{}{}
 		}
-		addedNodeIPs[ipAddr] = struct{}{}
+
 	}
 
 	return nodeIPs


### PR DESCRIPTION
The PR fixes the following issues:
- if mgmt IP was changes, the changed was not reflect since the config was persisted and not update -> config is not persisted anymore and its update on each agent start
- only k8s Internal IPs were routed from VPP -> route union of internal and external
- service process didn't handle multiple management IPs might be causing nodePort issues