### PR TITLE
Fix Dockerfiles for ARM64 platform

### DIFF
--- a/docker/vpp-crd/Dockerfile.arm64
+++ b/docker/vpp-crd/Dockerfile.arm64
@@ -3,6 +3,9 @@ FROM arm64v8/golang:1.10.7-alpine3.8 as builder
 # we want a static binary
 ENV CGO_ENABLED=0
 
+# contiv-crd depends on govppmux transitively, but only because it reads some constants from vpp-agent plugins
+ENV GO_BUILD_TAGS=mockvpp
+
 RUN apk add --update git make
 
 COPY . /go/src/github.com/contiv/vpp
@@ -11,7 +14,7 @@ WORKDIR /go/src/github.com/contiv/vpp
 
 RUN make contiv-crd && make contiv-netctl
 
-FROM scratch
+FROM alpine:3.8
 
 COPY --from=builder /go/src/github.com/contiv/vpp/cmd/contiv-crd/contiv-crd /contiv-crd
 COPY --from=builder /go/src/github.com/contiv/vpp/cmd/contiv-netctl/contiv-netctl /contiv-netctl

--- a/docker/vpp-ui/Dockerfile.arm64
+++ b/docker/vpp-ui/Dockerfile.arm64
@@ -16,6 +16,7 @@ ENV PATH="/root/.npm-global/bin:${PATH}"
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NPM_CONFIG_PREFIX=/root/.npm-global
 
+RUN npm config set unsafe-perm true
 RUN npm install -g npm@latest
 RUN npm install -g @angular/cli@7.0.2
 RUN mkdir -p /src/ui


### PR DESCRIPTION
The file vpp-crd/Dockerfile.arm64 was adjusted according AMD64 version.
The file vpp-ui/Dockerfile.arm64 - there was a failure during building a docker image. (see solution at https://github.com/npm/npm/issues/20861)

Step 13/26 : RUN npm install -g npm@latest
 ---> Running in 2c75c09afa78
[91mError: could not get uid/gid
[ 'nobody', 0 ]
    at /usr/local/lib/node_modules/npm/node_modules/uid-number/uid-number.js:37:16
...
...
[0m[91mTypeError: Cannot read property 'get' of undefined
...
...
[0mThe command '/bin/sh -c npm install -g npm@latest' returned a non-zero code: 7
Build step 'Execute shell' marked build as failure
Finished: FAILURE 