### PR TITLE
 service endpoint support for secondary interfaces

### DIFF
--- a/docs/operation/CUSTOM_POD_INTERFACES.md
+++ b/docs/operation/CUSTOM_POD_INTERFACES.md
@@ -23,6 +23,10 @@ format. The `<network>` part is optional, leaving it unspecified means the defau
 network. Apart from the default pod network, only a special `stub` network is 
 currently supported, which leaves the interface without any IP address and routes pointing to it.
 
+K8s service traffic can be also redirected towards custom interfaces using the `contivpp.io/service-endpoint-if` 
+pod annotation, where the value should refer to the name of a custom interface in the default pod network.
+An example of this feature can be found in the [k8s example folder](../../k8s/examples/memif).
+
 An example of a pod definition that connects a pod with a default interface plus one 
 extra tap interface with the name `tap1` and one extra veth interface with the name `veth1`:
 

--- a/k8s/examples/memif/README.md
+++ b/k8s/examples/memif/README.md
@@ -1,0 +1,69 @@
+# Memif interface usage in Contiv-VPP
+
+This example showcases usage of a memif interface in a pod, including redirecting of k8s service traffic
+towards the memif interface instead of the default pod interface using the `contivpp.io/service-endpoint-if` 
+pod annotation.
+
+For more information on multi-interface pods in Contiv-VPP, look at the 
+[custom pod interfaces documentation](../../../docs/operation/CUSTOM_POD_INTERFACES.md).
+
+## Demo
+This folder contains two yaml files:
+  - [memif-pod.yaml](memif-pod.yaml) is a pod definition requesting an additional
+memif interface (`contivpp.io/custom-if: memif1/memif`) and routing k8s service endpoint traffic
+towards that interface (`contivpp.io/service-endpoint-if: memif1`). This pod will run a VPP within it,
+and the memif interface will be connected to this VPP instance.
+  - [memif-svc.yaml](memif-svc.yaml) defines a k8s service for web traffic destined to the memif pod
+
+Start by deploying them:
+ ```bash
+kubectl apply -f memif-pod.yaml
+kubectl apply -f memif-svc.yaml
+```
+
+Verify that `memif-pod` is running:
+```bash
+$ kubectl get pods -o wide
+NAME                    READY   STATUS    RESTARTS   AGE     IP         NODE      NOMINATED NODE   READINESS GATES
+memif-pod               1/1     Running   0          7m49s   10.1.1.4   lubuntu   <none>           <none>
+```
+
+Verify that memif on the pod VPP is configured with an IP address from the default pod subnet and
+enable HTTP server on this VPP (`test http server` CLI command):
+```bash
+ kubectl exec -it memif-pod -- vppctl -s :5002
+    _______    _        _   _____  ___ 
+ __/ __/ _ \  (_)__    | | / / _ \/ _ \
+ _/ _// // / / / _ \   | |/ / ___/ ___/
+ /_/ /____(_)_/\___/   |___/_/  /_/    
+
+vpp# sh inter addr
+local0 (dn):
+memif0/0 (up):
+  L3 10.1.1.5/32
+vpp# 
+vpp# test http server
+vpp# quit
+```
+
+Now check that `memif-service` is deployed and retrieve its cluster IP address:
+```bash
+ kubectl get svc
+NAME            TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
+memif-service   ClusterIP   10.99.12.224   <none>        80/TCP    3m57s
+```
+
+Start a new pod and try accessing the cluster IP address from it using the `curl` tool. VPP should
+respond with CLI output of the command encoded in the requested URL:
+```bash
+kubectl run -it curl --image=appropriate/curl sh
+/ # curl 10.99.12.224/sh/inter/addr
+
+<html><head><title>sh inter addr</title></head><link rel="icon" href="data:,"><body><pre>local0 (dn):
+memif0/0 (up):
+  L3 10.1.1.5/32
+</pre></body></html>
+```
+
+This confirms that request to the service's cluster IP (`10.99.12.224`) has been served by the
+pod over the memif interface connected to VPP running in the pod.

--- a/k8s/examples/memif/memif-pod.yaml
+++ b/k8s/examples/memif/memif-pod.yaml
@@ -1,0 +1,52 @@
+---
+# This config maps tells the vpp-agent running in the memif-pod how to connect to ETCD
+# from where the VPP agent gets its memif configuration.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-cfg
+  labels:
+    name: etcd-cfg
+  namespace: default
+data:
+  etcd.conf: |
+    insecure-transport: true
+    dial-timeout: 10000000000
+    allow-delayed-start: true
+    endpoints:
+      - "contiv-etcd.kube-system.svc.cluster.local:12379"
+
+---
+# Memif pod definition. Pod is connected with one additional memif interface
+# in the "default" pod network = IP address assigned from the standard pod subnet.
+# The "service-endpoint-if" annotation tells Contiv to route all k8s service endpoint traffic
+# destined to this pod towards the memif interfaces instead of the primary pod interface.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: memif-pod
+  annotations:
+    contivpp.io/custom-if: memif1/memif
+    contivpp.io/service-endpoint-if: memif1
+    contivpp.io/microservice-label: memif-pod
+  labels:
+    app: memif-pod
+spec:
+  containers:
+    - name: vpp-agent
+      image: ligato/vpp-agent:latest
+      env:
+        - name: ETCD_CONFIG
+          value: "/etc/etcd/etcd.conf"
+        - name: MICROSERVICE_LABEL
+          value: memif-pod
+      resources:
+        limits:
+          contivpp.io/memif: 1
+      volumeMounts:
+        - name: etcd-cfg
+          mountPath: /etc/etcd
+  volumes:
+    - name: etcd-cfg
+      configMap:
+        name: etcd-cfg

--- a/k8s/examples/memif/memif-svc.yaml
+++ b/k8s/examples/memif/memif-svc.yaml
@@ -1,0 +1,12 @@
+---
+# K8s service for web traffic destined to the memif pods
+apiVersion: v1
+kind: Service
+metadata:
+  name: memif-service
+spec:
+  selector:
+    app: memif-pod
+  ports:
+  - protocol: TCP
+    port: 80

--- a/k8s/examples/memif/memif-svc.yaml
+++ b/k8s/examples/memif/memif-svc.yaml
@@ -8,5 +8,5 @@ spec:
   selector:
     app: memif-pod
   ports:
-  - protocol: TCP
-    port: 80
+    - protocol: TCP
+      port: 80

--- a/plugins/ipam/ipam.go
+++ b/plugins/ipam/ipam.go
@@ -146,9 +146,13 @@ func (i *IPAM) Init() (err error) {
 	// register REST handlers
 	i.registerRESTHandlers()
 
+	return nil
+}
+
+// AfterInit initializes the DB broker.
+func (i *IPAM) AfterInit() error {
 	// init DB broker
 	i.dbBroker = i.RemoteDB.NewBroker(servicelabel.GetDifferentAgentPrefix(ksr.MicroserviceLabel))
-
 	return nil
 }
 

--- a/plugins/ipam/ipam_api.go
+++ b/plugins/ipam/ipam_api.go
@@ -85,7 +85,7 @@ type API interface {
 	GetPodIP(podID podmodel.ID) *net.IPNet
 
 	// AllocatePodCustomIfIP tries to allocate custom IP address for the given interface of a given pod.
-	AllocatePodCustomIfIP(podID podmodel.ID, ifName, network string) (net.IP, error)
+	AllocatePodCustomIfIP(podID podmodel.ID, ifName, network string, isServiceEndpoint bool) (net.IP, error)
 
 	// GetPodCustomIfIP returns the allocated custom interface pod IP, together with the mask.
 	// Returns nil if the pod does not have allocated custom interface IP address.

--- a/plugins/service/plugin_impl_service.go
+++ b/plugins/service/plugin_impl_service.go
@@ -15,6 +15,7 @@
 package service
 
 import (
+	"github.com/contiv/vpp/plugins/ipam/ipalloc"
 	"strings"
 
 	"github.com/contiv/vpp/plugins/statscollector"
@@ -206,6 +207,8 @@ func (p *Plugin) HandlesEvent(event controller.Event) bool {
 		case epmodel.EndpointsKeyword:
 			return true
 		case svcmodel.ServiceKeyword:
+			return true
+		case ipalloc.Keyword:
 			return true
 		default:
 			// unhandled Kubernetes state change

--- a/plugins/service/processor/processor_impl.go
+++ b/plugins/service/processor/processor_impl.go
@@ -17,6 +17,7 @@
 package processor
 
 import (
+	"github.com/contiv/vpp/plugins/ipam/ipalloc"
 	"strings"
 
 	"github.com/ligato/cn-infra/logging"
@@ -34,6 +35,10 @@ import (
 	"github.com/contiv/vpp/plugins/service/renderer"
 )
 
+const (
+	defaultPodNetwork = "default" // name of the default pod network
+)
+
 // ServiceProcessor implements ServiceProcessorAPI.
 type ServiceProcessor struct {
 	Deps
@@ -41,8 +46,9 @@ type ServiceProcessor struct {
 	renderers []renderer.ServiceRendererAPI
 
 	/* internal maps */
-	services map[svcmodel.ID]*Service
-	localEps map[podmodel.ID]*LocalEndpoint
+	services    map[svcmodel.ID]*Service
+	localEps    map[podmodel.ID]*LocalEndpoint
+	epRedirects map[string]string
 
 	/* local frontend and backend interfaces */
 	frontendIfs renderer.Interfaces
@@ -62,8 +68,9 @@ type Deps struct {
 
 // LocalEndpoint represents a node-local endpoint.
 type LocalEndpoint struct {
-	ifName   string
-	svcCount int /* number of services running on this endpoint. */
+	ifName     string   /* main interface name used as the pod service front-end and (optionally) back-end */
+	secIfNames []string /* secondary interfaces used as service front-ends (may be empty, used for multi-interface pods) */
+	svcCount   int      /* number of services running on this endpoint. */
 }
 
 // Init initializes service processor.
@@ -81,6 +88,7 @@ func (sp *ServiceProcessor) AfterInit() error {
 func (sp *ServiceProcessor) reset() error {
 	sp.services = make(map[svcmodel.ID]*Service)
 	sp.localEps = make(map[podmodel.ID]*LocalEndpoint)
+	sp.epRedirects = make(map[string]string)
 	sp.frontendIfs = renderer.NewInterfaces()
 	sp.backendIfs = renderer.NewInterfaces()
 	return nil
@@ -193,12 +201,16 @@ func (sp *ServiceProcessor) ProcessDeletingPod(podNamespace string, podName stri
 	}
 	newFrontendIfs := sp.frontendIfs.Copy()
 	newFrontendIfs.Del(ifName)
+	for _, iface := range sp.localEps[podID].secIfNames {
+		newFrontendIfs.Del(iface)
+	}
 	for _, renderer := range sp.renderers {
 		/* ignore errors */
 		renderer.UpdateLocalFrontendIfs(sp.frontendIfs, newFrontendIfs)
 	}
 	sp.frontendIfs = newFrontendIfs
 	delete(sp.localEps, podID)
+
 	return nil
 }
 
@@ -237,6 +249,127 @@ func (sp *ServiceProcessor) processDeletedEndpoints(epsID epmodel.ID) error {
 	oldBackends := svc.GetLocalBackends()
 	svc.SetEndpoints(nil)
 	return sp.renderService(svc, oldContivSvc, oldBackends)
+}
+
+func (sp *ServiceProcessor) processCustomIPAlloc(alloc *ipalloc.CustomIPAllocation) error {
+
+	sp.Log.WithFields(logging.Fields{
+		"alloc": alloc,
+	}).Debug("ServiceProcessor - processCustomIPAlloc()")
+
+	updateFrontendIfs, updateBackendIfs, err := sp.applyCustomIPAlloc(alloc)
+	if err != nil {
+		sp.Log.Errorf("Error by applying custom IP allocation %v", err)
+		return nil
+	}
+
+	oldFrontendIfs := sp.frontendIfs.Copy()
+	oldBackendIfs := sp.backendIfs.Copy()
+
+	// update frontend interfaces
+	if updateFrontendIfs {
+		for _, renderer := range sp.renderers {
+			err := renderer.UpdateLocalFrontendIfs(oldFrontendIfs, sp.frontendIfs)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// update backend interfaces
+	if updateBackendIfs {
+		for _, renderer := range sp.renderers {
+			err := renderer.UpdateLocalBackendIfs(oldBackendIfs, sp.backendIfs)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// lookup for affected services & re-render them
+	podID := podmodel.ID{Name: alloc.PodName, Namespace: alloc.PodNamespace}
+	pod := sp.PodManager.GetPods()[podID]
+	if pod == nil {
+		return nil
+	}
+	affectedServices := sp.getServicesForBackend(pod)
+	for _, svc := range affectedServices {
+		oldContivSvc := svc.GetContivService()
+		oldBackends := svc.GetLocalBackends()
+		svc.refreshed = false
+		err := sp.renderService(svc, oldContivSvc, oldBackends)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (sp *ServiceProcessor) applyCustomIPAlloc(alloc *ipalloc.CustomIPAllocation) (
+	updateFrontendIfs, updateBackendIfs bool, err error) {
+
+	podID := podmodel.ID{Name: alloc.PodName, Namespace: alloc.PodNamespace}
+	pod := sp.PodManager.GetPods()[podID]
+	if pod == nil || pod.IPAddress == "" {
+		return
+	}
+	_, isLocal := sp.PodManager.GetLocalPods()[podID]
+
+	redirected := false
+	var serviceEndpointIf *ipalloc.CustomPodInterface
+	for _, ci := range alloc.CustomInterfaces {
+		if ci.ServiceEndpoint {
+			// mark service endpoint redirect for this pod
+			sp.Log.Debugf("Service endpoint for pod %s (%s) will be redirected to interface %s (%s)",
+				podID.String(), pod.IPAddress, ci.Name, ci.IpAddress)
+
+			sp.epRedirects[pod.IPAddress] = ci.IpAddress
+			serviceEndpointIf = ci
+			redirected = true
+		}
+		if isLocal && ci.Network == defaultPodNetwork || ci.Network == "" {
+			// for local pod interfaces in the default pod network, update frontend interfaces
+			ifName, ifExists := sp.IPNet.GetPodCustomIfName(podID.Namespace, podID.Name, ci.Name)
+			if !ifExists {
+				sp.Log.Warnf("Unable to obtain interface name for interface %v, skipping frontend if update", ci)
+				continue
+			}
+			sp.Log.Debugf("Adding pod %s interface %s into service front-end ifs", podID.String(), ifName)
+			localEp := sp.getLocalEndpoint(podID)
+			localEp.secIfNames = append(localEp.secIfNames, ifName)
+			// add the interface to frontend interfaces
+			sp.frontendIfs.Add(ifName)
+			updateFrontendIfs = true
+		}
+	}
+
+	if redirected {
+		if isLocal && serviceEndpointIf != nil {
+			// for local pods with service redirect, update backend interfaces
+			ifName, ifExists := sp.IPNet.GetPodCustomIfName(podID.Namespace, podID.Name, serviceEndpointIf.Name)
+			if !ifExists {
+				sp.Log.Warnf("Unable to obtain interface name for interface %s, skipping backend if update",
+					serviceEndpointIf.Name)
+				return
+			}
+			localEp := sp.getLocalEndpoint(podID)
+			if localEp.ifName != ifName {
+				// switch the main endpoint interface name with the custom interface name
+				oldIfName := localEp.ifName
+				localEp.secIfNames = append(localEp.secIfNames, oldIfName)
+				localEp.ifName = ifName
+				if localEp.svcCount > 0 {
+					sp.Log.Debugf("Adding pod %s interface %s into service backend-end ifs", podID.String(), ifName)
+					sp.backendIfs.Del(oldIfName)
+					sp.backendIfs.Add(ifName)
+					updateBackendIfs = true
+				}
+			}
+		}
+	}
+
+	return
 }
 
 func (sp *ServiceProcessor) processNewService(service *svcmodel.Service) error {
@@ -469,6 +602,11 @@ func (sp *ServiceProcessor) processResyncEvent(resyncEv *ResyncEventData) error 
 		svc.SetMetadata(service)
 	}
 
+	// -> custom IP allocations
+	for _, alloc := range resyncEv.IPAllocations {
+		sp.applyCustomIPAlloc(alloc)
+	}
+
 	// Iterate over services with complete data to get backend interfaces.
 	for _, svc := range sp.services {
 		contivSvc := svc.GetContivService()
@@ -518,4 +656,20 @@ func (sp *ServiceProcessor) getLocalEndpoint(podID podmodel.ID) *LocalEndpoint {
 		sp.localEps[podID] = &LocalEndpoint{}
 	}
 	return sp.localEps[podID]
+}
+
+func (sp *ServiceProcessor) getServicesForBackend(pod *podmanager.Pod) []*Service {
+	services := make([]*Service, 0)
+
+	for _, service := range sp.services {
+		for _, ep := range service.endpoints.EndpointSubsets {
+			for _, addr := range ep.Addresses {
+				if addr.Ip == pod.IPAddress {
+					services = append(services, service)
+				}
+			}
+		}
+	}
+
+	return services
 }

--- a/plugins/service/processor/service.go
+++ b/plugins/service/processor/service.go
@@ -170,6 +170,9 @@ func (s *Service) Refresh() {
 				}).Warn("Failed to parse endpoint IP")
 				continue
 			}
+			if redirIP, isRedirected := s.sp.epRedirects[epAddr.GetIp()]; isRedirected {
+				epIP = net.ParseIP(redirIP)
+			}
 			if s.sp.IPAM.PodSubnetThisNode().Contains(epIP) {
 				local = true
 			}


### PR DESCRIPTION
This PR allows defining service endpoint interface for pods with multiple interfaces. This way, endpoint of a k8s service may e.g. an application using a memif interface to communicate with the vswitch.