### PR TITLE
fix ARM64 docker image build

### DIFF
--- a/docker/vpp-vswitch/dev/Dockerfile.arm64
+++ b/docker/vpp-vswitch/dev/Dockerfile.arm64
@@ -6,7 +6,12 @@ RUN apt-get update && apt-get install -y \
  make \
  wget \
  git \
- gcc
+ gcc\
+ gcc-8 g++-8 \
+ && rm /usr/bin/gcc \
+ && rm /usr/bin/g++ \
+ && ln -s /usr/bin/gcc-8 /usr/bin/gcc \
+ && ln -s /usr/bin/g++-8 /usr/bin/g++
 
 # install vpp
 WORKDIR $VPP_BUILD_DIR

--- a/docker/vpp-vswitch/vpp/Dockerfile.arm64
+++ b/docker/vpp-vswitch/vpp/Dockerfile.arm64
@@ -13,6 +13,8 @@ RUN apt-get update \
     # ability to run vpptrace.sh
     netcat-openbsd \
  && apt-get remove -y --purge gcc \
+ && apt-get remove -y --purge gcc-8 \
+ && apt-get remove -y --purge g++-8 \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /opt/vpp-agent/dev/vpp /opt/vpp-agent/plugin
 

--- a/docker/vpp-vswitch/vpp/build-vpp.sh
+++ b/docker/vpp-vswitch/vpp/build-vpp.sh
@@ -42,6 +42,15 @@ fi
 
 # run the production build
 UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom' install-dep dpdk-install-dev
+
+if [ "$(uname -m)" = "aarch64" ] ; then
+  apt-get install -y gcc-8 g++-8
+  rm /usr/bin/gcc
+  rm /usr/bin/g++
+  ln -s /usr/bin/gcc-8 /usr/bin/gcc
+  ln -s /usr/bin/g++-8 /usr/bin/g++
+fi
+
 rm -rf /var/lib/apt/lists/*
 cd ${VPP_DIR}
 UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom' build-release pkg-deb


### PR DESCRIPTION
For building VPP was used gcc-7 which ended by failure on ARM64 platform
gcc-8 and g++-8 are installed and used instead to ensure successfull build

Signed-off-by: Stanislav Chlebec <stanislav.chlebec@pantheon.tech>