### PR TITLE
Fix external interfaces for l2xconn renderer

### DIFF
--- a/plugins/sfc/processor/processor_impl.go
+++ b/plugins/sfc/processor/processor_impl.go
@@ -472,8 +472,8 @@ func (sp *SFCProcessor) renderServiceFunctionPod(f *sfcmodel.ServiceFunctionChai
 
 	// look for matching pods
 	for podID, pod := range sp.PodManager.GetPods() {
-		inputIfLogicalName := inputIfCRDName   // interface name that will be use in VPP
-		outputIfLogicalName := outputIfCRDName // interface name that will be use in VPP
+		inputIfConfigName := inputIfCRDName   // interface name that will be used in VPP
+		outputIfConfigName := outputIfCRDName // interface name that will be used in VPP
 		if sp.podMatchesSelector(pod, f.PodSelector) {
 			if deletedPod != nil && deletedPod.ID == podID {
 				continue
@@ -488,14 +488,14 @@ func (sp *SFCProcessor) renderServiceFunctionPod(f *sfcmodel.ServiceFunctionChai
 				// process interface names to actual pod interface names
 				exists := false
 				if inputIfCRDName != "" {
-					inputIfLogicalName, _, exists = sp.IPNet.GetPodCustomIfNames(
+					inputIfConfigName, _, exists = sp.IPNet.GetPodCustomIfNames(
 						pod.ID.Namespace, pod.ID.Name, inputIfCRDName)
 					if !exists {
 						continue
 					}
 				}
 				if outputIfCRDName != "" {
-					outputIfLogicalName, _, exists = sp.IPNet.GetPodCustomIfNames(
+					outputIfConfigName, _, exists = sp.IPNet.GetPodCustomIfNames(
 						pod.ID.Namespace, pod.ID.Name, outputIfCRDName)
 					if !exists {
 						continue
@@ -508,12 +508,12 @@ func (sp *SFCProcessor) renderServiceFunctionPod(f *sfcmodel.ServiceFunctionChai
 				NodeID: nodeID,
 				Local:  isLocal,
 				InputInterface: &renderer.InterfaceNames{
-					LogicalName: inputIfLogicalName,
-					CRDName:     inputIfCRDName,
+					ConfigName: inputIfConfigName,
+					CRDName:    inputIfCRDName,
 				},
 				OutputInterface: &renderer.InterfaceNames{
-					LogicalName: outputIfLogicalName,
-					CRDName:     outputIfCRDName,
+					ConfigName: outputIfConfigName,
+					CRDName:    outputIfCRDName,
 				},
 			})
 		}
@@ -568,10 +568,12 @@ func (sp *SFCProcessor) renderServiceFunctionInterface(f *sfcmodel.ServiceFuncti
 			nodeID = node.ID
 		}
 		sfIfs = append(sfIfs, &renderer.InterfaceSF{
-			InterfaceName:    sp.IPNet.GetExternalIfName(extIf.Name, nodeIf.Vlan),
-			VppInterfaceName: nodeIf.VppInterfaceName,
-			NodeID:           nodeID,
-			Local:            local,
+			InterfaceNames: renderer.InterfaceNames{
+				CRDName:    extIf.Name,
+				ConfigName: sp.IPNet.GetExternalIfName(nodeIf.VppInterfaceName, nodeIf.Vlan),
+			},
+			NodeID: nodeID,
+			Local:  local,
 		})
 	}
 

--- a/plugins/sfc/renderer/api.go
+++ b/plugins/sfc/renderer/api.go
@@ -1,7 +1,8 @@
 /*
  * // Copyright (c) 2019 Cisco and/or its affiliates.
- * // Other Contributors: 1. Adel Bouridah Centre Universitaire Abdelhafid Boussouf Mila - Algerie a.bouridah@centre-univ-mila.dz
- * // 2. Nadjib Aitsaadi Universite Paris Est Creteil, nadjib.aitsaadi@u-pec.fr
+ * // Other Contributors:
+ * //    1. Adel Bouridah Centre Universitaire Abdelhafid Boussouf Mila - Algerie a.bouridah@centre-univ-mila.dz
+ * //    2. Nadjib Aitsaadi Universite Paris Est Creteil, nadjib.aitsaadi@u-pec.fr
  * // Licensed under the Apache License, Version 2.0 (the "License");
  * // you may not use this file except in compliance with the License.
  * // You may obtain a copy of the License at:
@@ -161,26 +162,27 @@ func (pod PodSF) String() string {
 		pod.ID, pod.NodeID, pod.Local, pod.InputInterface, pod.OutputInterface)
 }
 
-// InterfaceNames is container for multiple names for one interface
+// InterfaceNames is container for multiple logical names assigned to one interface (k8s vs. vpp-agent namespace).
 type InterfaceNames struct {
-	// LogicalName for local pods, LogicalName contain actual pod interface name which can be used for configuration
-	// without further processing. LogicalName for non-local pods contain name from CRD.
-	LogicalName string
-	// CRDName is name of the interface as it came from CRD
+	// ConfigName contains the logical interface name used in the namespace of the configuration for
+	// the underlying vpp-agent.
+	//
+	// For non-local pods, it contains the name from CRD.  (TODO: is this special case really needed?)
+	ConfigName string
+	// CRDName is name of the interface as it came from CRD.
 	CRDName string
 }
 
 // String converts InterfaceNames into a human-readable string.
 func (in InterfaceNames) String() string {
-	return fmt.Sprintf("<LogicalName: %s, CRDName: %s>", in.LogicalName, in.CRDName)
+	return fmt.Sprintf("<ConfigName: %s, CRDName: %s>", in.ConfigName, in.CRDName)
 }
 
 // InterfaceSF represents an interface-type service function.
 type InterfaceSF struct {
-	// InterfaceName contains name of the interface to/from which the traffic flows
-	// (can be used for the configuration without further processing).
-	InterfaceName    string // name of the vpp interface attached to this external interface
-	VppInterfaceName string // true if this is a node-local interface
+	// External Interface name as defined in CRD vs. the actual interface name used inside the configuration
+	// for the vpp-agent.
+	InterfaceNames
 
 	NodeID uint32 // ID of the node where the interface resides
 	Local  bool   // true if this is a node-local interface
@@ -188,8 +190,8 @@ type InterfaceSF struct {
 
 // String converts InterfaceSF into a human-readable string.
 func (iface InterfaceSF) String() string {
-	return fmt.Sprintf("{InterfaceName: %s, NodeID: %d, Local:%v}",
-		iface.InterfaceName, iface.NodeID, iface.Local)
+	return fmt.Sprintf("{CRDName: %s, ConfigName: %s, NodeID: %d, Local:%v}",
+		iface.CRDName, iface.ConfigName, iface.NodeID, iface.Local)
 }
 
 // ResyncEventData wraps an entire state of K8s services as provided by the Processor.

--- a/plugins/sfc/renderer/l2xconn/l2xconn_renderer.go
+++ b/plugins/sfc/renderer/l2xconn/l2xconn_renderer.go
@@ -265,16 +265,16 @@ func (rndr *Renderer) getSFInterface(sf *renderer.ServiceFunction, input bool) s
 			return ""
 		}
 		if input {
-			return pod.InputInterface.LogicalName
+			return pod.InputInterface.ConfigName
 		}
-		return pod.OutputInterface.LogicalName
+		return pod.OutputInterface.ConfigName
 
 	case renderer.ExternalInterface:
 		iface := rndr.getPreferredSFInterface(sf)
 		if iface == nil {
 			return ""
 		}
-		return iface.InterfaceName
+		return iface.ConfigName
 	}
 	return ""
 }

--- a/plugins/sfc/renderer/srv6/srv6_renderer_test.go
+++ b/plugins/sfc/renderer/srv6/srv6_renderer_test.go
@@ -451,7 +451,7 @@ func sfcModel(sfc *renderer.ContivSFC) *sfcmodel.ServiceFunctionChain {
 			newSF.OutputInterface = link.Pods[0].OutputInterface.CRDName
 		case renderer.ExternalInterface:
 			newSF.Type = sfcmodel.ServiceFunctionChain_ServiceFunction_ExternalInterface
-			newSF.Interface = link.ExternalInterfaces[0].InterfaceName
+			newSF.Interface = link.ExternalInterfaces[0].CRDName
 		}
 		sfcModel.Chain = append(sfcModel.Chain, newSF)
 	}
@@ -822,9 +822,11 @@ func getPodToInterfaceChain(node Node) (sfc *renderer.ContivSFC) {
 	}
 
 	endExtIf := &renderer.InterfaceSF{
-		InterfaceName:    endExtIfName,
-		VppInterfaceName: endExtIfName,
-		NodeID:           WorkerID,
+		InterfaceNames: renderer.InterfaceNames{
+			ConfigName: endExtIfName,
+			CRDName:    endExtIfName,
+		},
+		NodeID: WorkerID,
 	}
 	sf4 := &renderer.ServiceFunction{
 		Type:               renderer.ExternalInterface,


### PR DESCRIPTION
The recent SRv6-related changes introduced a bug which caused that external interfaces would not be properly chained with l2xconn renderer. Specifically, the external interface name used in the configuration for xconnects was the CRD name itself, instead of the `vppInterfaceName` (`+.vlan` if defined). I believe this was also caused by a confusing naming for interfaces by SFC renderer: https://github.com/contiv/vpp/blob/dev/plugins/sfc/renderer/api.go#L165-L183

Both names in `InterfaceNames` are "logical", so I would avoid that label. To differentiate between the crd and vpp-agent namespaces, I would propose to use `ConfigName` instead of `LogicalName` and keep `CRDName` as is. I have applied the proposed change in this PR. Also, I decided to reuse `InterfaceNames` for `InterfaceSF`.

Also there is currently a special case in https://github.com/contiv/vpp/blob/dev/plugins/sfc/renderer/api.go#L167: "LogicalName for non-local pods contain name from CRD" (whereas for local pods it contains the config name)
I think it is not a good practice to re-use the same attribute for different purposes. There is already `Local  bool` attribute in `PodSF` that can be used to tell if the pod is local and decide which of the interface names to use in a particular case. But I didn't do any changes here since it relates to SRv6-renderer which I haven't familiarized myself with enough yet. 

Signed-off-by: Milan Lenco <milenco@cisco.com>