### PR TITLE
Installation doc: tell users to open the etcd ports on centos

### DIFF
--- a/docs/setup/MANUAL_INSTALL.md
+++ b/docs/setup/MANUAL_INSTALL.md
@@ -176,6 +176,11 @@ the most recent Docker images on each node:
 bash <(curl -s https://raw.githubusercontent.com/contiv/vpp/master/k8s/pull-images.sh)
 ```
 
+If you are using centos, you will need to open the port for the contiv etcd on your master:
+```
+firewall-cmd --permanent --add-port=12379-12380/tcp
+```
+
 Contiv-VPP CNI plugin can be installed in two ways:
 - [Contiv-VPP Helm Installation](../../k8s/contiv-vpp/README.md), allows for customization via helm options,
   but is more complex, described in [this document](../../k8s/contiv-vpp/README.md).


### PR DESCRIPTION
Centos firewall is restrictive by default and all ports are closed. As a result contiv-vpp on the minion cannot reach the etcd cluster and crashes if the port is not explicitely opened.

Since there are several install paths for contiv-vpp there may be other places where this should be specified,  or there may be a better place to document this - let me know and I can update the PR as needed.