### PR TITLE
move external etcd in multimaster test to different master node

### DIFF
--- a/k8s/multi-master/external_etcd.yaml
+++ b/k8s/multi-master/external_etcd.yaml
@@ -31,7 +31,7 @@ spec:
           operator: Exists
       # Only run this pod on the master.
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        kubernetes.io/hostname: "k8s-master1"
       hostNetwork: true
 
       containers:


### PR DESCRIPTION
Multimaster test destroys the primary master node, we need etcd to remain accessible.

Signed-off-by: samuel.elias <samelias@cisco.com>