### PR TITLE
Improve ubuntu-based/ Docker build times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ cmd/contiv-crd/contiv-crd
 cmd/contiv-netctl/contiv-netctl
 cmd/tools/ldpreload-label-injector/ldpreload-label-injector
 vagrant/images.tar
-vagrant/dev-contiv-vswitch.tar
 .vagrant
 .vagrant-state

--- a/docker/DEVIMAGE.md
+++ b/docker/DEVIMAGE.md
@@ -1,16 +1,16 @@
 ### Using the Development image for testing with a specific VPP version (patch)
 
 Start with building the images locally, [as described here](README.md). Once the build process finishes,
-you should see a `dev-contiv-vswitch` image with some specific tag, e.g.:
+you should see a `contivvpp/dev-vswitch` image with some specific tag, e.g.:
 
 ```
-$ docker images | grep dev-contiv-vswitch
-dev-contiv-vswitch                                       0.0.1-424-gd1a17e5   e6c9f12da183        About an hour ago   20.2GB
+$ docker images | grep contivvpp/dev-vswitch
+contivvpp/dev-vswitch                                       0.0.1-424-gd1a17e5   e6c9f12da183        About an hour ago   20.2GB
 ```
 
 #### 1. Start the development container
 ```
-docker run -it dev-contiv-vswitch:0.0.1-424-gd1a17e5 bash
+docker run -it contivvpp/dev-vswitch:0.0.1-424-gd1a17e5 bash
 
 # if you are behind a proxy
 export HTTPS_PROXY=http://proxy-wsa.esl.cisco.com:80/
@@ -79,9 +79,9 @@ make install
 #### 7. Commit the changes in the running container
 ```
 docker ps | grep vswitch
-ba4e8b8b69d6        dev-contiv-vswitch:0.0.1-424-gd1a17e5   "bash"                   2 minutes ago       Up 2 minutes                            pensive_jepsen
+ba4e8b8b69d6        contivvpp/dev-vswitch:0.0.1-424-gd1a17e5   "bash"                   2 minutes ago       Up 2 minutes                            pensive_jepsen
 
-docker commit --change='CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]' ba4e8b8b69d6 dev-contiv-vswitch:0.0.1-424-gd1a17e5
+docker commit --change='CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]' ba4e8b8b69d6 contivvpp/dev-vswitch:0.0.1-424-gd1a17e5
 ```
 
 (the CMD statement would be overwritten, so we need to specify it. If you don't want to start 
@@ -107,7 +107,7 @@ index df94c82..47a40b4 100644
        # This init container extracts/copies VPP LD_PRELOAD libs and default VPP config to the host.
        - name: vpp-init
 -        image: contivvpp/vswitch
-+        image: dev-contiv-vswitch:0.0.1-424-gd1a17e5
++        image: contivvpp/dev-vswitch:0.0.1-424-gd1a17e5
          imagePullPolicy: IfNotPresent
          command:
          - /bin/sh
@@ -116,7 +116,7 @@ index df94c82..47a40b4 100644
          # It contains the vSwitch VPP and its management agent.
          - name: contiv-vswitch
 -          image: contivvpp/vswitch
-+          image: dev-contiv-vswitch:0.0.1-424-gd1a17e5
++          image: contivvpp/dev-vswitch:0.0.1-424-gd1a17e5
            imagePullPolicy: IfNotPresent
            securityContext:
              privileged: true

--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -24,7 +24,7 @@ source ../vpp.env
 # default values for build args
 export DOCKER_BUILD_ARGS=""
 export SKIP_DEBUG_BUILD=0
-
+export SKIP_DOCKER_CACHE=0
 
 # override defaults from arguments
 while [ "$1" != "" ]; do
@@ -43,12 +43,20 @@ while [ "$1" != "" ]; do
             export SKIP_DEBUG_BUILD=1
             echo "Using SKIP_DEBUG_BUILD=1"
             ;;
+        -n | --no-cache )
+            export SKIP_DOCKER_CACHE=1
+            echo "Using SKIP_DOCKER_CACHE=1"
+            ;;
         * )
             echo "Invalid parameter: "$1
             exit 1
     esac
     shift
 done
+
+if [ ${SKIP_DOCKER_CACHE} = 1 ]; then
+  export DOCKER_BUILD_ARGS="--no-cache=true --force-rm=true $DOCKER_BUILD_ARGS"
+fi
 
 # builds all Ubuntu -based images
 cd ubuntu-based

--- a/docker/build-new.sh
+++ b/docker/build-new.sh
@@ -59,10 +59,10 @@ KSRBUILDIMG="prod-contiv-ksr"-${BUILDARCH}:${TAG}
 STNBUILDIMG="prod-contiv-stn"-${BUILDARCH}:${TAG}
 
 
-docker build -t ${CNIBUILDIMG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-cni/${DOCKERFILE} .
-docker build -t ${CRDBUILDIMG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-crd/${DOCKERFILE} .
-docker build -t ${KSRBUILDIMG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-ksr/${DOCKERFILE} .
-docker build -t ${STNBUILDIMG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm -f docker/vpp-stn/${DOCKERFILE} .
+docker build -t ${CNIBUILDIMG} ${DOCKER_BUILD_ARGS} -f docker/vpp-cni/${DOCKERFILE} .
+docker build -t ${CRDBUILDIMG} ${DOCKER_BUILD_ARGS} -f docker/vpp-crd/${DOCKERFILE} .
+docker build -t ${KSRBUILDIMG} ${DOCKER_BUILD_ARGS} -f docker/vpp-ksr/${DOCKERFILE} .
+docker build -t ${STNBUILDIMG} ${DOCKER_BUILD_ARGS} -f docker/vpp-stn/${DOCKERFILE} .
 
 
 if [ ${BUILDARCH} = "amd64" ] ; then

--- a/docker/build-new.sh
+++ b/docker/build-new.sh
@@ -47,16 +47,16 @@ DOCKERFILE=Dockerfile${DOCKERFILE_tag}
 #ALL_ARCH = amd64 arm64
 
 
-CNIDEFAULTIMG="prod-contiv-cni":${TAG}
-CRDDEFAULTIMG="prod-contiv-crd":${TAG}
-KSRDEFAULTIMG="prod-contiv-ksr":${TAG}
-STNDEFAULTIMG="prod-contiv-stn":${TAG}
+CNIDEFAULTIMG="contivvpp/cni":${TAG}
+CRDDEFAULTIMG="contivvpp/crd":${TAG}
+KSRDEFAULTIMG="contivvpp/ksr":${TAG}
+STNDEFAULTIMG="contivvpp/stn":${TAG}
 
 
-CNIBUILDIMG="prod-contiv-cni"-${BUILDARCH}:${TAG}
-CRDBUILDIMG="prod-contiv-crd"-${BUILDARCH}:${TAG}
-KSRBUILDIMG="prod-contiv-ksr"-${BUILDARCH}:${TAG}
-STNBUILDIMG="prod-contiv-stn"-${BUILDARCH}:${TAG}
+CNIBUILDIMG="contivvpp/cni"-${BUILDARCH}:${TAG}
+CRDBUILDIMG="contivvpp/crd"-${BUILDARCH}:${TAG}
+KSRBUILDIMG="contivvpp/ksr"-${BUILDARCH}:${TAG}
+STNBUILDIMG="contivvpp/stn"-${BUILDARCH}:${TAG}
 
 
 docker build -t ${CNIBUILDIMG} ${DOCKER_BUILD_ARGS} -f docker/vpp-cni/${DOCKERFILE} .

--- a/docker/cleanup.sh
+++ b/docker/cleanup.sh
@@ -15,6 +15,3 @@
 
 # leave only contivvpp images tagged as latest
 docker images | grep contivvpp | grep -v latest | awk '{print $3}' | xargs docker rmi
-
-# delete all build-only images
-docker images | grep 'prod-contiv-\|dev-contiv-' | awk '{print $3}' | xargs docker rmi

--- a/docker/development/README.md
+++ b/docker/development/README.md
@@ -16,7 +16,7 @@ locally built container image. After that, you can proceed with
 
 ### Using the development container for builds
 
-The development container (dev-contiv-vswitch) is a full-fledged build & test
+The development container (contivvpp/dev-vswitch) is a full-fledged build & test
 environment for developing Contiv VPP Agent Go code. If you do not have the 
 build environment/tools installed on your host, you can use the development 
 container to run your builds. You can run your IDE on the host by sharing the
@@ -30,7 +30,7 @@ For example, if the contiv-vpp source code is located in the `src/` folder
 under your Go path root folder on your host, the command to start the
 development container will be:
 ```
-docker run -v $GOPATH/src/github.com/contiv/vpp/:/root/go/src/github.com/contiv/vpp/ -it --name dev-contiv --rm dev-contiv-vswitch bash
+docker run -v $GOPATH/src/github.com/contiv/vpp/:/root/go/src/github.com/contiv/vpp/ -it --name dev-contiv --rm contivvpp/dev-vswitch bash
 ```
 
 You can either download the development container from Dockerhub, or build it 

--- a/docker/push-all.sh
+++ b/docker/push-all.sh
@@ -74,7 +74,7 @@ done
 # obtain the current git tag for tagging the Docker images
 export TAG=`git describe --tags`
 echo "exported TAG=$TAG"
-export VPP=$(docker run --rm contivvpp/dev-vswitch${RUNARCH}:$TAG bash -c "cd \$VPP_DIR && git rev-parse --short HEAD")
+export VPP=$(docker run --rm contivvpp/vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} bash -c "cat \$VPP_BUILD_DIR/.version")
 echo "exported VPP=$VPP"
 
 # tag and push each image

--- a/docker/push-all.sh
+++ b/docker/push-all.sh
@@ -74,7 +74,7 @@ done
 # obtain the current git tag for tagging the Docker images
 export TAG=`git describe --tags`
 echo "exported TAG=$TAG"
-export VPP=$(docker run --rm dev-contiv-vswitch${RUNARCH}:$TAG bash -c "cd \$VPP_DIR && git rev-parse --short HEAD")
+export VPP=$(docker run --rm contivvpp/dev-vswitch${RUNARCH}:$TAG bash -c "cd \$VPP_DIR && git rev-parse --short HEAD")
 echo "exported VPP=$VPP"
 
 # tag and push each image

--- a/docker/push-all.sh
+++ b/docker/push-all.sh
@@ -16,6 +16,9 @@
 # fail in case of error
 set -e
 
+# source VPP commit ID and repo URL
+source ../vpp.env
+
 # default values for "branch name" and "skip upload"
 BRANCH_NAME="master"
 SKIP_UPLOAD="false"
@@ -87,7 +90,7 @@ fi
 # obtain the current git tag for tagging the Docker images
 export TAG=`git describe --tags`
 echo "exported TAG=$TAG"
-export VPP=$(docker run --rm contivvpp/vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} bash -c "cat \$VPP_BUILD_DIR/.version")
+export VPP="${VPP_COMMIT_VERSION}"
 echo "exported VPP=$VPP"
 
 # tag and push each image

--- a/docker/push-all.sh
+++ b/docker/push-all.sh
@@ -24,7 +24,7 @@ CLEANUP="false"
 
 # list of images we are tagging & pushing
 IMAGES=()
-IMAGES_VPP=("cni" "ksr" "stn" "crd" "vswitch")
+IMAGES_VPP=("cni" "ksr" "stn" "crd" "vswitch" "dev-vswitch")
 IMAGES_BIN=("vpp-binaries")
 
 IMAGEARCH=""
@@ -71,6 +71,19 @@ while [ "$1" != "" ]; do
     shift
 done
 
+BRANCH_TAG="${BRANCH_NAME}"
+BRANCH_ADV_TAG="${BRANCH_TAG}"
+if [ "${BRANCH_NAME}" == "master" ]; then
+  BRANCH_TAG="latest"
+  BRANCH_ADV_TAG=""
+fi
+
+VPP_COMMIT_VERSION="latest"
+if [ -n "${VPP_COMMIT_ID}" ]
+then
+  VPP_COMMIT_VERSION="${VPP_COMMIT_ID}"
+fi
+
 # obtain the current git tag for tagging the Docker images
 export TAG=`git describe --tags`
 echo "exported TAG=$TAG"
@@ -78,173 +91,43 @@ export VPP=$(docker run --rm contivvpp/vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VE
 echo "exported VPP=$VPP"
 
 # tag and push each image
-for IMAGE in "${IMAGES[@]}"
-do
-    if [ "${BRANCH_NAME}" == "master" ]
-    then
-        # master branch - tag with the git tag + "latest"
-        echo "Tagging as contivvpp/${IMAGE}:${TAG} + contivvpp/${IMAGE}:latest"
-        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${TAG}
-        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:latest
- 
-        if [ ${BUILDARCH} = "amd64" ] ; then
-            echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${TAG} + contivvpp/${IMAGE}${IMAGEARCH}:latest as default"
-            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${TAG}
-            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:latest
-        fi
-
-        # push the images
-        if [ "${SKIP_UPLOAD}" != "true" ]
-        then
-            docker push contivvpp/${IMAGE}${IMAGEARCH}:${TAG}
-            docker push contivvpp/${IMAGE}${IMAGEARCH}:latest
-            if [ ${BUILDARCH} = "amd64" ] ; then
-                docker push contivvpp/${IMAGE}:${TAG}
-                docker push contivvpp/${IMAGE}:latest
-            fi
-        fi
-    else
-        # other branch - tag with the branch name
-        echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG} + contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}"
-        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}
-        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}
-        if [ ${BUILDARCH} = "amd64" ] ; then
-            echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG} + contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME} as default"
-            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}
-            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}
-        fi
-
-        # push the images
-        if [ "${SKIP_UPLOAD}" != "true" ]
-        then
-            docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}
-            docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}
-            if [ ${BUILDARCH} = "amd64" ] ; then
-                docker push contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}
-                docker push contivvpp/${IMAGE}:${BRANCH_NAME}
-            fi
-        fi
-    fi
-done
-
 for IMAGE in "${IMAGES_VPP[@]}"
 do
-    if [ "${BRANCH_NAME}" == "master" ]
-    then
-        # master branch - tag with the git tag + "latest"
-        echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${TAG}-${VPP} + contivvpp/${IMAGE}${IMAGEARCH}:latest"
-        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${TAG}-${VPP}
-        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:latest
+	if [ "${DEV_UPLOAD}" != "true" ] && [ "$IMAGE" == dev* ]; then
+		continue
+	fi
 
-        if [ ${BUILDARCH} = "amd64" ] ; then
-            echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${TAG}-${VPP} + contivvpp/${IMAGE}${IMAGEARCH}:latest as default"
-            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${TAG}-${VPP}
-            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:latest
-        fi
+	docker tag contivvpp/${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_TAG}
+	docker tag contivvpp/${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_ADV_TAG}${TAG}-${VPP}
 
-        # push the images
-        if [ "${SKIP_UPLOAD}" != "true" ]
-        then
-            docker push contivvpp/${IMAGE}${IMAGEARCH}:${TAG}-${VPP}
-            docker push contivvpp/${IMAGE}${IMAGEARCH}:latest
-            if [ ${BUILDARCH} = "amd64" ] ; then
-                docker push contivvpp/${IMAGE}:${TAG}-${VPP}
-                docker push contivvpp/${IMAGE}:latest
-            fi
-        fi
-    else
-        # other branch - tag with the branch name
-        echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP} + contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}"
-        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}
-        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP}
+	if [ ${BUILDARCH} = "amd64" ] ; then
+		docker tag contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_TAG} contivvpp/${IMAGE}:${BRANCH_TAG}
+		docker tag contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_ADV_TAG}${TAG}-${VPP} contivvpp/${IMAGE}:${BRANCH_ADV_TAG}${TAG}-${VPP}
+	fi
 
-        if [ ${BUILDARCH} = "amd64" ] ; then
-            echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP} + contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME} as default"
-            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}
-            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${TAG} contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}-${VPP}
-        fi
-        # push the images
-        if [ "${SKIP_UPLOAD}" != "true" ]
-        then
-            docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}
-            docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP}
-            if [ ${BUILDARCH} = "amd64" ] ; then
-                docker push contivvpp/${IMAGE}:${BRANCH_NAME}
-                docker push contivvpp/${IMAGE}:${BRANCH_NAME}-${TAG}-${VPP}
-            fi
-        fi
-    fi
+	# push the images
+	if [ "${SKIP_UPLOAD}" != "true" ]
+	then
+		docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_TAG}
+		docker push contivvpp/${IMAGE}${IMAGEARCH}:${BRANCH_ADV_TAG}${TAG}-${VPP}
+		if [ ${BUILDARCH} = "amd64" ] ; then
+			docker push contivvpp/${IMAGE}:${BRANCH_TAG}
+			docker push contivvpp/${IMAGE}:${BRANCH_ADV_TAG}${TAG}-${VPP}
+		fi
+	fi
 done
 
 for IMAGE in "${IMAGES_BIN[@]}"
 do
-    if [ "${BRANCH_NAME}" == "master" ]
-    then
-        # master branch - tag with the vpp tag
-        echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${VPP}"
-        docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${VPP} contivvpp/${IMAGE}${IMAGEARCH}:${VPP}
+    if [ "${BRANCH_NAME}" != "master" ] || [ "${SKIP_UPLOAD}" == "true" ]; then
+		continue
+	fi
 
-        if [ ${BUILDARCH} = "amd64" ] ; then
-            echo "Tagging as contivvpp/${IMAGE}${IMAGEARCH}:${VPP}"
-            docker tag prod-contiv-${IMAGE}${IMAGEARCH}:${VPP} contivvpp/${IMAGE}:${VPP}
-        fi
-
-        # push the images
-        if [ "${SKIP_UPLOAD}" != "true" ]
-        then
-            docker push contivvpp/${IMAGE}${IMAGEARCH}:${VPP}
-            if [ ${BUILDARCH} = "amd64" ] ; then
-                docker push contivvpp/${IMAGE}:${VPP}
-            fi
-        fi
-    fi
+	docker push contivvpp/${IMAGE}${IMAGEARCH}:${VPP}
+	if [ ${BUILDARCH} = "amd64" ] ; then
+		docker push contivvpp/${IMAGE}:${VPP}
+	fi
 done
-
-if [ "${DEV_UPLOAD}" == "true" ]
-then
-    if [ "${BRANCH_NAME}" == "master" ]
-    then
-        # master branch - tag with the git tag + "latest"
-        echo "Tagging as contivvpp/dev-vswitch${IMAGEARCH}:${TAG}-${VPP} + contivvpp/dev-vswitch${IMAGEARCH}:latest"
-        docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch${IMAGEARCH}:${TAG}-${VPP}
-        docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch${IMAGEARCH}:latest
-        if [ ${BUILDARCH} = "amd64" ] ; then
-            docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch:${TAG}-${VPP}
-            docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch:latest
-        fi
-
-        # push the images
-        if [ "${SKIP_UPLOAD}" != "true" ]
-        then
-            docker push contivvpp/dev-vswitch${IMAGEARCH}:${TAG}-${VPP}
-            docker push contivvpp/dev-vswitch${IMAGEARCH}:latest
-            if [ ${BUILDARCH} = "amd64" ] ; then
-                docker push contivvpp/dev-vswitch:${TAG}-${VPP}
-                docker push contivvpp/dev-vswitch:latest
-            fi
-        fi
-    else
-        # other branch - tag with the branch name
-        echo "Tagging as contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP} + contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}"
-        docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}
-        docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP}
-        if [ ${BUILDARCH} = "amd64" ] ; then
-            docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch:${BRANCH_NAME}
-            docker tag dev-contiv-vswitch${IMAGEARCH}:${TAG} contivvpp/dev-vswitch:${BRANCH_NAME}-${TAG}-${VPP}
-        fi
-
-        # push the images
-        if [ "${SKIP_UPLOAD}" != "true" ]
-        then
-            docker push contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}
-            docker push contivvpp/dev-vswitch${IMAGEARCH}:${BRANCH_NAME}-${TAG}-${VPP}
-            if [ ${BUILDARCH} = "amd64" ] ; then
-                docker push contivvpp/dev-vswitch:${BRANCH_NAME}
-                docker push contivvpp/dev-vswitch:${BRANCH_NAME}-${TAG}-${VPP}
-            fi
-        fi
-    fi
-fi
 
 if [ "${CLEANUP}" == "true" ]
 then

--- a/docker/ubuntu-based/README.md
+++ b/docker/ubuntu-based/README.md
@@ -27,7 +27,7 @@ The result of this procedure is the set of container images similar to this:
 ```
 $ docker images | grep contiv-vswitch
 prod-contiv-vswitch      0.0.1-7-g46d22f7        a18a66f3091f        20 seconds ago      473.9 MB
-dev-contiv-vswitch       0.0.1-7-g46d22f7        b494c8622263        23 seconds ago      5.252 GB
+contivvpp/dev-vswitch       0.0.1-7-g46d22f7        b494c8622263        23 seconds ago      5.252 GB
 ```
 
 Note that the images are tagged with the current git version (obtained using `git describe --tags`).

--- a/docker/ubuntu-based/build.sh
+++ b/docker/ubuntu-based/build.sh
@@ -23,11 +23,8 @@ set -e
 # obtain the current git tag for tagging the Docker images
 TAG=`git describe --tags`
 
-cd vpp
-./build.sh
-
 # build vpp-binaries image
-cd ../vpp-binaries
+cd vpp-binaries
 ./build.sh ${TAG}
 
 # build development image

--- a/docker/ubuntu-based/build.sh
+++ b/docker/ubuntu-based/build.sh
@@ -26,12 +26,12 @@ TAG=`git describe --tags`
 cd vpp
 ./build.sh
 
-# build development image
-cd ../dev
-./build.sh ${TAG}
-
 # build vpp-binaries image
 cd ../vpp-binaries
+./build.sh ${TAG}
+
+# build development image
+cd ../dev
 ./build.sh ${TAG}
 
 # build production images

--- a/docker/ubuntu-based/dev/Dockerfile
+++ b/docker/ubuntu-based/dev/Dockerfile
@@ -1,8 +1,30 @@
 ARG VPP_IMAGE
 FROM ${VPP_IMAGE}
 
+# install deps
+RUN apt-get update && apt-get install -y \
+ make \
+ wget \
+ git \
+ gcc
+
+# install vpp
+WORKDIR $VPP_BUILD_DIR
+ARG VPP_INSTALL_PKG
+RUN if [ -n "$VPP_INSTALL_PKG" ]; then \
+ apt-get install -y ./*.deb; \
+ fi
+
 # copy source files to the container
 COPY / /root/go/src/github.com/contiv/vpp
+
+# install Go
+ENV GOLANG_VERSION 1.10.4
+RUN if [ -n "$VPP_INSTALL_PKG" ]; then \
+ wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz" \
+ && tar -C /usr/local -xzf go.tgz \
+ && rm go.tgz; \
+ fi
 
 # set env. variables required for go build
 ENV GOROOT /usr/local/go

--- a/docker/ubuntu-based/dev/Dockerfile.arm64
+++ b/docker/ubuntu-based/dev/Dockerfile.arm64
@@ -1,8 +1,30 @@
 ARG VPP_IMAGE
 FROM ${VPP_IMAGE}
 
+# install deps
+RUN apt-get update && apt-get install -y \
+ make \
+ wget \
+ git \
+ gcc
+
+# install vpp
+WORKDIR $VPP_BUILD_DIR
+ARG VPP_INSTALL_PKG
+RUN if [ -n "$VPP_INSTALL_PKG" ]; then \
+ apt-get install -y ./*.deb; \
+ fi
+
 # copy source files to the container
 COPY / /root/go/src/github.com/contiv/vpp
+
+# install Go
+ENV GOLANG_VERSION 1.10.4
+RUN if [ -n "$VPP_INSTALL_PKG" ]; then \
+ wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz" \
+ && tar -C /usr/local -xzf go.tgz \
+ && rm go.tgz; \
+ fi
 
 # set env. variables required for go build
 ENV GOROOT /usr/local/go

--- a/docker/ubuntu-based/dev/build.sh
+++ b/docker/ubuntu-based/dev/build.sh
@@ -53,7 +53,7 @@ then
   VPP_BUILD_ARGS="--build-arg VPP_INSTALL_PKG=true"
 fi
 
-VPP=$(docker run --rm contivvpp/vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} bash -c "cat \$VPP_BUILD_DIR/.version")
+VPP="${VPP_COMMIT_VERSION}"
 
 # check if build is really necessary
 function validate_docker_tag() {

--- a/docker/ubuntu-based/dev/build.sh
+++ b/docker/ubuntu-based/dev/build.sh
@@ -28,7 +28,6 @@ if [ ${BUILDARCH} = "aarch64" ] ; then
   BUILDARCH="arm64"
 fi
 
-
 if [ ${BUILDARCH} = "x86_64" ] ; then
   BUILDARCH="amd64"
 fi
@@ -39,15 +38,15 @@ DOCKERFILE=Dockerfile${DOCKERFILETAG}
 # all the source files without the need of cloning them:
 cd ../../../
 
-# execute the build
-if [ -z "${VPP_COMMIT_ID}" ]
+# determine extra vpp version based args
+VPP_COMMIT_VERSION="latest"
+if [ -n "${VPP_COMMIT_ID}" ]
 then
-    # no specific VPP commit ID
-    docker build -f docker/ubuntu-based/dev/${DOCKERFILE} -t dev-contiv-vswitch-${BUILDARCH}:${TAG} --build-arg VPP_IMAGE=dev-contiv-vpp-${BUILDARCH}:latest ${DOCKER_BUILD_ARGS} .
-else
-    # specific VPP commit ID
-    docker build -f docker/ubuntu-based/dev/${DOCKERFILE} -t dev-contiv-vswitch-${BUILDARCH}:${TAG} --build-arg VPP_IMAGE=dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_ID} ${DOCKER_BUILD_ARGS} .
+  VPP_COMMIT_VERSION="${VPP_COMMIT_ID}"
 fi
+
+# execute the build
+docker build -f docker/ubuntu-based/dev/${DOCKERFILE} -t dev-contiv-vswitch-${BUILDARCH}:${TAG} --build-arg VPP_IMAGE=dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} ${DOCKER_BUILD_ARGS} .
 
 VPP=$(docker run --rm dev-contiv-vswitch-${BUILDARCH}:${TAG} bash -c "cd \$VPP_DIR && git rev-parse --short HEAD")
 docker tag dev-contiv-vswitch-${BUILDARCH}:${TAG} dev-contiv-vswitch-${BUILDARCH}:${TAG}-${VPP}

--- a/docker/ubuntu-based/dev/build.sh
+++ b/docker/ubuntu-based/dev/build.sh
@@ -46,12 +46,12 @@ then
 fi
 
 # execute the build
-docker build -f docker/ubuntu-based/dev/${DOCKERFILE} -t dev-contiv-vswitch-${BUILDARCH}:${TAG} --build-arg VPP_IMAGE=dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} ${DOCKER_BUILD_ARGS} .
+docker build -f docker/ubuntu-based/dev/${DOCKERFILE} -t contivvpp/dev-vswitch-${BUILDARCH}:${TAG} --build-arg VPP_IMAGE=contivvpp/vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} ${DOCKER_BUILD_ARGS} .
 
-VPP=$(docker run --rm dev-contiv-vswitch-${BUILDARCH}:${TAG} bash -c "cd \$VPP_DIR && git rev-parse --short HEAD")
-docker tag dev-contiv-vswitch-${BUILDARCH}:${TAG} dev-contiv-vswitch-${BUILDARCH}:${TAG}-${VPP}
+VPP=$(docker run --rm contivvpp/dev-vswitch-${BUILDARCH}:${TAG} bash -c "cd \$VPP_DIR && git rev-parse --short HEAD")
+docker tag contivvpp/dev-vswitch-${BUILDARCH}:${TAG} contivvpp/dev-vswitch-${BUILDARCH}:${TAG}-${VPP}
 
 if [ ${BUILDARCH} = "amd64" ] ; then
-   docker tag dev-contiv-vswitch-${BUILDARCH}:${TAG} dev-contiv-vswitch:${TAG}
-   docker tag dev-contiv-vswitch:${TAG} dev-contiv-vswitch:${TAG}-${VPP}
+   docker tag contivvpp/dev-vswitch-${BUILDARCH}:${TAG} contivvpp/dev-vswitch:${TAG}
+   docker tag contivvpp/dev-vswitch:${TAG} contivvpp/dev-vswitch:${TAG}-${VPP}
 fi

--- a/docker/ubuntu-based/dev/build.sh
+++ b/docker/ubuntu-based/dev/build.sh
@@ -33,10 +33,7 @@ if [ ${BUILDARCH} = "x86_64" ] ; then
   BUILDARCH="amd64"
 fi
 
-
 DOCKERFILE=Dockerfile${DOCKERFILETAG}
-#ALL_ARCH = amd64 arm64
-
 
 # the build needs to be executed from the github repository root, so that we can add
 # all the source files without the need of cloning them:
@@ -46,10 +43,10 @@ cd ../../../
 if [ -z "${VPP_COMMIT_ID}" ]
 then
     # no specific VPP commit ID
-    docker build -f docker/ubuntu-based/dev/${DOCKERFILE} -t dev-contiv-vswitch-${BUILDARCH}:${TAG} --build-arg VPP_IMAGE=dev-contiv-vpp-${BUILDARCH}:latest ${DOCKER_BUILD_ARGS} --force-rm=true .
+    docker build -f docker/ubuntu-based/dev/${DOCKERFILE} -t dev-contiv-vswitch-${BUILDARCH}:${TAG} --build-arg VPP_IMAGE=dev-contiv-vpp-${BUILDARCH}:latest ${DOCKER_BUILD_ARGS} .
 else
     # specific VPP commit ID
-    docker build -f docker/ubuntu-based/dev/${DOCKERFILE} -t dev-contiv-vswitch-${BUILDARCH}:${TAG} --build-arg VPP_IMAGE=dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_ID} ${DOCKER_BUILD_ARGS} --force-rm=true .
+    docker build -f docker/ubuntu-based/dev/${DOCKERFILE} -t dev-contiv-vswitch-${BUILDARCH}:${TAG} --build-arg VPP_IMAGE=dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_ID} ${DOCKER_BUILD_ARGS} .
 fi
 
 VPP=$(docker run --rm dev-contiv-vswitch-${BUILDARCH}:${TAG} bash -c "cd \$VPP_DIR && git rev-parse --short HEAD")

--- a/docker/ubuntu-based/prod/build.sh
+++ b/docker/ubuntu-based/prod/build.sh
@@ -34,13 +34,13 @@ fi
 DOCKERFILE=Dockerfile${DOCKERFILE_tag}
 
 # extract the binaries from the development image into the "binaries/" folder
-./extract.sh dev-contiv-vswitch-${BUILDARCH}:${TAG}
+./extract.sh contivvpp/dev-vswitch-${BUILDARCH}:${TAG}
 
 # build the production images
-docker build -t prod-contiv-vswitch-${BUILDARCH}:${TAG} ${DOCKER_BUILD_ARGS} -f vswitch/${DOCKERFILE} .
+docker build -t contivvpp/vswitch-${BUILDARCH}:${TAG} ${DOCKER_BUILD_ARGS} -f vswitch/${DOCKERFILE} .
 
 if [ ${BUILDARCH} = "amd64" ] ; then
-  docker tag prod-contiv-vswitch-${BUILDARCH}:${TAG} prod-contiv-vswitch:${TAG}
+  docker tag contivvpp/vswitch-${BUILDARCH}:${TAG} contivvpp/vswitch:${TAG}
 fi
 
 # delete the extracted binaries

--- a/docker/ubuntu-based/prod/build.sh
+++ b/docker/ubuntu-based/prod/build.sh
@@ -34,13 +34,12 @@ if [ ${BUILDARCH} = "x86_64" ] ; then
 fi
 
 DOCKERFILE=Dockerfile${DOCKERFILE_tag}
-#ALL_ARCH = amd64 arm64
 
 # extract the binaries from the development image into the "binaries/" folder
 ./extract.sh dev-contiv-vswitch${IMAGEARCH}:${TAG}
 
 # build the production images
-docker build -t prod-contiv-vswitch-${BUILDARCH}:${TAG} ${DOCKER_BUILD_ARGS} --no-cache --force-rm=true -f vswitch/${DOCKERFILE} .
+docker build -t prod-contiv-vswitch-${BUILDARCH}:${TAG} ${DOCKER_BUILD_ARGS} -f vswitch/${DOCKERFILE} .
 
 if [ ${BUILDARCH} = "amd64" ] ; then
   docker tag prod-contiv-vswitch-${BUILDARCH}:${TAG} prod-contiv-vswitch:${TAG}

--- a/docker/ubuntu-based/prod/build.sh
+++ b/docker/ubuntu-based/prod/build.sh
@@ -21,12 +21,10 @@ TAG=${1-latest}
 
 DOCKERFILE_tag=""
 BUILDARCH=`uname -m`
-IMAGEARCH=""
 
 if [ ${BUILDARCH} = "aarch64" ] ; then
   DOCKERFILE_tag=".arm64"
   BUILDARCH="arm64"
-  IMAGEARCH="-arm64"
 fi
 
 if [ ${BUILDARCH} = "x86_64" ] ; then
@@ -36,7 +34,7 @@ fi
 DOCKERFILE=Dockerfile${DOCKERFILE_tag}
 
 # extract the binaries from the development image into the "binaries/" folder
-./extract.sh dev-contiv-vswitch${IMAGEARCH}:${TAG}
+./extract.sh dev-contiv-vswitch-${BUILDARCH}:${TAG}
 
 # build the production images
 docker build -t prod-contiv-vswitch-${BUILDARCH}:${TAG} ${DOCKER_BUILD_ARGS} -f vswitch/${DOCKERFILE} .

--- a/docker/ubuntu-based/vpp-binaries/Dockerfile
+++ b/docker/ubuntu-based/vpp-binaries/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:16.04
 
 # set work directory
-WORKDIR /root/
+ENV VPP_BUILD_DIR /opt/vpp-agent/dev/vpp/build-root
+WORKDIR $VPP_BUILD_DIR
 
 # add VPP binaries (add also extracts from .tar.gz)
 ADD binaries/vpp.tar.gz .

--- a/docker/ubuntu-based/vpp-binaries/Dockerfile.arm64
+++ b/docker/ubuntu-based/vpp-binaries/Dockerfile.arm64
@@ -1,7 +1,8 @@
 FROM arm64v8/ubuntu:16.04
 
 # set work directory
-WORKDIR /root/
+ENV VPP_BUILD_DIR /opt/vpp-agent/dev/vpp/build-root
+WORKDIR $VPP_BUILD_DIR
 
 # add VPP binaries (add also extracts from .tar.gz)
 ADD binaries/vpp.tar.gz .

--- a/docker/ubuntu-based/vpp-binaries/build.sh
+++ b/docker/ubuntu-based/vpp-binaries/build.sh
@@ -41,13 +41,13 @@ then
 fi
 
 # extract the binaries from the development image into the "binaries/" folder
-./extract.sh dev-contiv-vswitch-${BUILDARCH}:${TAG}
+./extract.sh contivvpp/dev-vswitch-${BUILDARCH}:${TAG}
 
 # build the production images
-docker build -t prod-contiv-vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} ${DOCKER_BUILD_ARGS} -f ${DOCKERFILE} .
+docker build -t contivvpp/vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} ${DOCKER_BUILD_ARGS} -f ${DOCKERFILE} .
 
 if [ ${BUILDARCH} = "amd64" ] ; then
-  docker tag prod-contiv-vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} prod-contiv-vpp-binaries:${VPP_COMMIT_VERSION}
+  docker tag contivvpp/vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} contivvpp/vpp-binaries:${VPP_COMMIT_VERSION}
 fi
 
 # delete the extracted binaries

--- a/docker/ubuntu-based/vpp-binaries/build.sh
+++ b/docker/ubuntu-based/vpp-binaries/build.sh
@@ -37,11 +37,11 @@ DOCKERFILE=Dockerfile${DOCKERFILE_tag}
 VPP_COMMIT_VERSION="latest"
 if [ -n "${VPP_COMMIT_ID}" ]
 then
-  VPP_COMMIT_VERSION="${VPP_COMMIT_ID:0:7}"
+  VPP_COMMIT_VERSION="${VPP_COMMIT_ID}"
 fi
 
 # extract the binaries from the development image into the "binaries/" folder
-./extract.sh contivvpp/dev-vswitch-${BUILDARCH}:${TAG}
+./extract.sh contivvpp/vpp-${BUILDARCH}:${VPP_COMMIT_VERSION}
 
 # build the production images
 docker build -t contivvpp/vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} ${DOCKER_BUILD_ARGS} -f ${DOCKERFILE} .

--- a/docker/ubuntu-based/vpp-binaries/build.sh
+++ b/docker/ubuntu-based/vpp-binaries/build.sh
@@ -34,13 +34,12 @@ if [ ${BUILDARCH} = "x86_64" ] ; then
 fi
 
 DOCKERFILE=Dockerfile${DOCKERFILE_tag}
-#ALL_ARCH = amd64 arm64
 
 # extract the binaries from the development image into the "binaries/" folder
 ./extract.sh dev-contiv-vswitch${IMAGEARCH}:${TAG}
 
 # build the production images
-docker build -t prod-contiv-vpp-binaries-${BUILDARCH}:${VPP_COMMIT_ID:0:7} ${DOCKER_BUILD_ARGS} --no-cache --force-rm=true -f ${DOCKERFILE} .
+docker build -t prod-contiv-vpp-binaries-${BUILDARCH}:${VPP_COMMIT_ID:0:7} ${DOCKER_BUILD_ARGS} -f ${DOCKERFILE} .
 
 if [ ${BUILDARCH} = "amd64" ] ; then
   docker tag prod-contiv-vpp-binaries-${BUILDARCH}:${VPP_COMMIT_ID:0:7} prod-contiv-vpp-binaries:${VPP_COMMIT_ID:0:7}

--- a/docker/ubuntu-based/vpp-binaries/build.sh
+++ b/docker/ubuntu-based/vpp-binaries/build.sh
@@ -21,12 +21,10 @@ TAG=${1-latest}
 
 DOCKERFILE_tag=""
 BUILDARCH=`uname -m`
-IMAGEARCH=""
 
 if [ ${BUILDARCH} = "aarch64" ] ; then
   DOCKERFILE_tag=".arm64"
   BUILDARCH="arm64"
-  IMAGEARCH="-arm64"
 fi
 
 if [ ${BUILDARCH} = "x86_64" ] ; then
@@ -35,14 +33,21 @@ fi
 
 DOCKERFILE=Dockerfile${DOCKERFILE_tag}
 
+# determine extra vpp version based args
+VPP_COMMIT_VERSION="latest"
+if [ -n "${VPP_COMMIT_ID}" ]
+then
+  VPP_COMMIT_VERSION="${VPP_COMMIT_ID:0:7}"
+fi
+
 # extract the binaries from the development image into the "binaries/" folder
-./extract.sh dev-contiv-vswitch${IMAGEARCH}:${TAG}
+./extract.sh dev-contiv-vswitch-${BUILDARCH}:${TAG}
 
 # build the production images
-docker build -t prod-contiv-vpp-binaries-${BUILDARCH}:${VPP_COMMIT_ID:0:7} ${DOCKER_BUILD_ARGS} -f ${DOCKERFILE} .
+docker build -t prod-contiv-vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} ${DOCKER_BUILD_ARGS} -f ${DOCKERFILE} .
 
 if [ ${BUILDARCH} = "amd64" ] ; then
-  docker tag prod-contiv-vpp-binaries-${BUILDARCH}:${VPP_COMMIT_ID:0:7} prod-contiv-vpp-binaries:${VPP_COMMIT_ID:0:7}
+  docker tag prod-contiv-vpp-binaries-${BUILDARCH}:${VPP_COMMIT_VERSION} prod-contiv-vpp-binaries:${VPP_COMMIT_VERSION}
 fi
 
 # delete the extracted binaries

--- a/docker/ubuntu-based/vpp-binaries/build.sh
+++ b/docker/ubuntu-based/vpp-binaries/build.sh
@@ -40,6 +40,11 @@ then
   VPP_COMMIT_VERSION="${VPP_COMMIT_ID}"
 fi
 
+# build vpp
+cd ../vpp
+./build.sh ${TAG}
+cd -
+
 # extract the binaries from the development image into the "binaries/" folder
 ./extract.sh contivvpp/vpp-${BUILDARCH}:${VPP_COMMIT_VERSION}
 

--- a/docker/ubuntu-based/vpp-binaries/extract.sh
+++ b/docker/ubuntu-based/vpp-binaries/extract.sh
@@ -30,9 +30,8 @@ mkdir -p binaries
 # extract VPP binaries
 docker exec ${CID} /bin/bash -c 'mkdir -p /root/vpp &&
   cp /opt/vpp-agent/dev/vpp/build-root/*.deb /root/vpp/ &&
-  cp /opt/vpp-agent/dev/vpp/build-root/.version /root/vpp/ &&
   cd /root/vpp/ &&
-  tar -zcvf /root/vpp.tar.gz * .version'
+  tar -zcvf /root/vpp.tar.gz *'
 
 docker cp ${CID}:/root/vpp.tar.gz binaries/
 

--- a/docker/ubuntu-based/vpp-binaries/extract.sh
+++ b/docker/ubuntu-based/vpp-binaries/extract.sh
@@ -28,7 +28,12 @@ rm -rf binaries
 mkdir -p binaries
 
 # extract VPP binaries
-docker exec ${CID} /bin/bash -c 'mkdir -p /root/vpp && cp /opt/vpp-agent/dev/vpp/build-root/*.deb /root/vpp/ && cd /root && tar -zcvf /root/vpp.tar.gz vpp/*'
+docker exec ${CID} /bin/bash -c 'mkdir -p /root/vpp &&
+  cp /opt/vpp-agent/dev/vpp/build-root/*.deb /root/vpp/ &&
+  cp /opt/vpp-agent/dev/vpp/build-root/.version /root/vpp/ &&
+  cd /root/vpp/ &&
+  tar -zcvf /root/vpp.tar.gz * .version'
+
 docker cp ${CID}:/root/vpp.tar.gz binaries/
 
 # delete the "extract" container

--- a/docker/ubuntu-based/vpp/Dockerfile
+++ b/docker/ubuntu-based/vpp/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /root/
 
 # Path to VPP ws root directory
 ENV VPP_DIR /opt/vpp-agent/dev/vpp
+ENV VPP_BUILD_DIR $VPP_DIR/build-root
 ENV VPP_BIN_DIR $VPP_DIR/build-root/install-vpp_debug-native/vpp/bin
 ENV VPP_LIB_DIR $VPP_DIR/build-root/install-vpp_debug-native/vpp/lib64
 ENV VPP_BIN $VPP_BIN_DIR/vpp

--- a/docker/ubuntu-based/vpp/Dockerfile.arm64
+++ b/docker/ubuntu-based/vpp/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN apt-get update \
  && mkdir -p /opt/vpp-agent/dev/vpp /opt/vpp-agent/plugin
 
 # install Go
-ENV GOLANG_VERSION 1.9.3
+ENV GOLANG_VERSION 1.10.4
 RUN wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz" \
  && tar -C /usr/local -xzf go.tgz \
  && rm go.tgz
@@ -30,6 +30,7 @@ WORKDIR /root/
 
 # Path to VPP ws root directory
 ENV VPP_DIR /opt/vpp-agent/dev/vpp
+ENV VPP_BUILD_DIR $VPP_DIR/build-root
 ENV VPP_BIN_DIR $VPP_DIR/build-root/install-vpp_debug-native/vpp/bin
 ENV VPP_LIB_DIR $VPP_DIR/build-root/install-vpp_debug-native/vpp/lib64
 ENV VPP_BIN $VPP_BIN_DIR/vpp

--- a/docker/ubuntu-based/vpp/build-vpp.sh
+++ b/docker/ubuntu-based/vpp/build-vpp.sh
@@ -50,6 +50,8 @@ rm -rf .ccache \
 rm *java*.deb
 dpkg -i vpp_*.deb vpp-dev_*.deb vpp-lib_*.deb vpp-plugins_*.deb vpp-dbg_*.deb
 
+echo $(git rev-parse --short HEAD) > ${VPP_BUILD_DIR}/.version
+
 # run the debug build too unless the SKIP_DEBUG_BUILD env var is set to non-0 value
 if [ "${SKIP_DEBUG_BUILD}" == "" ] || [ "${SKIP_DEBUG_BUILD}" -eq 0 ]; then
 	cd ${VPP_DIR}

--- a/docker/ubuntu-based/vpp/build-vpp.sh
+++ b/docker/ubuntu-based/vpp/build-vpp.sh
@@ -50,8 +50,6 @@ rm -rf .ccache \
 rm *java*.deb
 dpkg -i vpp_*.deb vpp-dev_*.deb vpp-lib_*.deb vpp-plugins_*.deb vpp-dbg_*.deb
 
-echo $(git rev-parse --short HEAD) > ${VPP_BUILD_DIR}/.version
-
 # run the debug build too unless the SKIP_DEBUG_BUILD env var is set to non-0 value
 if [ "${SKIP_DEBUG_BUILD}" == "" ] || [ "${SKIP_DEBUG_BUILD}" -eq 0 ]; then
 	cd ${VPP_DIR}

--- a/docker/ubuntu-based/vpp/build.sh
+++ b/docker/ubuntu-based/vpp/build.sh
@@ -25,36 +25,30 @@ if [ ${BUILDARCH} = "aarch64" ] ; then
   BUILDARCH="arm64"
 fi
 
-
 if [ ${BUILDARCH} = "x86_64" ] ; then
   BUILDARCH="amd64"
 fi
 
 DOCKERFILE=Dockerfile${DOCKERFILETAG}
 
-# execute the build
-if [ -z "${VPP_COMMIT_ID}" ]
+# determine extra vpp version based args
+VPP_COMMIT_ARGS=""
+VPP_COMMIT_VERSION="latest"
+if [ -n "${VPP_COMMIT_ID}" ]
 then
-    # no specific VPP commit ID
-    docker build -t dev-contiv-vpp-${BUILDARCH}:latest \
-        -f ${DOCKERFILE} \
-        --build-arg VPP_REPO_URL=${VPP_REPO_URL} \
-        --build-arg VPP_BRANCH_NAME=${VPP_BRANCH_NAME} \
-        --build-arg SKIP_DEBUG_BUILD=${SKIP_DEBUG_BUILD} \
-        ${DOCKER_BUILD_ARGS} .
-    if [ ${BUILDARCH} = "amd64" ] ; then
-       docker tag  dev-contiv-vpp-${BUILDARCH}:latest dev-contiv-vpp:latest
-    fi
-else
-    # specific VPP commit ID
-    docker build -t dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_ID} \
-        -f ${DOCKERFILE} \
-        --build-arg VPP_REPO_URL=${VPP_REPO_URL} \
-        --build-arg VPP_BRANCH_NAME=${VPP_BRANCH_NAME} \
-        --build-arg VPP_COMMIT_ID=${VPP_COMMIT_ID} \
-        --build-arg SKIP_DEBUG_BUILD=${SKIP_DEBUG_BUILD} \
-        ${DOCKER_BUILD_ARGS} .
-    if [ ${BUILDARCH} = "amd64" ] ; then
-       docker tag  dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_ID} dev-contiv-vpp:${VPP_COMMIT_ID}
-    fi
+  VPP_COMMIT_ARGS="--build-arg VPP_COMMIT_ID=${VPP_COMMIT_ID}"
+  VPP_COMMIT_VERSION="${VPP_COMMIT_ID}"
+fi
+
+# execute the build
+docker build -t dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} \
+	-f ${DOCKERFILE} \
+	--build-arg VPP_REPO_URL=${VPP_REPO_URL} \
+	--build-arg VPP_BRANCH_NAME=${VPP_BRANCH_NAME} \
+	--build-arg SKIP_DEBUG_BUILD=${SKIP_DEBUG_BUILD} \
+	${VPP_COMMIT_ARGS} \
+	${DOCKER_BUILD_ARGS} .
+
+if [ ${BUILDARCH} = "amd64" ] ; then
+   docker tag dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} dev-contiv-vpp:${VPP_COMMIT_VERSION}
 fi

--- a/docker/ubuntu-based/vpp/build.sh
+++ b/docker/ubuntu-based/vpp/build.sh
@@ -30,10 +30,7 @@ if [ ${BUILDARCH} = "x86_64" ] ; then
   BUILDARCH="amd64"
 fi
 
-
 DOCKERFILE=Dockerfile${DOCKERFILETAG}
-#ALL_ARCH = amd64 arm64
-
 
 # execute the build
 if [ -z "${VPP_COMMIT_ID}" ]
@@ -44,7 +41,7 @@ then
         --build-arg VPP_REPO_URL=${VPP_REPO_URL} \
         --build-arg VPP_BRANCH_NAME=${VPP_BRANCH_NAME} \
         --build-arg SKIP_DEBUG_BUILD=${SKIP_DEBUG_BUILD} \
-        ${DOCKER_BUILD_ARGS} --force-rm=true .
+        ${DOCKER_BUILD_ARGS} .
     if [ ${BUILDARCH} = "amd64" ] ; then
        docker tag  dev-contiv-vpp-${BUILDARCH}:latest dev-contiv-vpp:latest
     fi
@@ -56,7 +53,7 @@ else
         --build-arg VPP_BRANCH_NAME=${VPP_BRANCH_NAME} \
         --build-arg VPP_COMMIT_ID=${VPP_COMMIT_ID} \
         --build-arg SKIP_DEBUG_BUILD=${SKIP_DEBUG_BUILD} \
-        ${DOCKER_BUILD_ARGS} --force-rm=true .
+        ${DOCKER_BUILD_ARGS} .
     if [ ${BUILDARCH} = "amd64" ] ; then
        docker tag  dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_ID} dev-contiv-vpp:${VPP_COMMIT_ID}
     fi

--- a/docker/ubuntu-based/vpp/build.sh
+++ b/docker/ubuntu-based/vpp/build.sh
@@ -41,7 +41,7 @@ then
 fi
 
 # execute the build
-docker build -t dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} \
+docker build -t contivvpp/vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} \
 	-f ${DOCKERFILE} \
 	--build-arg VPP_REPO_URL=${VPP_REPO_URL} \
 	--build-arg VPP_BRANCH_NAME=${VPP_BRANCH_NAME} \
@@ -50,5 +50,5 @@ docker build -t dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} \
 	${DOCKER_BUILD_ARGS} .
 
 if [ ${BUILDARCH} = "amd64" ] ; then
-   docker tag dev-contiv-vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} dev-contiv-vpp:${VPP_COMMIT_VERSION}
+   docker tag contivvpp/vpp-${BUILDARCH}:${VPP_COMMIT_VERSION} contivvpp/vpp:${VPP_COMMIT_VERSION}
 fi

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -12,10 +12,10 @@ kubectl apply -f contiv-vpp.yaml
 # undeploy
 kubectl delete -f contiv-vpp.yaml
 ```
-Optionally you can edit `contiv-vpp.yaml` to deploy the dev-contiv-vswitch image, built
+Optionally you can edit `contiv-vpp.yaml` to deploy the contivvpp/dev-vswitch image, built
 in local environment with `../docker/build-all.sh`.
 ```
-sed -i "s@image: contivvpp/vswitch@image: dev-contiv-vswitch:<your image version>@g" ./contiv-vpp.yaml
+sed -i "s@image: contivvpp/vswitch@image: contivvpp/dev-vswitch:<your image version>@g" ./contiv-vpp.yaml
 ```
 
 This manifest can be generated and updated from the contiv-vpp helm chart:
@@ -26,7 +26,7 @@ make generate-manifest
 And optionally, a new manifest can be generated with different configuration values than the defaults in contiv-vpp/values.yaml:
 ```
 helm template --name contiv-vpp contiv-vpp \
-  --set vswitch.image.repository=dev-contiv-vswitch \
+  --set vswitch.image.repository=contivvpp/dev-vswitch \
   --set vswitch.image.tag=<your image version> > dev-contiv-vpp.yaml
 ```
 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -98,7 +98,7 @@ From a suspended state, or after a reboot of the host machine, the cluster
 can be brought up by running the vagrant-up script.
 
 
-### Building and deploying the dev-contiv-vswitch image (optional)
+### Building and deploying the contivvpp/dev-vswitch image (optional)
 If you chose the deployment with the development environment follow the
 instructions to build a modified contivvpp/vswitch image.
 

--- a/vagrant/config/save-dev-image
+++ b/vagrant/config/save-dev-image
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo "Building contivvpp agent binary..."
-dev_vswitch_ids="$(docker images dev-contiv-vswitch --format "{{.ID}}")"
+dev_vswitch_ids="$(docker images contivvpp/dev-vswitch --format "{{.ID}}")"
 dev_vswitch_id="$(echo $dev_vswitch_ids | awk '{print $1;}')"
 docker kill dev-contiv || true
 docker run -v /home/vagrant/gopath/src/github.com/contiv/vpp/:/root/go/src/github.com/contiv/vpp/ -itd --name dev-contiv --rm $dev_vswitch_id bash


### PR DESCRIPTION
- Add --no-cacahe param to build-all.sh script that will skip all
locally and remotely cached versions of built images
- Make default behaviour of all docker/ubuntu-based images to use cache
and skip force-rm
- Unify VPP_COMMIT_ID based builds
- Remove IMAGEARCH and simply use BUILDARCH
- Remove prod-/dev- images and tag them properly immediately
- If SKIP_DEBUG_BUILD is set, use vpp-binaries instead of vpp as base for
images to avoid recompiling vpp
- To add ability to skip VPP build when needed, build VPP from VPP
binaries script
- Before building docker images in ubuntu-based/ try to check if image
already exists on remote and if yes, pull it
- Remove IMAGES array from push-all as it is not needed
- Remove prod/dev from cleanup.sh as those images do not exists anymore
- Update push-all.sh to use correctly tagged docker image names
- Always use VPP_COMMIT_VERSION instead of shorthand from git rev --parse
for consistency

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>
