### PR TITLE
Fixed that l2 fibs for vxlan tunnel for custom-if are not added

### DIFF
--- a/plugins/ipnet/node.go
+++ b/plugins/ipnet/node.go
@@ -1032,10 +1032,16 @@ func (n *IPNet) vxlanArpEntry(network string, otherNodeID uint32, vxlanIP net.IP
 // vxlanFibEntry returns configuration for L2 FIB used inside the bridge domain with VXLANs
 // to route traffic destinated to the given other node through the right VXLAN interface.
 func (n *IPNet) vxlanFibEntry(network string, otherNodeID uint32) (key string, config *vpp_l2.FIBEntry) {
+	var vxlanName string
+	if network == "" || network == DefaultPodNetworkName {
+		vxlanName = defaultPodVxlanName
+	} else {
+		vxlanName = network
+	}
 	fib := &vpp_l2.FIBEntry{
 		BridgeDomain:            n.vxlanBDName(network),
 		PhysAddress:             hwAddrForNodeInterface(otherNodeID, vxlanBVIHwAddrPrefix),
-		OutgoingInterface:       n.nameForVxlanToOtherNode(defaultPodVxlanName, otherNodeID),
+		OutgoingInterface:       n.nameForVxlanToOtherNode(vxlanName, otherNodeID),
 		StaticConfig:            true,
 		BridgedVirtualInterface: false,
 		Action:                  vpp_l2.FIBEntry_FORWARD,


### PR DESCRIPTION
When I create a new network, the l2 fibs for vxlan tunnel for custom-if are not added correctly.
I observed that following pending messages were printed on logs.

2. CREATE [NOOP IS-PENDING]:
    - key: config/vpp/l2/v2/fib/vxlanBD-l3net/mac/12:2b:00:00:00:02
    - value: { phys_address:"12:2b:00:00:00:02" bridge_domain:"vxlanBD-l3net" outgoing_interface:"vxlan-default-2" static_config:true  }
3. CREATE [NOOP IS-PENDING]:
    - key: config/vpp/l2/v2/fib/vxlanBD-l3net/mac/12:2b:00:00:00:03
    - value: { phys_address:"12:2b:00:00:00:03" bridge_domain:"vxlanBD-l3net" outgoing_interface:"vxlan-default-3" static_config:true  }

I created a network as 'l3net' so that the it expected that outgoing_interface will be 'vxlan-l3net-2' and 'vxlan-l3net-2' not default.
So, l2 fib adding was pended.

This changes use the network name as outgoing interface name but use the default vxlan name when network name is default.
As you know that the outgoing interface name is also composed to network name by original code.