### PR TITLE
Fix CRD validation errors

### DIFF
--- a/plugins/crd/cache/data_resync.go
+++ b/plugins/crd/cache/data_resync.go
@@ -104,8 +104,7 @@ func (ctc *ContivTelemetryCache) parseAndCacheNodeInfoData(key string, evData da
 		return fmt.Errorf("invalid key '%s' or node id '%d'", key, nodeInfoValue.Id)
 	}
 
-	if nodeInfoValue.Id == 0 || nodeInfoValue.Name == "" ||
-		nodeInfoValue.IpAddress == "" || nodeInfoValue.ManagementIpAddress == "" {
+	if nodeInfoValue.Id == 0 || nodeInfoValue.Name == "" || nodeInfoValue.IpAddress == "" {
 		return fmt.Errorf("invalid nodeInfo data: '%+v'", nodeInfoValue)
 	}
 

--- a/plugins/crd/validator/l3/l3_validator.go
+++ b/plugins/crd/validator/l3/l3_validator.go
@@ -240,7 +240,7 @@ func (v *Validator) validateVrf0GigERoutes(node *telemetrymodel.Node, vrfMap Vrf
 
 	// Validate the route to the GigE subnet
 	numErrs += v.validateRoute(node.IPAddr, 0, vrfMap, routeMap, node.Name, ifc.If.Name,
-		uint32(ifc.IfMeta.SwIfIndex), "0.0.0.0", 0, 0)
+		ifc.IfMeta.SwIfIndex, "0.0.0.0", 0, 0)
 
 	// Validate gigE interface drop routes
 	for _, ipAddr := range ifc.If.IPAddresses {
@@ -261,7 +261,7 @@ func (v *Validator) validateVrf0GigERoutes(node *telemetrymodel.Node, vrfMap Vrf
 
 		dstIP := strings.Split(remoteNode.IPAddr, "/")
 		numErrs += v.validateRoute(dstIP[0]+"/32", 0, vrfMap, routeMap, node.Name, ifc.If.Name,
-			uint32(ifc.IfMeta.SwIfIndex), dstIP[0], 0, 0)
+			ifc.IfMeta.SwIfIndex, dstIP[0], 0, 0)
 	}
 
 	return numErrs
@@ -426,7 +426,7 @@ func (v *Validator) validateDefaultRoutes(node *telemetrymodel.Node, vrfMap VrfM
 	// the default Gateway, validate the route to it
 	// numErrs += v.validateGigEDefaultRteNextHop("0.0.0.0/0", 0, vrfMap, routeMap, node, ifc)
 	numErrs += v.validateRoute("0.0.0.0/0", 0, vrfMap, routeMap, node.Name,
-		ifc.If.Name, maxIfIdx, "", 0, 2)
+		ifc.If.Name, ifc.IfMeta.SwIfIndex, "", 0, 0)
 
 	// Validate VRF0 boiler plate routes
 	numErrs += v.validateRoute("0.0.0.0/32", 0, vrfMap, routeMap, node.Name,
@@ -802,10 +802,15 @@ func (v *Validator) checkUnvalidatedRoutes(routeMap RouteMap, nodeName string) i
 		for rteID, rteStatus := range vrf {
 			switch rteStatus {
 			case routeNotValidated:
+				notValidated++
+				if strings.HasSuffix(rteID, "/32") {
+					v.Log.Warnf("skipping validation of route %s in VRF%d; route ends with /32", rteID, vrfID)
+					continue
+				}
+
 				numErrs++
 				v.Report.AppendToNodeReport(nodeName, fmt.Sprintf("unexpected route %s in VRF%d; "+
 					"route not validated", rteID, vrfID))
-				notValidated++
 			case routeInvalid:
 				invalid++
 			case routeValid:

--- a/plugins/crd/validator/l3/l3_validator_test.go
+++ b/plugins/crd/validator/l3/l3_validator_test.go
@@ -132,9 +132,7 @@ func testErrorFreeEndToEnd(t *testing.T) {
 	vtv.report.Clear()
 	vtv.l3Validator.Validate()
 
-	// NOTE: Expect one error per node in L3 validation until we can validate
-	// static routes configured through Linux
-	checkDataReport(1, 3, 3)
+	checkDataReport(1, 4, 4)
 }
 
 func testMissingIPAM(t *testing.T) {
@@ -149,7 +147,7 @@ func testMissingIPAM(t *testing.T) {
 	vtv.report.Clear()
 	vtv.l3Validator.Validate()
 
-	checkDataReport(1, 1, 8)
+	checkDataReport(1, 1, 7)
 
 	vrfMap, err := vtv.l3Validator.createVrfMap(vtv.vppCache.NodeMap[vtv.nodeKey])
 	gomega.Expect(err).To(gomega.BeNil())
@@ -173,7 +171,7 @@ func testMissingInterfaces(t *testing.T) {
 
 	// NOTE: Expect one error per node in L3 validation until we can validate
 	// static routes configured through Linux
-	checkDataReport(1, 1, 8)
+	checkDataReport(1, 1, 7)
 }
 
 func testMissingStaticRoutes(t *testing.T) {
@@ -190,7 +188,7 @@ func testMissingStaticRoutes(t *testing.T) {
 
 	// NOTE: Expect one error per node in L3 validation until we can validate
 	// static routes configured through Linux
-	checkDataReport(1, 1, 3)
+	checkDataReport(1, 1, 4)
 }
 
 func testValidateRoutesToLocalPods(t *testing.T) {


### PR DESCRIPTION
- Do not explicitely cast to uint32 from uint32
- Correctly check for route 0.0.0.0/0 to be valid and not drop route
- Skip validation for /32 suffix routes
- Create node from resync even without management IP (what will be
appended later with data sync event)

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Example validation output:

```
vagrant@k8s-master:~$ kubectl get telemetryreports.telemetry.contiv.vpp -o yaml
apiVersion: v1
items:
- apiVersion: telemetry.contiv.vpp/v1
  kind: TelemetryReport
  metadata:
    creationTimestamp: 2018-11-14T12:55:07Z
    generation: 1
    name: default-telemetry
    namespace: default
    resourceVersion: "4639"
    selfLink: /apis/telemetry.contiv.vpp/v1/namespaces/default/telemetryreports/default-telemetry
    uid: 830e3702-e80c-11e8-ab2d-08002733828a
  spec:
    report_polling_period_seconds: 10
  status:
    nodes:
    - ID: 1
      IPAddr: 192.168.16.1/24
      ManIPAddr: 10.20.0.2
      Name: k8s-master
    - ID: 2
      IPAddr: 192.168.16.2/24
      ManIPAddr: 10.20.0.10
      Name: k8s-worker1
    reports:
      global:
      - 'IP-ARP: validation OK'
      - 'VXLAN-BD: validation OK'
      - 'L2-FIB: validation OK'
      - 'K8S-NODE: validation OK'
      - 'K8S-POD: validation OK'
      - 'L3-FIB: validation OK'
      k8s-master:
      - 'L3-FIB: Rte report VRF0: total 23, notValidated 2, invalid: 0, valid:21'
      - 'L3-FIB: Rte report VRF1: total 19, notValidated 0, invalid: 0, valid:19'
      k8s-worker1:
      - 'L3-FIB: Rte report VRF0: total 23, notValidated 2, invalid: 0, valid:21'
      - 'L3-FIB: Rte report VRF1: total 15, notValidated 0, invalid: 0, valid:15'
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
``` 