### PR TITLE
Add multi-arch support for contivvpp images

### DIFF
--- a/docker/push-all.sh
+++ b/docker/push-all.sh
@@ -150,6 +150,7 @@ then
     docker images | fgrep "${TAG}" | awk '{print $3}' | sort -u | xargs docker rmi -f || true
     docker images | fgrep "${VPP}" | awk '{print $3}' | sort -u | xargs docker rmi -f || true
 fi
+
 #Before push, 'docker login' is needed
 push_multi_arch(){
 

--- a/docker/push-all.sh
+++ b/docker/push-all.sh
@@ -51,7 +51,7 @@ LINUX_ARCH=(amd64 arm64)
 PLATFORMS=linux/${LINUX_ARCH[0]}
 for i in $(seq 1  $[${#LINUX_ARCH[@]}-1])
 do
-PLATFORMS=$PLATFORMS,linux/${LINUX_ARCH[$i]}
+    PLATFORMS=$PLATFORMS,linux/${LINUX_ARCH[$i]}
 done
 
 # override defaults from arguments
@@ -167,11 +167,10 @@ push_multi_arch(){
          if [ "${DEV_UPLOAD}" != "true" ] && [ "$IMAGE" == contivvpp/dev* ]; then
             continue
          fi
-	 set -x
          ./manifest-tool push from-args --platforms ${PLATFORMS} --template contivvpp/${IMAGE}-ARCH:${BRANCH_TAG} \
                 --target contivvpp/${IMAGE}:${BRANCH_TAG}
-         ./manifest-tool push from-args --platforms $(PLATFORMS) --template contivvpp/${IMAGE}-ARCH:${BRANCH_ADV_TAG}${TAG}-${VPP} \
-               --target contivvpp/${IMAGE}:${BRANCH_ADV_TAG}${TAG}-${VPP}
+         ./manifest-tool push from-args --platforms ${PLATFORMS} --template contivvpp/${IMAGE}-ARCH:${BRANCH_ADV_TAG}${TAG}-${VPP} \
+                --target contivvpp/${IMAGE}:${BRANCH_ADV_TAG}${TAG}-${VPP}
        done
 }
 


### PR DESCRIPTION
Now the Contiv/VPP images supports both x86_64(amd64) and aarch64(arm64) platforms at the same time in the repo, so it's time to add multi-arch support for contivpp images by enabling
fat-manifest of images which would facilitate the installation and verification of Contiv/VPP.

With the support, a simple image name as contivvpp/${image}:${tag}
can be used in pulling the right images for the matched x86_64 or
aarch64 platform.
It would also simply the deployment of Contiv/VPP in k8s environment.
