### PR TITLE
Properly handle routes for custom interfaces

### DIFF
--- a/plugins/ipnet/pod.go
+++ b/plugins/ipnet/pod.go
@@ -395,6 +395,13 @@ func (n *IPNet) getOrAllocatePodCustomIfIP(pod *podmanager.LocalPod, customIf *p
 func (n *IPNet) linuxPodL3CustomIfConfig(pod *podmanager.LocalPod, customIf *podCustomIfInfo) controller.KeyValuePairs {
 	config := make(controller.KeyValuePairs)
 
+	if n.isDefaultPodNetwork(customIf.ifNet) {
+		// Do not configure routes / ARP for interface in default network,
+		// since they are already present on the main pod interface.
+		// Linux does not allow multiple link-scope routes for the same destination IP.
+		return config
+	}
+
 	// ARP entry for the GW
 	key, podArp := n.podToVPPArpEntry(pod, customIf.ifName, customIf.ifType, customIf.ifNet)
 	config[key] = podArp

--- a/plugins/ipnet/pod.go
+++ b/plugins/ipnet/pod.go
@@ -406,7 +406,7 @@ func (n *IPNet) linuxPodL3CustomIfConfig(pod *podmanager.LocalPod, customIf *pod
 		// configure routes / ARP for interfaces in non-default networks only once per pod
 		return config
 	}
-	customNwCounter[customIf.ifNet] += 1
+	customNwCounter[customIf.ifNet]++
 
 	// ARP entry for the GW
 	key, podArp := n.podToVPPArpEntry(pod, customIf.ifName, customIf.ifType, customIf.ifNet)


### PR DESCRIPTION
- for custom interfaces in default network, do not configure routes towards the pod subnet / gateway, as they are already configured via the primary pod interface
- for custom interfaces in non-default L3 network, configure routes towards the custom network subnet / gateway only once per pod (on the first custom interface in the given network)