### PR TITLE
bump Jool nat64 version ip IPv6 deployments

### DIFF
--- a/vagrant/provision/provision_gateway.sh
+++ b/vagrant/provision/provision_gateway.sh
@@ -11,7 +11,7 @@ if [ "${ip_version}" == "ipv6" ]; then
 
    echo "Downloading Jool"
    git clone https://github.com/NICMx/Jool.git
-   cd /home/vagrant/Jool && git checkout v3.5.7
+   cd /home/vagrant/Jool && git checkout v3.5.8
    echo "Installing Jool kernel modules"
   ( cd /home/vagrant/ && sudo dkms install Jool )
 


### PR DESCRIPTION
old version does not compile on newer ubuntu18

Signed-off-by: samuel.elias <samelias@cisco.com>