### PR TITLE
quote image tags in vagrant setup

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -473,7 +473,7 @@ EOL
 
 applyVPPnetwork() {
   if [ "#{image_tag}" != "latest" ]; then
-    sed -i -e "s/latest/#{image_tag}/" #{contiv_dir}/k8s/contiv-vpp/Chart.yaml
+    sed -i -e 's/latest/"#{image_tag}"/' #{contiv_dir}/k8s/contiv-vpp/Chart.yaml
   fi
 
   if [ "#{crd_disabled}" = "false" ]; then


### PR DESCRIPTION
Helm treats tags as float64 whenever possible. This means tag "2.0"
would become just "2" which causes ImagePullBackOff.

Signed-off-by: samuel.elias <samelias@cisco.com>