### PR TITLE
Tune jool-specific configuration on ipv6 gateway node

### DIFF
--- a/vagrant/provision/provision_every_node.sh
+++ b/vagrant/provision/provision_every_node.sh
@@ -189,6 +189,9 @@ statseg {
 EOF
 }
 
+# Pull image used in k8s-systest "max_pod" scale
+docker pull kahou82/kubia
+
 createVPPconfig
 split_node_os_release="$(cut -d "." -f 1 <<< "${node_os_release}")"
 if [ "$split_node_os_release" = '16' ]; then
@@ -215,6 +218,3 @@ else
     ip link set enp0s8 down
   fi
 fi
-
-# Pull image used in k8s-systest "max_pod" scale
-docker pull kahou82/kubia

--- a/vagrant/provision/provision_gateway.sh
+++ b/vagrant/provision/provision_gateway.sh
@@ -39,10 +39,19 @@ ip4_address=\$(ip -o addr show dev enp0s3 | sed 's,/, ,g' | awk '\$3=="inet" { p
 jool -4 --add $ip4_address 7000-8000
 jool -4 -d
 jool -6 -d
+jool --global --update --mtu-plateaus="9000,1450,1280"
 jool --enable
 EOF
 
    sudo chmod a+x /root/nat64-setup.sh
+
+   sudo ip link set mtu 1450 dev enp0s3
+   sudo ip link set mtu 1450 dev enp0s8
+   sudo ip link set mtu 1450 dev enp0s9
+
+   sudo ethtool --offload enp0s3 gro off
+   sudo ethtool --offload enp0s8 gro off
+   sudo ethtool --offload enp0s9 gro off
 
    sudo systemctl start nat64.service
    sudo systemctl enable nat64.service


### PR DESCRIPTION
- set gateway interfaces MTU to 1450, same as pod interfaces
- try to disable receive offload on gateway interfaces
- set jool MTU plateaus to values we use in the cluster

Signed-off-by: samuel.elias <samelias@cisco.com>