### PR TITLE
fix shebang in vagrant-cleanup script

### DIFF
--- a/vagrant/vagrant-cleanup
+++ b/vagrant/vagrant-cleanup
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -euo pipefail


### PR DESCRIPTION
Shebang does nothing if it is not on the first line. 
The next command "set -o pipefail" will fail in any non-bash shell.

Signed-off-by: samuel.elias <samelias@cisco.com>