### PR TITLE
Pull systest image in vagrant setup

### DIFF
--- a/vagrant/provision/provision_every_node.sh
+++ b/vagrant/provision/provision_every_node.sh
@@ -211,3 +211,6 @@ else
     ip link set enp0s8 down
   fi
 fi
+
+# Pull image used in k8s-systest "max_pod" scale
+docker pull kahou82/kubia


### PR DESCRIPTION
image used in max_pod scale test often fails to pull in time

Signed-off-by: samuel.elias <samelias@cisco.com>