### PR TITLE
re-add VPP buffer override to Vagrant deployment

### DIFF
--- a/vagrant/provision/provision_every_node.sh
+++ b/vagrant/provision/provision_every_node.sh
@@ -198,6 +198,9 @@ socksvr {
 statseg {
    default
 }
+buffers {
+   buffers-per-numa 131072
+}
 EOF
 }
 


### PR DESCRIPTION
was removed in cfde5f, but no replacement provided

Signed-off-by: samuel.elias <samelias@cisco.com>