### PR TITLE
Fix for bad removal of SRv6 localsids in case of SRv6-rendered service removal

### DIFF
--- a/plugins/service/processor/processor_impl.go
+++ b/plugins/service/processor/processor_impl.go
@@ -283,6 +283,7 @@ func (sp *ServiceProcessor) renderService(svc *Service, oldContivSvc *renderer.C
 	var err error
 	newContivSvc := svc.GetContivService()
 	newBackends := svc.GetLocalBackends()
+	otherContiveServices := sp.otherContivServices(svc)
 
 	// Render service.
 	if newContivSvc != nil {
@@ -294,7 +295,7 @@ func (sp *ServiceProcessor) renderService(svc *Service, oldContivSvc *renderer.C
 			}
 		} else {
 			for _, renderer := range sp.renderers {
-				if err = renderer.UpdateService(oldContivSvc, newContivSvc); err != nil {
+				if err = renderer.UpdateService(oldContivSvc, newContivSvc, otherContiveServices); err != nil {
 					return err
 				}
 			}
@@ -302,7 +303,7 @@ func (sp *ServiceProcessor) renderService(svc *Service, oldContivSvc *renderer.C
 	} else {
 		if oldContivSvc != nil {
 			for _, renderer := range sp.renderers {
-				if err = renderer.DeleteService(oldContivSvc); err != nil {
+				if err = renderer.DeleteService(oldContivSvc, otherContiveServices); err != nil {
 					return err
 				}
 			}
@@ -360,6 +361,17 @@ func (sp *ServiceProcessor) renderService(svc *Service, oldContivSvc *renderer.C
 	}
 
 	return err
+}
+
+// otherContivServices retrieves all existing ContivService-s except the one given as parameter <exceludeService>
+func (sp *ServiceProcessor) otherContivServices(excludedService *Service) []*renderer.ContivService {
+	otherServices := make([]*renderer.ContivService, 0, len(sp.services))
+	for _, service := range sp.services {
+		if service != excludedService {
+			otherServices = append(otherServices, service.GetContivService())
+		}
+	}
+	return otherServices
 }
 
 // renderNodePorts re-renders all services with a node port.

--- a/plugins/service/processor/processor_impl.go
+++ b/plugins/service/processor/processor_impl.go
@@ -368,7 +368,9 @@ func (sp *ServiceProcessor) otherContivServices(excludedService *Service) []*ren
 	otherServices := make([]*renderer.ContivService, 0, len(sp.services))
 	for _, service := range sp.services {
 		if service != excludedService {
-			otherServices = append(otherServices, service.GetContivService())
+			if contivService := service.GetContivService(); contivService != nil {
+				otherServices = append(otherServices, contivService)
+			}
 		}
 	}
 	return otherServices

--- a/plugins/service/renderer/api.go
+++ b/plugins/service/renderer/api.go
@@ -80,11 +80,13 @@ type ServiceRendererAPI interface {
 	AddService(service *ContivService) error
 
 	// UpdateService informs renderer about a change in the configuration
-	// or in the state of a service.
-	UpdateService(oldService, newService *ContivService) error
+	// or in the state of a service. The renderer can also use info about
+	// other existing services to perform update correctly.
+	UpdateService(oldService, newService *ContivService, otherExistingServices []*ContivService) error
 
-	// DeleteService is called for every removed service.
-	DeleteService(service *ContivService) error
+	// DeleteService is called for every removed service. The renderer can
+	// also use info about other existing services to handle service removal correctly.
+	DeleteService(service *ContivService, otherExistingServices []*ContivService) error
 
 	// UpdateNodePortServices is called whenever the set of node IPs in the cluster
 	// changes.

--- a/plugins/service/renderer/ipv6route/ipv6route_renderer.go
+++ b/plugins/service/renderer/ipv6route/ipv6route_renderer.go
@@ -128,7 +128,7 @@ func (rndr *Renderer) AddService(service *renderer.ContivService) error {
 }
 
 // UpdateService updates VPP config for a changed service.
-func (rndr *Renderer) UpdateService(oldService, newService *renderer.ContivService) error {
+func (rndr *Renderer) UpdateService(oldService, newService *renderer.ContivService, otherExistingServices []*renderer.ContivService) error {
 	if rndr.snatOnly {
 		return nil
 	}
@@ -147,7 +147,7 @@ func (rndr *Renderer) UpdateService(oldService, newService *renderer.ContivServi
 }
 
 // DeleteService removes VPP config associated with a freshly un-deployed service.
-func (rndr *Renderer) DeleteService(service *renderer.ContivService) error {
+func (rndr *Renderer) DeleteService(service *renderer.ContivService, otherExistingServices []*renderer.ContivService) error {
 	if rndr.snatOnly {
 		return nil
 	}

--- a/plugins/service/renderer/nat44/nat44_renderer.go
+++ b/plugins/service/renderer/nat44/nat44_renderer.go
@@ -155,7 +155,7 @@ func (rndr *Renderer) AddService(service *renderer.ContivService) error {
 }
 
 // UpdateService updates destination-NAT rules for a changed service.
-func (rndr *Renderer) UpdateService(oldService, newService *renderer.ContivService) error {
+func (rndr *Renderer) UpdateService(oldService, newService *renderer.ContivService, otherExistingServices []*renderer.ContivService) error {
 	if rndr.snatOnly {
 		return nil
 	}
@@ -167,7 +167,7 @@ func (rndr *Renderer) UpdateService(oldService, newService *renderer.ContivServi
 
 // DeleteService removes destination-NAT configuration associated with a freshly
 // un-deployed service.
-func (rndr *Renderer) DeleteService(service *renderer.ContivService) error {
+func (rndr *Renderer) DeleteService(service *renderer.ContivService, otherExistingServices []*renderer.ContivService) error {
 	if rndr.snatOnly {
 		return nil
 	}

--- a/plugins/service/renderer/srv6/srv6_renderer.go
+++ b/plugins/service/renderer/srv6/srv6_renderer.go
@@ -209,66 +209,17 @@ func (r *Renderer) renderService(service *renderer.ContivService, oper operation
 
 	addDelConfig = make(controller.KeyValuePairs)
 	updateConfig = make(controller.KeyValuePairs)
-	localBackends := make(map[localBackendKey]*localBackend, 0)
-	hasHostNetworkLocalBackend := false
-	remoteBackends := make(map[remoteBackendKey]*remoteBackend, 0)
 
-	// collect info about the backends
-	for servicePortName, servicePort := range service.Ports {
-		for _, backend := range service.Backends[servicePortName] {
-			if backend.Local {
-				// collect local backend info
-				if backend.HostNetwork {
-					hasHostNetworkLocalBackend = true
-					lb := &localBackend{
-						useHostNetwork: true,
-						ip:             backend.IP,
-					}
-					localBackends[lb.Key()] = lb
-				} else {
-					lb := &localBackend{ip: backend.IP}
-					if servicePort.Port != backend.Port {
-						previousForwards := lb.portForwards
-						if previousLB, exists := localBackends[lb.Key()]; exists {
-							previousForwards = previousLB.portForwards
-						}
-						lb.portForwards = append(previousForwards, &portForward{
-							proto: servicePort.Protocol,
-							from:  servicePort.Port,
-							to:    backend.Port,
-						})
-					}
-					localBackends[lb.Key()] = lb
-				}
-			} else {
-				// collect remote backend info
-				var nodeID uint32
-				var err error
-				if backend.HostNetwork {
-					nodeID, err = r.nodeIDFromNodeOrHostIP(backend.IP)
-					if err != nil {
-						r.Log.Warnf("Error by extracting node ID from host IP: %v", err)
-						continue
-					}
-				} else {
-					nodeID, err = r.IPAM.NodeIDFromPodIP(backend.IP)
-					if err != nil {
-						r.Log.Warnf("Error by extracting node ID from pod ID: %v", err)
-						continue
-					}
-				}
-				nodeIP, _, err := r.IPAM.NodeIPAddress(nodeID)
-				if err != nil {
-					r.Log.Warnf("Error by extracting node IP from node ID %v due to: %v", nodeID, err)
-				} else {
-					rb := &remoteBackend{
-						ip:             backend.IP,
-						nodeID:         nodeID,
-						nodeIP:         nodeIP,
-						useHostNetwork: backend.HostNetwork,
-					}
-					remoteBackends[rb.Key()] = rb
-				}
+	// collecting/transforming needed information
+	localBackends, remoteBackends, hasHostNetworkLocalBackend := r.collectBackendInfo(service)
+	var hostNetworkLocalBackendInOtherServices bool
+	otherServiceLocalBackends := make(map[localBackendKey]*localBackend)
+	if oper == serviceDel {
+		for _, otherService := range otherExistingServices {
+			otherLocalBackends, _, otherHostLocalBackend := r.collectBackendInfo(otherService)
+			hostNetworkLocalBackendInOtherServices = hostNetworkLocalBackendInOtherServices || otherHostLocalBackend
+			for k, v := range otherLocalBackends {
+				otherServiceLocalBackends[k] = v
 			}
 		}
 	}
@@ -386,15 +337,18 @@ func (r *Renderer) renderService(service *renderer.ContivService, oper operation
 		}
 
 		// adding LocalSID
-		localSID := &vpp_srv6.LocalSID{
-			Sid:               r.IPAM.SidForServicePodLocalsid(backend.ip).String(),
-			InstallationVrfId: r.ContivConf.GetRoutingConfig().PodVRFID,
-			EndFunction: &vpp_srv6.LocalSID_EndFunction_DX6{EndFunction_DX6: &vpp_srv6.LocalSID_EndDX6{
-				NextHop:           backend.ip.String(),
-				OutgoingInterface: vppIfName,
-			}},
+		_, usedInOtherService := otherServiceLocalBackends[backend.Key()]
+		if !(oper == serviceDel && usedInOtherService) { // don't delete local sid if it is used in other service
+			localSID := &vpp_srv6.LocalSID{
+				Sid:               r.IPAM.SidForServicePodLocalsid(backend.ip).String(),
+				InstallationVrfId: r.ContivConf.GetRoutingConfig().PodVRFID,
+				EndFunction: &vpp_srv6.LocalSID_EndFunction_DX6{EndFunction_DX6: &vpp_srv6.LocalSID_EndDX6{
+					NextHop:           backend.ip.String(),
+					OutgoingInterface: vppIfName,
+				}},
+			}
+			addDelConfig[models.Key(localSID)] = localSID
 		}
-		addDelConfig[models.Key(localSID)] = localSID
 
 		for _, serviceIP := range serviceIPs {
 			// assign serviceIPs on the backend pod loopbacks
@@ -448,7 +402,7 @@ func (r *Renderer) renderService(service *renderer.ContivService, oper operation
 		// policy in main vrf table -> no need to for inter-vrf table route like in ipv6 renderer
 
 		// from main VRF to host (create localsid with decapsulation and crossconnect to the host (DX6 end function))
-		if !(oper == serviceDel && r.isHostNetworkLocalBackendSharedWith(otherExistingServices)) { // don't delete host network local sid if it is used in other service
+		if !(oper == serviceDel && hostNetworkLocalBackendInOtherServices) { // don't delete host network local sid if it is used in other services
 			nextHop := r.IPAM.HostInterconnectIPInLinux()
 			if r.ContivConf.InSTNMode() {
 				nextHop, _ = r.IPNet.GetNodeIP()
@@ -468,17 +422,70 @@ func (r *Renderer) renderService(service *renderer.ContivService, oper operation
 	return addDelConfig, updateConfig
 }
 
-func (r *Renderer) isHostNetworkLocalBackendSharedWith(services []*renderer.ContivService) bool {
-	for _, service := range services {
-		for servicePortName := range service.Ports {
-			for _, backend := range service.Backends[servicePortName] {
-				if backend.Local && backend.HostNetwork {
-					return true
+func (r *Renderer) collectBackendInfo(service *renderer.ContivService) (map[localBackendKey]*localBackend, map[remoteBackendKey]*remoteBackend, bool) {
+	localBackends := make(map[localBackendKey]*localBackend, 0)
+	hasHostNetworkLocalBackend := false
+	remoteBackends := make(map[remoteBackendKey]*remoteBackend, 0)
+
+	for servicePortName, servicePort := range service.Ports {
+		for _, backend := range service.Backends[servicePortName] {
+			if backend.Local {
+				// collect local backend info
+				if backend.HostNetwork {
+					hasHostNetworkLocalBackend = true
+					lb := &localBackend{
+						useHostNetwork: true,
+						ip:             backend.IP,
+					}
+					localBackends[lb.Key()] = lb
+				} else {
+					lb := &localBackend{ip: backend.IP}
+					if servicePort.Port != backend.Port {
+						previousForwards := lb.portForwards
+						if previousLB, exists := localBackends[lb.Key()]; exists {
+							previousForwards = previousLB.portForwards
+						}
+						lb.portForwards = append(previousForwards, &portForward{
+							proto: servicePort.Protocol,
+							from:  servicePort.Port,
+							to:    backend.Port,
+						})
+					}
+					localBackends[lb.Key()] = lb
+				}
+			} else {
+				// collect remote backend info
+				var nodeID uint32
+				var err error
+				if backend.HostNetwork {
+					nodeID, err = r.nodeIDFromNodeOrHostIP(backend.IP)
+					if err != nil {
+						r.Log.Warnf("Error by extracting node ID from host IP: %v", err)
+						continue
+					}
+				} else {
+					nodeID, err = r.IPAM.NodeIDFromPodIP(backend.IP)
+					if err != nil {
+						r.Log.Warnf("Error by extracting node ID from pod ID: %v", err)
+						continue
+					}
+				}
+				nodeIP, _, err := r.IPAM.NodeIPAddress(nodeID)
+				if err != nil {
+					r.Log.Warnf("Error by extracting node IP from node ID %v due to: %v", nodeID, err)
+				} else {
+					rb := &remoteBackend{
+						ip:             backend.IP,
+						nodeID:         nodeID,
+						nodeIP:         nodeIP,
+						useHostNetwork: backend.HostNetwork,
+					}
+					remoteBackends[rb.Key()] = rb
 				}
 			}
 		}
 	}
-	return false
+	return localBackends, remoteBackends, hasHostNetworkLocalBackend
 }
 
 // getPodPFRuleChain returns the config of the pod-local iptables rule chain of given chain type -


### PR DESCRIPTION
Problem explain:
Localsids are identified by SID that are computed from configurable prefix and service backend's ip address. That means that in some cases, services can share the same localsid. So when SRv6-rendered service is removed, SRv6 localsids are removed too. Even those that are still need by other services. That causes packet drops for those services. 
Fix (content of this PR):
Remove only localsids that are not used in other SRv6-rendered services.