### PR TITLE
Add/fix info about collection in CRD plugin

### DIFF
--- a/plugins/crd/cache/telemetry_cache.go
+++ b/plugins/crd/cache/telemetry_cache.go
@@ -39,7 +39,6 @@ const (
 	livenessURL       = "/liveness"
 	linuxInterfaceURL = "/linux/dump/v1/interfaces"
 	ipamURL           = "/contiv/v1/ipam"
-	telemetryURL      = "/telemetry"
 
 	nodeInterfaceURL = "/vpp/dump/v1/interfaces"
 	bridgeDomainURL  = "/vpp/dump/v1/bd"
@@ -47,9 +46,7 @@ const (
 	arpURL           = "/vpp/dump/v1/arps"
 	staticRouteURL   = "/vpp/dump/v1/routes"
 
-	clientTimeout      = 10 // HTTP client timeout, in seconds
-	collectionInterval = 1  // data collection interval, in minutes
-
+	clientTimeout = 10 // HTTP client timeout, in seconds
 )
 
 // ContivTelemetryCache is used for a in-memory storage of K8s State data
@@ -103,7 +100,7 @@ type NodeDTO struct {
 }
 
 // NewTelemetryCache returns a new instance of telemetry cache
-func NewTelemetryCache(p logging.PluginLogger, verbose bool) *ContivTelemetryCache {
+func NewTelemetryCache(p logging.PluginLogger, collectionInterval time.Duration, verbose bool) *ContivTelemetryCache {
 	return &ContivTelemetryCache{
 		Deps: Deps{
 			Log: p.NewLogger("-telemetryCache"),
@@ -115,7 +112,7 @@ func NewTelemetryCache(p logging.PluginLogger, verbose bool) *ContivTelemetryCac
 		Verbose:  verbose,
 
 		agentPort:            agentPort,
-		collectionInterval:   collectionInterval * time.Minute,
+		collectionInterval:   collectionInterval,
 		httpClientTimeout:    clientTimeout * time.Second,
 		validationInProgress: false,
 
@@ -123,7 +120,7 @@ func NewTelemetryCache(p logging.PluginLogger, verbose bool) *ContivTelemetryCac
 		dsUpdateChannel:     make(chan interface{}),
 		dtoList:             make([]*NodeDTO, 0),
 		dataChangeEvents:    make(DcEventQueue, 0),
-		ticker:              time.NewTicker(collectionInterval * time.Minute),
+		ticker:              time.NewTicker(collectionInterval),
 		databaseVersion:     0,
 	}
 }

--- a/plugins/crd/controller/telemetry/telemetry_controller.go
+++ b/plugins/crd/controller/telemetry/telemetry_controller.go
@@ -57,6 +57,8 @@ type Controller struct {
 	CrdClient *crdClientSet.Clientset
 	APIClient *apiextcs.Clientset
 
+	CollectionInterval time.Duration
+
 	queue workqueue.RateLimitingInterface
 	// Telemetry CRD specifics
 	telemetryInformer     informers.TelemetryReportInformer
@@ -328,7 +330,7 @@ func (cr *CRDReport) GenerateCRDReport() {
 				APIVersion: v1.CRDGroupVersion,
 			},
 			Spec: v1.TelemetryReportSpec{
-				ReportPollingPeriodSeconds: 10,
+				ReportPollingPeriodSeconds: uint32(cr.Ctlr.CollectionInterval.Seconds()),
 			},
 		}
 
@@ -336,6 +338,7 @@ func (cr *CRDReport) GenerateCRDReport() {
 	}
 
 	crdTelemetryReportCopy := crdTelemetryReport.DeepCopy()
+	crdTelemetryReportCopy.Status.UpdatedAt = time.Now().String()
 
 	for _, node := range cr.VppCache.RetrieveAllNodes() {
 		crdTelemetryReportCopy.Status.Nodes = appendIfMissing(crdTelemetryReportCopy.Status.Nodes, *node.NodeInfo)

--- a/plugins/crd/pkg/apis/telemetry/v1/types.go
+++ b/plugins/crd/pkg/apis/telemetry/v1/types.go
@@ -57,6 +57,7 @@ type TelemetryReportList struct {
 
 // TelemetryReportStatus is the state for the contiv telemetry report
 type TelemetryReportStatus struct {
-	Nodes   []telemetrymodel.NodeInfo `json:"nodes"`
-	Reports telemetrymodel.Reports    `json:"reports"`
+	UpdatedAt string                    `json:"updatedAt"`
+	Nodes     []telemetrymodel.NodeInfo `json:"nodes"`
+	Reports   telemetrymodel.Reports    `json:"reports"`
 }

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -19,8 +19,6 @@ package crd
 import (
 	"context"
 	"fmt"
-	"sync"
-
 	"github.com/contiv/vpp/plugins/crd/api"
 	"github.com/contiv/vpp/plugins/crd/cache"
 	"github.com/contiv/vpp/plugins/crd/controller/nodeconfig"
@@ -34,6 +32,8 @@ import (
 	"github.com/ligato/cn-infra/logging"
 	"github.com/ligato/cn-infra/utils/safeclose"
 	"github.com/namsral/flag"
+	"sync"
+	"time"
 
 	nodeinfomodel "github.com/contiv/vpp/plugins/contiv/model/node"
 	crdClientSet "github.com/contiv/vpp/plugins/crd/pkg/client/clientset/versioned"
@@ -115,7 +115,11 @@ func (p *Plugin) Init() error {
 		return fmt.Errorf("failed to build api Client: %s", err)
 	}
 
+	// Time interval for periodic report collection
+	collectionInterval := 1 * time.Minute
+
 	p.telemetryController = &telemetry.Controller{
+		CollectionInterval: collectionInterval,
 		Deps: telemetry.Deps{
 			Log: p.Log.NewLogger("-telemetryController"),
 		},
@@ -124,7 +128,7 @@ func (p *Plugin) Init() error {
 	}
 
 	// This where we initialize all layers
-	p.cache = cache.NewTelemetryCache(p.Log, *verbose)
+	p.cache = cache.NewTelemetryCache(p.Log, collectionInterval, *verbose)
 
 	p.cache.Init()
 


### PR DESCRIPTION
- Fix the collectionInterval amount reported in telemetry report
- Add `UpdatedAt` field to telemetry report to show when was the last
report update

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Output preview:
```
$ kubectl get telemetryreports.telemetry.contiv.vpp -o yaml
```

```yaml
apiVersion: v1
items:
- apiVersion: telemetry.contiv.vpp/v1
  kind: TelemetryReport
  metadata:
    creationTimestamp: 2018-11-16T13:20:06Z
    generation: 1
    name: default-telemetry
    namespace: default
    resourceVersion: "985"
    selfLink: /apis/telemetry.contiv.vpp/v1/namespaces/default/telemetryreports/default-telemetry
    uid: 5559118b-e9a2-11e8-8db7-080027d4e5bf
  spec:
    report_polling_period_seconds: 60
  status:
    nodes:
    - ID: 1
      IPAddr: 192.168.16.1/24
      ManIPAddr: 10.0.2.15
      Name: vagrant-arch.vagrantup.com
    reports:
      global:
      - 'IP-ARP: validation OK'
      - 'VXLAN-BD: 2 errors found'
      - 'L2-FIB: 3 errors found'
      - 'K8S-NODE: validation OK'
      - 'K8S-POD: validation OK'
      - 'L3-FIB: 11 errors found'
      vagrant-arch.vagrantup.com:
      - 'VXLAN-BD: validator internal error: bad MAC Addr index, MAC Addr 1a:2b:3c:4d:5e:01,
        BVI vxlanBVI (ifIndex 3, ifName vxlanBVI)'
      - 'VXLAN-BD: missing/invalid VXLAN interface in VXLAN BD for node vagrant-arch.vagrantup.com'
      - 'L2-FIB: invalid L2Fib BVI entry ''1a:2b:3c:4d:5e:01''; bad MAC address -
        have ''1a:2b:3c:4d:5e:01'', expecting ''de:ad:00:00:00:00'''
      - 'L2-FIB: L2Fib validator internal error: inconsistent MAC Address index, MAC
        1a:2b:3c:4d:5e:01'
      - 'L2-FIB: L2Fib entry for interface ''loop0'' not found'
      - 'L3-FIB: local GigE interface not found, error interface pattern GigabitEthernet[[:alnum:]]*/[[:alnum:]]*/[[:alnum:]]*
        not found'
      - 'L3-FIB: failed to validate route 0.0.0.0/0 VRF0 - local GigE interface not
        found (error ''interface pattern GigabitEthernet[[:alnum:]]*/[[:alnum:]]*/[[:alnum:]]*
        not found'')'
      - 'L3-FIB: unexpected route 240.0.0.0/4 in VRF0; route not validated'
      - 'L3-FIB: unexpected route fe80::/10 in VRF0; route not validated'
      - 'L3-FIB: unexpected route 0.0.0.0/0 in VRF0; route not validated'
      - 'L3-FIB: unexpected route ::/0 in VRF0; route not validated'
      - 'L3-FIB: unexpected route 192.168.16.1/24 in VRF0; route not validated'
      - 'L3-FIB: unexpected route 224.0.0.0/4 in VRF0; route not validated'
      - 'L3-FIB: unexpected route 240.0.0.0/4 in VRF1; route not validated'
      - 'L3-FIB: unexpected route 0.0.0.0/0 in VRF1; route not validated'
      - 'L3-FIB: unexpected route 224.0.0.0/4 in VRF1; route not validated'
      - 'L3-FIB: Rte report VRF0: total 19, notValidated 11, invalid: 0, valid:8'
      - 'L3-FIB: Rte report VRF1: total 16, notValidated 5, invalid: 0, valid:11'
    updatedAt: 2018-11-16 13:22:06.023974063 +0000 UTC m=+240.078351696
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```