### PR TITLE
Optional CRD fields should not fail validation when undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ ui/node_modules
 .vagrant-state
 vagrant/config/cert
 vagrant/config/init
+crdgen

--- a/plugins/crd/pkg/apis/contivppio/v1/types.go
+++ b/plugins/crd/pkg/apis/contivppio/v1/types.go
@@ -43,7 +43,7 @@ type CustomNetwork struct {
 // CustomNetworkSpec is the spec for custom network configuration resource
 type CustomNetworkSpec struct {
 	Type                   string `json:"type"`
-	SubnetCIDR             string `json:"subnetCIDR"`
+	SubnetCIDR             string `json:"subnetCIDR,omitempty"`
 	SubnetOneNodePrefixLen uint32 `json:"subnetOneNodePrefixLen"`
 }
 
@@ -83,7 +83,7 @@ type ExternalInterfaceSpec struct {
 type NodeInterface struct {
 	Node             string `json:"node"`
 	VppInterfaceName string `json:"vppInterfaceName"`
-	IP               string `json:"ip"`
+	IP               string `json:"ip,omitempty"`
 	VLAN             uint32 `json:"vlan"`
 }
 

--- a/plugins/crd/scripts/update-codegen.sh
+++ b/plugins/crd/scripts/update-codegen.sh
@@ -18,12 +18,24 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../../..
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+# Set directory for dependency symlinks
+CRDGEN_DEPS_DIR="crdgen"
+mkdir -p $CRDGEN_DEPS_DIR
+
+# Remove any existing
+find "${CRDGEN_DEPS_DIR}" -type l -delete
+find "${CRDGEN_DEPS_DIR}" -type d -empty -delete
+
+# Create symlink to generator
+# TODO get version from the go.mod file
+module="k8s.io/code-generator@v0.0.0-20191004115455-8e001e5d1894"
+echo "setting up symplink for $module"
+go list -f "${CRDGEN_DEPS_DIR}/{{ .Path }}" -m $module | xargs -L1 dirname | sort | uniq | xargs mkdir -p
+go list -f "{{ .Dir }} ${CRDGEN_DEPS_DIR}/{{ .Path }}" -m $module | xargs -L1 -- ln -s
 
 # generate the code with:
-${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
+${CRDGEN_DEPS_DIR}/k8s.io/code-generator/generate-groups.sh "deepcopy,client,informer,lister" \
   github.com/contiv/vpp/plugins/crd/pkg/client \
   github.com/contiv/vpp/plugins/crd/pkg/apis \
   "telemetry:v1 nodeconfig:v1 contivppio:v1" \
-  --go-header-file ${SCRIPT_ROOT}/plugins/crd/scripts/custom-boilerplate.go.txt
+  --go-header-file plugins/crd/scripts/custom-boilerplate.go.txt


### PR DESCRIPTION
When CRD is configured programmatically via kubernetes client (as opposed to kubectl), every field will be included even if zero value was left out, unless the "omitempty" json tag is included. Zero value can potentially fail validation which is not desirable for optional fields.

Also plugins/crd/scripts/update-codegen.sh script needed to be updated after migration to go modules. The solution is a bit hacky but it is the best we could come up with so far...

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>