### PR TITLE
acl renderer: do not treat delay between pod removal and the notification with warning

### DIFF
--- a/plugins/controller/plugin_controller.go
+++ b/plugins/controller/plugin_controller.go
@@ -445,6 +445,7 @@ func (c *Controller) eventLoop() {
 				if elapsed <= ageLimit {
 					break
 				}
+				c.eventHistory[i] = nil
 			}
 			if i > 0 {
 				c.eventHistory = c.eventHistory[i:]

--- a/plugins/policy/renderer/acl/acl_renderer.go
+++ b/plugins/policy/renderer/acl/acl_renderer.go
@@ -369,9 +369,13 @@ func (art *RendererTxn) renderInterfaces(pods cache.PodSet, ingress bool) *vpp_a
 		// Get the interface associated with the pod.
 		ifName, found := art.renderer.podInterfaces[podID] // first query local cache
 		if !found {
-			ifName, found = art.renderer.IPv4Net.GetIfName(podID.Namespace, podID.Name) // next query Contiv plugin
+			ifName, found = art.renderer.IPv4Net.GetIfName(podID.Namespace, podID.Name) // next query IPv4Net plugin
 			if !found {
-				art.renderer.Log.WithField("pod", podID).Warn("Unable to get the interface assigned to the Pod")
+				// pod has been deleted in the meantime but notification from K8s
+				// has not arrived yet
+				art.renderer.Log.WithField("pod", podID).Debug(
+				"Unable to get the interface assigned to the Pod "+
+				"(expecting notification about its deletion)")
 				continue
 			}
 		}

--- a/plugins/policy/renderer/acl/acl_renderer.go
+++ b/plugins/policy/renderer/acl/acl_renderer.go
@@ -374,8 +374,8 @@ func (art *RendererTxn) renderInterfaces(pods cache.PodSet, ingress bool) *vpp_a
 				// pod has been deleted in the meantime but notification from K8s
 				// has not arrived yet
 				art.renderer.Log.WithField("pod", podID).Debug(
-				"Unable to get the interface assigned to the Pod "+
-				"(expecting notification about its deletion)")
+					"Unable to get the interface assigned to the Pod " +
+						"(expecting notification about its deletion)")
 				continue
 			}
 		}

--- a/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph/graph_write.go
+++ b/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph/graph_write.go
@@ -217,9 +217,13 @@ func (graph *graphRW) Release() {
 					if elapsed <= graph.parent.recordAgeLimit {
 						break
 					}
+					records[i] = nil
 				}
 				if i > 0 {
 					destGraph.timeline[key] = records[i:]
+				}
+				if len(destGraph.timeline[key]) == 0 {
+					delete(destGraph.timeline, key)
 				}
 			}
 			graph.parent.lastRevTrimming = now

--- a/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/txn_record.go
+++ b/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/txn_record.go
@@ -195,6 +195,7 @@ func (s *Scheduler) transactionHistoryTrimming() {
 				if elapsed <= ageLimit {
 					break
 				}
+				s.txnHistory[i] = nil
 			}
 			if i > 0 {
 				s.txnHistory = s.txnHistory[i:]


### PR DESCRIPTION
+ fix history trimming