### PR TITLE
Nodesync: Do not include prevValue in updateEv if its ID is 0

### DIFF
--- a/plugins/nodesync/nodesync.go
+++ b/plugins/nodesync/nodesync.go
@@ -457,11 +457,17 @@ func (ns *NodeSync) Update(event controller.Event, txn controller.UpdateOperatio
 			node.ID = vppNode.Id
 			node.VppIPAddresses = ns.nodeVPPAddresses(vppNode)
 		}
-		ns.EventLoop.PushEvent(&NodeUpdate{
+		ev := &NodeUpdate{
 			NodeName:  nodeName,
 			PrevState: prev,
 			NewState:  node,
-		})
+		}
+		// do not include prevState if it doesn't contain
+		// allocated node.ID
+		if ev.PrevState != nil && ev.PrevState.ID == 0 {
+			ev.PrevState = nil
+		}
+		ns.EventLoop.PushEvent(ev)
 	}
 	return "", nil
 }


### PR DESCRIPTION
The PR fixes issue where ipv4net tried to handle change
of nodeID 0 -> X (not allocated -> a meaningful value).
Attempt to generate previous config (corresponding to 0),
in order to remove it, failed.