### PR TITLE
common memif mount point for vnfs/vswitch, 

### DIFF
--- a/k8s/examples/sfc-controller/set-node-labels
+++ b/k8s/examples/sfc-controller/set-node-labels
@@ -2,5 +2,5 @@
 
 echo "Schedule Pods on master"
 kubectl taint nodes --all node-role.kubernetes.io/master-
-kubectl label nodes k8s-master role=affinity
-kubectl label nodes k8s-worker1 role=no-affinity
+kubectl label nodes k8s-master role=affinity --overwrite=true
+kubectl label nodes k8s-worker1 role=no-affinity --overwrite=true

--- a/k8s/examples/sfc-controller/sfc-controller.yaml
+++ b/k8s/examples/sfc-controller/sfc-controller.yaml
@@ -89,6 +89,9 @@ data:
     sfc_controller_config_version: 2
     description: 2 vnf chains spanning 2 hosts, memif's and vxlan tunnels
 
+    system_parameters:
+      memif_directory: "/var/run/contiv"
+
     ipam_pools:  # allocate internode vxlan mesh enpoints from a pool
       - metadata:
           name: vxlan_tunnel_pool
@@ -106,6 +109,7 @@ data:
           node_type: host
           interfaces:
             - name: GigabitEthernet0/8/0
+              bypass_renderer: true
               if_type: ethernet
               ip_addresses:
                 - "192.168.16.1/24"
@@ -115,6 +119,7 @@ data:
           node_type: host
           interfaces:
             - name: GigabitEthernet0/8/0
+              bypass_renderer: true
               if_type: ethernet
               ip_addresses:
                 - "192.168.16.2/24"

--- a/k8s/examples/sfc-controller/vnf-pods/vnf1.yaml
+++ b/k8s/examples/sfc-controller/vnf-pods/vnf1.yaml
@@ -23,7 +23,7 @@ spec:
         - name: agent-config
           mountPath: /opt/vpp-agent/dev
         - name: memif-sockets
-          mountPath: /tmp
+          mountPath: /var/run/contiv
   volumes:
   - name: vpp-config
     configMap:
@@ -33,7 +33,7 @@ spec:
       name: vnf-agent-cfg
   - name: memif-sockets
     hostPath:
-      path: /tmp
+      path: /var/run/contiv
   nodeSelector:
     role: affinity
 

--- a/k8s/examples/sfc-controller/vnf-pods/vnf2.yaml
+++ b/k8s/examples/sfc-controller/vnf-pods/vnf2.yaml
@@ -23,7 +23,7 @@ spec:
         - name: agent-config
           mountPath: /opt/vpp-agent/dev
         - name: memif-sockets
-          mountPath: /tmp
+          mountPath: /var/run/contiv
   volumes:
   - name: vpp-config
     configMap:
@@ -33,7 +33,7 @@ spec:
       name: vnf-agent-cfg
   - name: memif-sockets
     hostPath:
-      path: /tmp
+      path: /var/run/contiv
   nodeSelector:
     role: no-affinity
 

--- a/k8s/examples/sfc-controller/vnf-pods/vnf3.yaml
+++ b/k8s/examples/sfc-controller/vnf-pods/vnf3.yaml
@@ -23,7 +23,7 @@ spec:
         - name: agent-config
           mountPath: /opt/vpp-agent/dev
         - name: memif-sockets
-          mountPath: /tmp
+          mountPath: /var/run/contiv
   volumes:
   - name: vpp-config
     configMap:
@@ -33,7 +33,7 @@ spec:
       name: vnf-agent-cfg
   - name: memif-sockets
     hostPath:
-      path: /tmp
+      path: /var/run/contiv
   nodeSelector:
     role: affinity
 

--- a/k8s/examples/sfc-controller/vnf-pods/vnf4.yaml
+++ b/k8s/examples/sfc-controller/vnf-pods/vnf4.yaml
@@ -23,7 +23,7 @@ spec:
         - name: agent-config
           mountPath: /opt/vpp-agent/dev
         - name: memif-sockets
-          mountPath: /tmp
+          mountPath: /var/run/contiv
   volumes:
   - name: vpp-config
     configMap:
@@ -33,7 +33,7 @@ spec:
       name: vnf-agent-cfg
   - name: memif-sockets
     hostPath:
-      path: /tmp
+      path: /var/run/contiv
   nodeSelector:
     role: no-affinity
 


### PR DESCRIPTION
The vswitch and vnfs need a common mount point such as /tmp or /var/run/contiv for the memif sockets, otherwise traffic will not pass.

Also avoid sfc/contiv colliding on gig-e config ... the sfc.conf requires a bypass_renderer: true to be set so that the controller does not write to the gige interfaces.

Also, care must be taken to ensure the config in the sfc.conf for the gige interfaces matches that of the system.  The sfc-controller will soon discover the contiv host gige config so these will not be required in the sfc.conf and thus wont have to be configured in two different places.

