### PR TITLE
Get rid of the references to PodVPPSubnetCIDR in docs & comments

### DIFF
--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -33,11 +33,6 @@ has a `/24` slice of the `PodSubnetCIDR`. The Node ID is used to address the nod
 In case of `PodSubnetCIDR = 10.1.0.0/16`, `PodSubnetOneNodePrefixLen = 24` and `NodeID = 5`,
 the resulting POD subnet for the node would be `10.1.5.0/24`.
 
-- **PodVPPSubnetCIDR** (default `10.2.1.0/24`): VPP-internal addresses used to put
-the VPP interfaces facing towards the PODs into L3 mode. This IP range will be reused 
-on each node, thereby it is never externally addressable outside of the node itself.
-The only requirement is that this subnet should not collide with any other IPAM subnet.
-
 - **VPPHostSubnetCIDR** (default `172.30.0.0/16`): used for addressing 
 the interconnect of the VPP with the Linux network stack within the same node. 
 Since this subnet needs to  be unique on each node, the Node ID is used to determine 

--- a/docs/arm64/MANUAL_INSTALL_CAVIUM.md
+++ b/docs/arm64/MANUAL_INSTALL_CAVIUM.md
@@ -209,7 +209,7 @@ are a special case; they share their respective interfaces and IP addresses with
 the host. For proxying to work properly it is therefore required for services
 with backends running on the host to also **include the node management IP**
 within the `--pod-network-cidr` subnet. For example, with the default
-`PodSubnetCIDR=10.1.0.0/16` and `PodVPPSubnetCIDR=10.2.1.0/24`, the subnet
+`PodSubnetCIDR=10.1.0.0/16`, the subnet
 `10.3.0.0/16` could be allocated for the management network and
 `--pod-network-cidr` could be defined as `10.0.0.0/8`, so as to include IP
 addresses of all pods in all network namespaces:

--- a/docs/debugging/BUG_REPORTS.md
+++ b/docs/debugging/BUG_REPORTS.md
@@ -30,7 +30,6 @@ or the [corresponding part](https://github.com/contiv/vpp/blob/42b3bfbe873550866
     IPAMConfig:
       PodSubnetCIDR: 10.1.0.0/16
       PodSubnetOneNodePrefixLen: 24
-      PodVPPSubnetCIDR: 10.2.1.0/24
       VPPHostSubnetCIDR: 172.30.0.0/16
       VPPHostSubnetOneNodePrefixLen: 24
       NodeInterconnectCIDR: 192.168.16.0/24

--- a/docs/setup/MANUAL_INSTALL.md
+++ b/docs/setup/MANUAL_INSTALL.md
@@ -138,7 +138,7 @@ are a special case; they share their respective interfaces and IP addresses with
 the host. For proxying to work properly it is therefore required for services
 with backends running on the host to also **include the node management IP**
 within the `--pod-network-cidr` subnet. For example, with the default
-`PodSubnetCIDR=10.1.0.0/16` and `PodVPPSubnetCIDR=10.2.1.0/24`, the subnet
+`PodSubnetCIDR=10.1.0.0/16`, the subnet
 `10.3.0.0/16` could be allocated for the management network and
 `--pod-network-cidr` could be defined as `10.0.0.0/8`, so as to include IP
 addresses of all pods in all network namespaces:

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -67,7 +67,6 @@ manually or using the [helm options](contiv-vpp/README.md#configuration):
 
   * IPAM (section `ipamConfig`)
     - `podSubnetCIDR`: subnet used for all pods across all nodes
-    - `podVPPSubnetCIDR`: subnet CIDR for VPP-side POD addresses
     - `podSubnetOneNodePrefixLen`: subnet prefix length used for all pods of 1 k8s node
       (pod network = pod subnet for one k8s node);
     - `vppHostSubnetCIDR`: subnet used in each node for VPP-to-host connectivity;

--- a/k8s/contiv-vpp/README.md
+++ b/k8s/contiv-vpp/README.md
@@ -79,7 +79,6 @@ Parameter | Description | Default
 `contiv.disableNATVirtualReassembly` | Disable NAT virtual reassembly (drop fragmented packets) | `False`
 `contiv.ipamConfig.podSubnetCIDR` | Pod subnet CIDR | `10.1.0.0/16`
 `contiv.ipamConfig.podSubnetOneNodePrefixLen` | Pod network prefix length | `24`
-`contiv.ipamConfig.podVPPSubnetCIDR` | Subnet CIDR for VPP-side POD addresses | `10.2.1.0/24`
 `contiv.ipamConfig.vppHostSubnetCIDR` | VPP host subnet CIDR | `172.30.0.0/16`
 `contiv.ipamConfig.vppHostSubnetOneNodePrefixLen` | VPP host network prefix length | `24`
 `contiv.ipamConfig.vxlanCIDR` | VXLAN CIDR | `192.168.30.0/24`

--- a/plugins/crd/validator/l2/l2_validator.go
+++ b/plugins/crd/validator/l2/l2_validator.go
@@ -654,8 +654,6 @@ func (v *Validator) ValidatePodInfo() {
 			continue
 		}
 
-		// Get Contiv's view of the VPP's pod-facing tap interface subnet CIDR
-		// on this node (PodVPPSubnetCIDR)
 		if vppNode.NodeIPam == nil {
 			errCnt++
 			v.Log.Infof("No IPAM data for node %s", vppNode.Name)

--- a/plugins/ipnet/ipnet_test.go
+++ b/plugins/ipnet/ipnet_test.go
@@ -125,7 +125,6 @@ var (
 			IPAMConfig: contivconf.IPAMConfig{
 				PodSubnetCIDR:                 "10.1.0.0/16",
 				PodSubnetOneNodePrefixLen:     24,
-				PodVPPSubnetCIDR:              "10.2.1.0/24",
 				VPPHostSubnetCIDR:             "172.30.0.0/16",
 				VPPHostSubnetOneNodePrefixLen: 24,
 				NodeInterconnectCIDR:          "192.168.16.0/24",

--- a/scripts/contiv-network-report.sh
+++ b/scripts/contiv-network-report.sh
@@ -294,7 +294,7 @@ do
                         if echo "$n" | grep -q "tap"
                         then
                             # Compare just the 3rd digit of the IP address for now;
-                            # Assumes /16 PodSubnetCIDR and /24 PodVPPSubnetCIDR
+                            # Assumes /16 PodSubnetCIDR
                             POD_ID=$( echo "$POD_IP" | awk -F. '{print $4}' )
                             TAP_ID=$( echo "${IF_IP[$n]}" | awk -F/ '{print $1}' |awk -F. '{print $4}' )
                             if [ "$POD_ID" == "$TAP_ID" ]


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <raszabo@cisco.com>