### PR TITLE
Selectively remove CNI Contiv configuration file

### DIFF
--- a/docker/vpp-cni/install.sh
+++ b/docker/vpp-cni/install.sh
@@ -17,6 +17,7 @@
 # Defaults can be overridden via environment variables.
 HOST_CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin}
 HOST_CNI_NET_DIR=${CNI_NET_DIR:-/etc/cni/net.d}
+HOST_CNI_CONFIG_FILE=${CNI_CONFIG_FILE:-10-contiv-vpp.conflist}
 HOST_LOG_FILE=${HOST_LOG_FILE:-/var/run/contiv/cni.log}
 
 # Install loopback CNI binary if it does not exist yet.
@@ -36,7 +37,7 @@ cp /cni/bin/portmap ${HOST_CNI_BIN_DIR}
 
 # Erase all existing CNI config files.
 echo "Erasing old CNI config in ${HOST_CNI_NET_DIR}"
-rm -rf ${HOST_CNI_NET_DIR}/*
+rm -f ${HOST_CNI_NET_DIR}/${HOST_CNI_CONFIG_FILE}
 
 # Install our CNI config files.
 echo "Installing new CNI config to ${HOST_CNI_NET_DIR}"


### PR DESCRIPTION
Added variable to specify which configuration file that the contiv-cni container should clean up rather than everything. See #1670 for discussion.

Let me know if you would like it done in some other way. I tried following the way you clean up the host log file.