### PR TITLE
Dump k8s CRD report when running bug-report.sh

### DIFF
--- a/scripts/contiv-vpp-bug-report.sh
+++ b/scripts/contiv-vpp-bug-report.sh
@@ -246,6 +246,7 @@ K8S_COMMANDS["k8s-services.txt"]="get services -o wide --all-namespaces"
 K8S_COMMANDS["k8s-networkpolicy.txt"]="get networkpolicy -o wide --all-namespaces"
 K8S_COMMANDS["k8s-statefulsets.txt"]="get statefulsets -o wide --all-namespaces"
 K8S_COMMANDS["k8s-daemonsets.txt"]="get daemonsets -o wide --all-namespaces"
+K8S_COMMANDS["k8s-crd-report.yaml"]="get telemetryreports.telemetry.contiv.vpp -o yaml"
 
 while getopts "af:hi:m:r:su:w" opt
 do


### PR DESCRIPTION
Dump `get telemetryreports.telemetry.contiv.vpp -o yaml` to
`k8s-crd-report.yaml` from contiv-vpp-bug-report.sh.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Example dump:
```
$ ls -lh report/contiv-vpp-bug-report-2018-11-15-10-18 | \grep --color=auto .yaml
-rw-r--r-- 1 vagrant vagrant 2.6K Nov 15 10:18 k8s-crd-report.yaml
-rw-r--r-- 1 vagrant vagrant 1.5K Nov 15 10:18 k8s-vpp-config-maps.yaml
```
