### PR TITLE
Remove incorrect error message from docker builds

### DIFF
--- a/docker/ubuntu-based/dev/build.sh
+++ b/docker/ubuntu-based/dev/build.sh
@@ -64,7 +64,7 @@ function validate_docker_tag() {
   fi
 }
 
-if [ -z $(validate_docker_tag contivvpp/dev-vswitch-${BUILDARCH} ${TAG}-${VPP}) ]; then
+if [ -z "$(validate_docker_tag contivvpp/dev-vswitch-${BUILDARCH} ${TAG}-${VPP})" ]; then
   # execute the build
   # use no cache and force rm because docker cannot handle dynamic FROM and so trying to use cache is useless
   docker build --no-cache=true --force-rm=true -f docker/ubuntu-based/dev/${DOCKERFILE} -t contivvpp/dev-vswitch-${BUILDARCH}:${TAG}-${VPP} \

--- a/docker/ubuntu-based/prod/build.sh
+++ b/docker/ubuntu-based/prod/build.sh
@@ -42,7 +42,7 @@ function validate_docker_tag() {
   fi
 }
 
-if [ -z $(validate_docker_tag contivvpp/vswitch-${BUILDARCH} ${TAG}) ]; then
+if [ -z "$(validate_docker_tag contivvpp/vswitch-${BUILDARCH} ${TAG})" ]; then
   # extract the binaries from the development image into the "binaries/" folder
   ./extract.sh contivvpp/dev-vswitch-${BUILDARCH}:${TAG}
 

--- a/docker/ubuntu-based/vpp-binaries/build.sh
+++ b/docker/ubuntu-based/vpp-binaries/build.sh
@@ -49,7 +49,7 @@ function validate_docker_tag() {
   fi
 }
 
-if [ -z $(validate_docker_tag contivvpp/vpp-binaries-${BUILDARCH} ${VPP_COMMIT_VERSION}) ]; then
+if [ -z "$(validate_docker_tag contivvpp/vpp-binaries-${BUILDARCH} ${VPP_COMMIT_VERSION})" ]; then
   # build vpp
   cd ../vpp
   ./build.sh ${TAG}


### PR DESCRIPTION
`./build.sh: line 54: [: too many arguments` this is caused by output of
validate_docker_tag not being quoted, so it is expanded, what is
incorrect. The end result is the same (condition fails), but it should
still be fixed to avoid confusion.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>