### PR TITLE
Add support for configurable CRD polling interval

### DIFF
--- a/k8s/contiv-vpp.yaml
+++ b/k8s/contiv-vpp.yaml
@@ -673,6 +673,8 @@ spec:
           value: "/etc/http/http.conf"
         - name: HTTP_CLIENT_CONFIG
           value: "/etc/http/http.client.conf"
+        - name: CONTIV_CRD_INTERVAL
+          value: 1
         volumeMounts:
         - name: etcd-cfg
           mountPath: /etc/etcd

--- a/k8s/contiv-vpp/templates/vpp.yaml
+++ b/k8s/contiv-vpp/templates/vpp.yaml
@@ -1095,6 +1095,8 @@ spec:
           value: "/etc/http/http.conf"
         - name: HTTP_CLIENT_CONFIG
           value: "/etc/http/http.client.conf"
+        - name: CONTIV_CRD_INTERVAL
+          value: {{ .Values.crd.pollingInterval }}
         volumeMounts:
         - name: etcd-cfg
           mountPath: /etc/etcd

--- a/k8s/contiv-vpp/values.yaml
+++ b/k8s/contiv-vpp/values.yaml
@@ -120,6 +120,7 @@ crd:
     #tag:
     pullPolicy: IfNotPresent
   updateStrategy: RollingUpdate
+  pollingInterval: 1 # in minutes, 0 to disable
 
 # GoVPP configuration
 # It contains time intervals used for VPP health probing (in nanoseconds).

--- a/plugins/crd/cache/telemetry_cache.go
+++ b/plugins/crd/cache/telemetry_cache.go
@@ -101,6 +101,12 @@ type NodeDTO struct {
 
 // NewTelemetryCache returns a new instance of telemetry cache
 func NewTelemetryCache(p logging.PluginLogger, collectionInterval time.Duration, verbose bool) *ContivTelemetryCache {
+	ticker := time.NewTicker(collectionInterval)
+	if collectionInterval <= 0 {
+		// If we have 0 collection interval, just stop ticker
+		ticker.Stop()
+	}
+
 	return &ContivTelemetryCache{
 		Deps: Deps{
 			Log: p.NewLogger("-telemetryCache"),
@@ -120,7 +126,7 @@ func NewTelemetryCache(p logging.PluginLogger, collectionInterval time.Duration,
 		dsUpdateChannel:     make(chan interface{}),
 		dtoList:             make([]*NodeDTO, 0),
 		dataChangeEvents:    make(DcEventQueue, 0),
-		ticker:              time.NewTicker(collectionInterval),
+		ticker:              ticker,
 		databaseVersion:     0,
 	}
 }

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -32,6 +32,8 @@ import (
 	"github.com/ligato/cn-infra/logging"
 	"github.com/ligato/cn-infra/utils/safeclose"
 	"github.com/namsral/flag"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -117,6 +119,10 @@ func (p *Plugin) Init() error {
 
 	// Time interval for periodic report collection
 	collectionInterval := 1 * time.Minute
+	configuredInterval, err := strconv.Atoi(os.Getenv("CONTIV_CRD_INTERVAL"))
+	if err == nil {
+		collectionInterval = time.Duration(configuredInterval) * time.Minute
+	}
 
 	p.telemetryController = &telemetry.Controller{
 		CollectionInterval: collectionInterval,


### PR DESCRIPTION
- Add CONTIV_CRD_INTERVAL variable that is read from CRD plugin to
configure polling interval
- Add option to helm template to configure this value
- When configured polling interval is <= 0, simply disable polling

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>