### PR TITLE
fix reporting of ipv6 test results

### DIFF
--- a/vagrant/test_with_treshold.sh
+++ b/vagrant/test_with_treshold.sh
@@ -82,7 +82,7 @@ do
     cmd "lsof | awk '{ print \$2 \" \" \$1; }' | uniq -c | sort -rn | head -20"
     cmd date
     echo ""
-    status=`cat pytest_output_n$c | grep ==== | grep second | grep failed | cut -d " " -f 2`
+    status=`cat pytest_output_n$c | grep ==== | grep second | grep -w failed | cut -d " " -f 2`
     echo "Failed tests: $status"
     if (( status > TRESHOLD )); then
         echo "Too many failed tests, ending..."


### PR DESCRIPTION
IPv6 tests have some expected failures (xfailed) which the results
parser doesn't expect

Signed-off-by: samuel.elias <samelias@cisco.com>